### PR TITLE
chore(workflow): pin IMAGE_NAME to preserve GHCR URL across renames

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,7 +21,11 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  # Hardcoded to preserve the GHCR package URL across repo renames. If the
+  # repo is renamed (e.g. behalfbot-chassis -> behalfbot), the workflow keeps
+  # publishing to ghcr.io/scrollinondubs/behalfbot-chassis so consumers'
+  # `image:` references in docker-compose.yml keep resolving without change.
+  IMAGE_NAME: scrollinondubs/behalfbot-chassis
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Hardcode the docker-publish workflow's `IMAGE_NAME` to `scrollinondubs/behalfbot-chassis` instead of deriving from `github.repository`.

Pre-rename prep ahead of `behalfbot-chassis` → `behalfbot` rename.

## Why

Without this hardcoded value, renaming the repo would cause the workflow's next CI run to publish to a NEW GHCR package URL (`ghcr.io/scrollinondubs/behalfbot:latest`), creating a GHCR package split:

- Old package `ghcr.io/scrollinondubs/behalfbot-chassis:*` - existing image history
- New package `ghcr.io/scrollinondubs/behalfbot:*` - all future builds

By pinning the name, the workflow keeps publishing to the SAME GHCR URL regardless of repo name. Consumers' `image:` references in `docker-compose.yml` don't need any per-install updates after rename.

## Diff

```diff
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  # Hardcoded to preserve the GHCR package URL across repo renames. ...
+  IMAGE_NAME: scrollinondubs/behalfbot-chassis
```

## After merge

This PR's CI run will push a new image version to the canonical GHCR URL. Then it's safe to rename the repo without disturbing the container distribution.