### PR TITLE
fix: shellcheck errors on chassis CI

### DIFF
--- a/chassis/scripts/sync-claude-oauth-bridge.sh
+++ b/chassis/scripts/sync-claude-oauth-bridge.sh
@@ -7,8 +7,8 @@
 # ============
 # On macOS, Claude Code stores OAuth tokens (accessToken, refreshToken,
 # expiresAt, scopes) in the login Keychain under the service
-# `Claude Code-credentials`, account `<v1-reference-install>`. The on-disk
-# ~/.claude/.credentials.json file is only populated with `mcpOAuth` entries
+# `Claude Code-credentials`, account `${USER}` (the host login account name).
+# The on-disk ~/.claude/.credentials.json file is only populated with `mcpOAuth` entries
 # (MCP server tokens), not the Anthropic auth itself. Host `claude` invocations
 # work because the binary shells out to `security find-generic-password` to
 # pull the access token from Keychain.
@@ -17,7 +17,7 @@
 # exist. The container previously had NO working path to authenticate, which
 # meant every `claude -p` from the in-container dispatcher failed with
 # "Not logged in" and every heartbeat that invoked claude (morning-briefing,
-# github-issue-triage, <v1-reference-install>-pg-backup, daily-log, strava-ingest, etc.) tripped
+# github-issue-triage, pg-backup, daily-log, strava-ingest, etc.) tripped
 # the circuit breaker. Cutover regression: nothing fired post-cutover.
 #
 # This script is the bridge: it reads the Keychain JSON and writes it to
@@ -54,7 +54,9 @@ ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 log() { echo "[$(ts)] $*" >> "$LOG"; }
 
 # Read Keychain entry. -w prints the password (which is JSON for this entry).
-if ! KC_JSON=$(security find-generic-password -s "Claude Code-credentials" -a <v1-reference-install> -w 2>/dev/null); then
+# Account = host user (the login account Claude Code's OAuth flow saves under).
+KEYCHAIN_ACCOUNT="${KEYCHAIN_ACCOUNT:-${USER}}"
+if ! KC_JSON=$(security find-generic-password -s "Claude Code-credentials" -a "$KEYCHAIN_ACCOUNT" -w 2>/dev/null); then
     log "WARN: keychain read failed (entry missing or locked) — leaving file untouched"
     exit 0
 fi

--- a/plugins/angel-protocol/scripts/welfare-pause.sh
+++ b/plugins/angel-protocol/scripts/welfare-pause.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env bash
 # Pause/resume welfare checks for planned offline periods.
 # Usage: welfare-pause.sh until YYYY-MM-DD [--reason "camping"]
 #        welfare-pause.sh resume


### PR DESCRIPTION
## Summary

Fixes the shellcheck CI step that's been failing on every PR (`Build + publish chassis image` runs in parallel, so it's not blocking but the `Shell scripts lint` job exits red on every check).

Two errors flagged in https://github.com/scrollinondubs/behalfbot/actions/runs/26757378121:

```
./plugins/angel-protocol/scripts/welfare-pause.sh:1:1: error: ShellCheck only supports sh/bash/dash/ksh/'busybox sh' scripts. [SC1071]
./chassis/scripts/sync-claude-oauth-bridge.sh:57:100: error: This redirection takes output away from the command substitution (use tee to duplicate). [SC2328]
```

## What's fixed

### 1. welfare-pause.sh shebang

`#!/bin/zsh` → `#!/usr/bin/env bash`. Script uses only POSIX/bash syntax (jq calls, `case`, `[[`, `${...}`). No zsh-specific features. Safe shebang flip.

### 2. sync-claude-oauth-bridge.sh keychain-account

`-a <v1-reference-install>` was a regex-rewrite artifact from the 2026-05-31 chassis sanitization pass (`scrollinondubs/jax` placeholder string substitution accidentally inserted literal `<...>` into a shell command). Bash parses `<...>` as redirection operators, breaking the `security find-generic-password` invocation.

Fix: parameterize `KEYCHAIN_ACCOUNT` (defaults to `$USER`), pass as properly-quoted arg:

```diff
-if ! KC_JSON=$(security find-generic-password -s "Claude Code-credentials" -a <v1-reference-install> -w 2>/dev/null); then
+KEYCHAIN_ACCOUNT="${KEYCHAIN_ACCOUNT:-${USER}}"
+if ! KC_JSON=$(security find-generic-password -s "Claude Code-credentials" -a "$KEYCHAIN_ACCOUNT" -w 2>/dev/null); then
```

Header comments updated to reflect the env-var-driven model.

## Verification

```
$ shellcheck plugins/angel-protocol/scripts/welfare-pause.sh chassis/scripts/sync-claude-oauth-bridge.sh
(no output - both pass)
```

## Behavior impact

None for installs running at default location. `$USER` is the login account name Claude Code's OAuth flow saves under, which is what the script was reading via the hardcoded value pre-sanitization.

## Follow-up

Other `<v1-reference-install>` literal references survive in comments throughout the tree (not shellcheck errors since they're inside `#` lines). Worth a cleanup pass replacing them with more meaningful placeholders like `<v1-reference>` or just deleting the comment context, but non-urgent.