### PR TITLE
feat(chassis): customer state out of chassis tree (closes #6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,13 @@
 # into the compose-stack-wide env.
 
 # Host paths bound into the chassis container.
-# CUSTOMER_HOME is the customer's per-instance state directory - for V1 case
-# studies that's ~/behalfbot on the customer's box.
-CUSTOMER_HOME=/home/CHANGEME/behalfbot
+#
+# As of issue #6, customer state lives at ~/.behalfbot (CUSTOMER_HOME) while
+# the chassis git tree at ~/behalfbot (CHASSIS_HOME) is fully disposable.
+# Bare-metal installs read CHASSIS_HOME directly; containerized installs only
+# need CUSTOMER_HOME here (docker-compose bind-mounts CUSTOMER_HOME into
+# /app/customer and the baked image holds the chassis tree at /app/chassis).
+CUSTOMER_HOME=/home/CHANGEME/.behalfbot
 CUSTOMER_CLAUDE_DIR=/home/CHANGEME/.claude
 
 # UID/GID the container drops to. Match the host owner of CUSTOMER_HOME so

--- a/.github/workflows/no-customer-state-in-chassis.yml
+++ b/.github/workflows/no-customer-state-in-chassis.yml
@@ -1,0 +1,88 @@
+name: No customer state in chassis tree
+
+# Issue #6: customer state MUST live under CUSTOMER_HOME (~/.behalfbot/), not
+# inside the chassis git tree (~/behalfbot/). The full design is documented
+# in the issue and the project README. This workflow fails the build if any
+# tracked file looks like customer-side state that would survive a re-clone
+# of the chassis.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  check-no-customer-state:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Scan tracked tree for customer-state patterns
+        run: |
+          set -euo pipefail
+
+          # Patterns matched against every tracked file path. A match is a
+          # failure - the file should live under CUSTOMER_HOME on a customer
+          # machine, not in the chassis git repo.
+          #
+          # Carve-outs (allowed via the exception list below):
+          #   - chassis/scripts/templates/*.template   - canonical templates
+          #     for the rendered customer-side scripts, lives in chassis tree
+          #     by design (they're chassis-managed, expanded into CUSTOMER_HOME
+          #     by bootstrap-customer-scripts.sh).
+          #   - chassis/launchd/*.plist.template       - same shape, for plists
+          #   - any *.template, *.example file         - template/example, not
+          #     a runtime artifact
+          #   - chassis/scheduled-tasks/*-prompt.md    - shipped prompt files,
+          #     not state
+          #   - chassis/scheduled-tasks/*.sh           - dispatcher script
+
+          DISALLOWED=(
+            'scripts/restart-.*-discord\.sh$'
+            'scripts/watchdog-.*-discord\.sh$'
+            'state/.*\.json$'
+            'briefings/.*\.md$'
+            '^logs/'
+            '^temp/'
+            '^data/'
+            '^\.env$'
+            '^\.env\.baked$'
+            '^CLAUDE\.md$'
+            '^HEARTBEATS\.md$'
+            '^chassis\.config\.yaml$'
+            '^INSTALL_PROFILE\.md$'
+            'memory/lead_.*\.md$'
+            'memory/topic_.*\.md$'
+            'memory/feedback_.*\.md$'
+            'memory/project_.*\.md$'
+            'memory/reference_.*\.md$'
+            'memory/student_.*\.md$'
+            'memory/user_.*\.md$'
+            'memory/task_.*\.md$'
+            'memory/MEMORY\.md$'
+            'scheduled-tasks/heartbeat-state\.json$'
+            'scheduled-tasks/conservation-mode\.json$'
+          )
+
+          violators=()
+          for pat in "${DISALLOWED[@]}"; do
+            while IFS= read -r f; do
+              # Skip allowed-by-design exceptions
+              case "$f" in
+                *.template|*.example|chassis/scripts/templates/*|chassis/launchd/*|chassis/scheduled-tasks/*-prompt.md|chassis/scheduled-tasks/heartbeat-dispatcher.sh|chassis/HEARTBEATS.md.template|chassis/CLAUDE.md.template)
+                  continue ;;
+              esac
+              violators+=("$f")
+            done < <(git ls-files | grep -E "$pat" || true)
+          done
+
+          if [[ ${#violators[@]} -gt 0 ]]; then
+            echo "FAIL: customer-state files tracked in chassis tree (issue #6 violation):"
+            printf '  - %s\n' "${violators[@]}" | sort -u
+            echo ""
+            echo "These files belong under CUSTOMER_HOME (~/.behalfbot/) on a customer machine."
+            echo "Remove them from the chassis repo before merging."
+            exit 1
+          fi
+          echo "ok: no customer-state files in chassis tree"

--- a/.github/workflows/no-customer-state-in-chassis.yml
+++ b/.github/workflows/no-customer-state-in-chassis.yml
@@ -70,7 +70,16 @@ jobs:
             while IFS= read -r f; do
               # Skip allowed-by-design exceptions
               case "$f" in
+                # Templates / examples / shipped chassis files - allowed.
                 *.template|*.example|chassis/scripts/templates/*|chassis/launchd/*|chassis/scheduled-tasks/*-prompt.md|chassis/scheduled-tasks/heartbeat-dispatcher.sh|chassis/HEARTBEATS.md.template|chassis/CLAUDE.md.template)
+                  continue ;;
+                # Top-level INSTALL_PROFILE.md and chassis.config.yaml are
+                # the chassis-shipped EXAMPLE templates that a customer
+                # overrides at install time. They're tracked deliberately so
+                # the wizard / self-serve install path has a starting point.
+                # The CUSTOMER copies live under CUSTOMER_HOME and are NOT
+                # tracked.
+                INSTALL_PROFILE.md|chassis.config.yaml)
                   continue ;;
               esac
               violators+=("$f")

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,16 @@
-# Secrets — never commit
+# =========================================================================
+# CHASSIS_HOME hygiene (issue #6).
+#
+# Customer state must NEVER land in the chassis git tree (~/behalfbot/).
+# After issue #6 all customer-side state lives in CUSTOMER_HOME (~/.behalfbot/)
+# which is outside this repo entirely. The patterns below are kept as a
+# belt-and-braces guard against accidental commits during the transition
+# period (legacy installs still co-locate state here). A CI check
+# (.github/workflows/no-customer-state-in-chassis.yml) enforces the same
+# rules and will fail the build if customer-state files are ever tracked.
+# =========================================================================
+
+# Secrets - never commit
 .env
 .env.*
 !.env.example
@@ -7,7 +19,7 @@
 secrets/
 .vaultwarden-token
 
-# Per-installer state — populated at runtime, never templated in
+# Per-installer state - populated at runtime, never templated in
 chassis/memory/installer/
 chassis/memory/MEMORY.md
 chassis/memory/lead_*.md
@@ -19,11 +31,27 @@ chassis/memory/student_*.md
 chassis/memory/user_*.md
 chassis/memory/task_*.md
 
-# Briefings + ephemeral artifacts
+# Customer-side directories (must live under CUSTOMER_HOME, never CHASSIS_HOME)
 briefings/
 logs/
 temp/
 data/
+state/
+
+# Customer-side scripts rendered into CUSTOMER_HOME/scripts/ by
+# chassis/scripts/bootstrap-customer-scripts.sh. Never tracked.
+scripts/restart-*.sh
+scripts/watchdog-*.sh
+
+# Customer-side scheduled-task state. The template files (e.g. *.template,
+# *-prompt.md.template) live in chassis/ and remain tracked.
+scheduled-tasks/heartbeat-state.json
+scheduled-tasks/conservation-mode.json
+scheduled-tasks/quota-last-block-start.txt
+
+# Bootstrap / migration sentinel files (created inside CUSTOMER_HOME).
+.bootstrap-marker
+.migrated-from-chassis-home
 
 # Local DB
 *.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
     CHASSIS_ROOT=/app/chassis \
     CHASSIS_PLUGINS_ROOT=/app/plugins \
+    CUSTOMER_HOME=/app/customer \
     CHASSIS_HOME=/app/customer \
     HOME=/home/chassis \
     PATH=/home/chassis/.local/bin:/home/chassis/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/INSTALL_PROFILE.md
+++ b/INSTALL_PROFILE.md
@@ -39,7 +39,7 @@ For V1 case studies we hand-author the artifacts directly from an interview. Onc
 | `target_runtime` | `<linux_baremetal \| cloudflare_containers \| mac_mini>` |
 | `host_class` | `<home_server \| vps \| cloud_container>` |
 | `state_storage` | `local-fs` (recommended for V1) |
-| `state_path` | `~/behalfbot/state` |
+| `state_path` | `~/.behalfbot/state` (issue #6: customer state lives at `$CUSTOMER_HOME`, NOT inside the chassis tree) |
 | `database` | **Postgres** (chassis default; see LESSONS_FROM_V1.md #34) |
 | `network` | `<tailscale_node_share \| cloudflare_tunnel \| direct_ssh>` |
 
@@ -125,7 +125,7 @@ Execution model: **(b) Sean+${ASSISTANT_NAME} drive via SSH** (see <v1-reference
 1. Installer completes homework (`docs/installer-homework-<installer>.md`)
 2. We SSH in via Tailscale-shared node
 3. We install Linux prereqs
-4. We clone the chassis repo to `~/behalfbot/`
+4. We clone the chassis repo to `~/behalfbot/` (CHASSIS_HOME). Customer state will land in `~/.behalfbot/` (CUSTOMER_HOME), created by `bootstrap.sh` on first run.
 5. We hydrate the chassis from this profile + `docs/install-<installer>-chassis-config.yaml`
 6. We boot chassis + run smoke tests
 7. First-heartbeat smoke test: 3 consecutive clean morning briefings = signed off

--- a/README.md
+++ b/README.md
@@ -54,12 +54,61 @@ Personal-security components (live-location tracking, duress codewords, mode inf
 | `INSTALL_PROFILE.md` | Generic installer template. The wizard fills this in for you, or you author by hand. |
 | `chassis.config.yaml` | Machine-readable config template. Same — wizard-generated or hand-authored. |
 | `chassis/` | Generic core: heartbeat dispatcher, briefing pipeline, MCP wiring stubs, guardrails, second-brain adapters |
+| `chassis/scripts/templates/` | Per-install script templates (restart/watchdog) rendered into CUSTOMER_HOME at bootstrap |
+| `chassis/launchd/` | macOS LaunchAgent plist templates (rendered into CUSTOMER_HOME/launchd/ at bootstrap) |
 | `chassis/skills/` | Skill scaffolding (templates; populated per install) |
 | `chassis/scripts/` | Shared utilities (gather scripts, bake helpers, OAuth bridge, hydration) |
 | `chassis/memory/` | Memory format + seeded entries (structure only; no install-specific content) |
 | `plugins/` | Opt-in plugins (see ecosystem section above) |
 | `docs/` | Install runbook, hydration guide, architecture notes, anti-patterns, lessons |
 | `bootstrap.sh` | Auto-bootstrap orchestrator — reads your profile + config, wires everything up |
+
+### Directory layout on a customer machine (post-issue-#6)
+
+Customer state and chassis code live in two physically separate trees:
+
+```
+~/behalfbot/              # CHASSIS_HOME - fully disposable, re-pullable
+  chassis/                # the vendored chassis subtree
+  plugins/                # chassis plugins
+  bootstrap.sh
+  docker-compose.yml
+  Dockerfile
+  README.md
+  requirements.txt
+
+~/.behalfbot/             # CUSTOMER_HOME - never touched by reinstall
+  .env                    # customer secrets
+  CLAUDE.md               # hydrated per-install
+  HEARTBEATS.md           # per-customer heartbeat config
+  chassis.config.yaml     # per-customer chassis config
+  INSTALL_PROFILE.md      # per-customer install profile
+  scripts/                # customer-side: restart-${BOT}-discord.sh, watchdog-${BOT}-discord.sh
+  state/                  # heartbeat-state.json, conservation-mode.json
+  scheduled-tasks/        # customer overrides + per-tick state
+  memory/                 # installer-specific memory
+  briefings/              # generated artifacts
+  logs/                   # all logs
+  data/                   # any customer data
+  temp/
+  launchd/                # rendered LaunchAgent plists (symlinked into ~/Library/LaunchAgents/)
+```
+
+`rm -rf ~/behalfbot && git clone https://github.com/scrollinondubs/behalfbot.git ~/behalfbot` is safe - customer state is at `~/.behalfbot/` and untouched.
+
+### Migration from a pre-issue-#6 install
+
+If your install was bootstrapped before issue #6 (customer state under `~/behalfbot/`), run the migration script once:
+
+```
+cd ~/behalfbot
+bash chassis/scripts/migrate-customer-state.sh --dry-run   # preview
+bash chassis/scripts/migrate-customer-state.sh             # execute
+```
+
+The script `mv`'s every customer-side artifact (`.env`, `CLAUDE.md`, `HEARTBEATS.md`, `scripts/`, `state/`, `briefings/`, `logs/`, `data/`, `temp/`, installer-specific `chassis/memory/*`) from `~/behalfbot/` to `~/.behalfbot/`, re-renders the customer-side restart/watchdog scripts from chassis templates, and reloads the LaunchAgent plists at the new paths.
+
+Refer to `chassis/scripts/migrate-customer-state.sh --help` for flag details. The script is idempotent: a sentinel at `~/.behalfbot/.migrated-from-chassis-home` makes subsequent runs a no-op.
 
 ---
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,10 +2,27 @@
 # bootstrap.sh — chassis install / re-install orchestrator.
 #
 # Usage:
-#   CHASSIS_HOME=/path/to/chassis bash bootstrap.sh [--dry-run] [--skip-deps]
+#   CHASSIS_HOME=/path/to/chassis-tree \
+#     CUSTOMER_HOME=/path/to/customer-state \
+#     bash bootstrap.sh [--dry-run] [--skip-deps]
+#
+# As of issue #6 the chassis enforces a hard split between chassis-disposable
+# code and customer state:
+#
+#   CHASSIS_HOME   - chassis tree (chassis/, plugins/, bootstrap.sh, Dockerfile).
+#                    Fully disposable: rm -rf && git clone is safe.
+#                    Default: $HOME/behalfbot
+#   CUSTOMER_HOME  - customer state (.env, CLAUDE.md, HEARTBEATS.md, scripts/,
+#                    state/, logs/, briefings/, memory/, data/). NEVER touched
+#                    by reinstall. Default: $HOME/.behalfbot
+#
+# On first-install: this script creates $CUSTOMER_HOME and scaffolds the initial
+# subdir tree, then renders the customer-side scripts from chassis templates.
+# On re-bootstrap: this script verifies $CUSTOMER_HOME exists and never
+# overwrites anything inside it - only chassis-side setup runs.
 #
 # Idempotent: re-run after a partial install picks up where it left off.
-# Every command run gets logged to ${CHASSIS_HOME}/logs/bootstrap-<date>.log
+# Every command run gets logged to ${CUSTOMER_HOME}/logs/bootstrap-<date>.log
 # so installer #2 (the next case study) can run a near-identical transcript.
 #
 # Prerequisites (installer's homework, NOT this script's job):
@@ -21,17 +38,19 @@
 #
 # What this script does (in order):
 #   1. Validate environment + tool prerequisites
-#   2. Hydrate .env from installer's password manager (interactive prompts for paths)
-#   3. Render INSTALL_PROFILE.md + chassis.config.yaml validations
-#   4. Hydrate .mcp.json from .mcp.json.template + .env values
-#   5. Hydrate CLAUDE.md from CLAUDE.md.template + INSTALL_PROFILE.md values
-#   6. Initialize HEARTBEATS.md (copy chassis/HEARTBEATS.md.template -> $CHASSIS_HOME/HEARTBEATS.md, append chassis-defaults + plugin-registered heartbeats)
-#   7. Activate enabled plugins (per chassis.config.yaml.modules)
-#   8. Seed memory entries from INSTALL_PROFILE.md (no fabrication)
-#   9. Install OS-level deps (Python 3.12+, Node 20+, ffmpeg, sqlite3, jq, curl, Claude Code)
-#  10. Set up launchd plist (macOS) or systemd unit (Linux) for the dispatcher
-#  11. Run smoke tests (each plugin's basic functionality)
-#  12. Report status — green = install complete, yellow = follow-ups needed
+#   2. Scaffold $CUSTOMER_HOME if missing (first install)
+#   3. Hydrate .env from installer's password manager (interactive prompts for paths)
+#   4. Render INSTALL_PROFILE.md + chassis.config.yaml validations
+#   5. Hydrate .mcp.json from .mcp.json.template + .env values
+#   6. Hydrate CLAUDE.md from CLAUDE.md.template + INSTALL_PROFILE.md values
+#   7. Initialize HEARTBEATS.md (copy chassis/HEARTBEATS.md.template -> $CUSTOMER_HOME/HEARTBEATS.md, append chassis-defaults + plugin-registered heartbeats)
+#   8. Render customer-side scripts (restart/watchdog) from chassis templates
+#   9. Activate enabled plugins (per chassis.config.yaml.modules)
+#  10. Seed memory entries from INSTALL_PROFILE.md (no fabrication)
+#  11. Install OS-level deps (Python 3.12+, Node 20+, ffmpeg, sqlite3, jq, curl, Claude Code)
+#  12. Set up launchd plist (macOS) or systemd unit (Linux) for the dispatcher
+#  13. Run smoke tests (each plugin's basic functionality)
+#  14. Report status — green = install complete, yellow = follow-ups needed
 #
 # Each step is its own function. Failures within a step exit non-zero
 # with a clear message about what to fix + where to re-run from.
@@ -42,15 +61,43 @@ set -euo pipefail
 # 1. Setup + validation
 # ============================================================
 
-: "${CHASSIS_HOME:?CHASSIS_HOME must be set (export before running)}"
+: "${CHASSIS_HOME:?CHASSIS_HOME must be set (export before running; chassis git tree root)}"
+# CUSTOMER_HOME defaults to $HOME/.behalfbot per the issue #6 hard-split.
+# Pre-issue-#6 installs co-located customer state with CHASSIS_HOME; those
+# installs should run chassis/scripts/migrate-customer-state.sh first.
+CUSTOMER_HOME="${CUSTOMER_HOME:-$HOME/.behalfbot}"
+export CHASSIS_HOME CUSTOMER_HOME
 
 DRY_RUN="${DRY_RUN:-false}"
 SKIP_DEPS="${SKIP_DEPS:-false}"
+
+# CLI flag parsing
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)    DRY_RUN=true; shift ;;
+        --skip-deps)  SKIP_DEPS=true; shift ;;
+        -h|--help)
+            sed -n '1,50p' "$0" | sed 's/^# *//'
+            exit 0 ;;
+        *)
+            echo "unknown flag: $1" >&2
+            exit 2 ;;
+    esac
+done
+
 DATE=$(date +%Y-%m-%d)
-LOG_DIR="$CHASSIS_HOME/logs"
+LOG_DIR="$CUSTOMER_HOME/logs"
 TRANSCRIPT="$LOG_DIR/bootstrap-$DATE.log"
 
-mkdir -p "$LOG_DIR"
+# Don't create the log dir on dry-run - we promised CUSTOMER_HOME is untouched
+# if dry-run is on.
+if [[ "$DRY_RUN" != "true" ]]; then
+    mkdir -p "$LOG_DIR"
+else
+    # Re-route the transcript to a tmp location so logging still works.
+    TRANSCRIPT="${TMPDIR:-/tmp}/bootstrap-dryrun-$DATE.log"
+    : > "$TRANSCRIPT"
+fi
 
 log() {
     local msg="[$(date +%H:%M:%S)] $*"
@@ -78,10 +125,15 @@ step() {
 # ============================================================
 
 validate_environment() {
-    step "1/12" "Validate environment + tool prerequisites"
+    step "1/14" "Validate environment + tool prerequisites"
 
     if [[ ! -d "$CHASSIS_HOME" ]]; then
         log "FAIL: CHASSIS_HOME ($CHASSIS_HOME) does not exist"
+        exit 2
+    fi
+
+    if [[ ! -d "$CHASSIS_HOME/chassis" ]]; then
+        log "FAIL: $CHASSIS_HOME does not look like a chassis tree (no chassis/ subdir)"
         exit 2
     fi
 
@@ -97,16 +149,88 @@ validate_environment() {
         exit 2
     fi
 
-    if [[ ! -f "$CHASSIS_HOME/INSTALL_PROFILE.md" ]]; then
-        log "FAIL: $CHASSIS_HOME/INSTALL_PROFILE.md missing — needed for hydration"
+    # INSTALL_PROFILE.md + chassis.config.yaml are PER-INSTALL artifacts. They
+    # live under CUSTOMER_HOME post-#6; for legacy installs they sit at
+    # CHASSIS_HOME. Accept either to make this script work mid-migration.
+    local profile_src config_src
+    profile_src="$(first_existing "$CUSTOMER_HOME/INSTALL_PROFILE.md" "$CHASSIS_HOME/INSTALL_PROFILE.md")"
+    config_src="$(first_existing "$CUSTOMER_HOME/chassis.config.yaml" "$CHASSIS_HOME/chassis.config.yaml")"
+
+    if [[ -z "$profile_src" ]]; then
+        log "FAIL: INSTALL_PROFILE.md missing - looked under $CUSTOMER_HOME and $CHASSIS_HOME"
         exit 2
     fi
-    if [[ ! -f "$CHASSIS_HOME/chassis.config.yaml" ]]; then
-        log "FAIL: $CHASSIS_HOME/chassis.config.yaml missing — needed for hydration"
+    if [[ -z "$config_src" ]]; then
+        log "FAIL: chassis.config.yaml missing - looked under $CUSTOMER_HOME and $CHASSIS_HOME"
         exit 2
     fi
 
     log "✓ environment OK"
+    log "  CHASSIS_HOME  (chassis tree)    : $CHASSIS_HOME"
+    log "  CUSTOMER_HOME (customer state)  : $CUSTOMER_HOME"
+    log "  INSTALL_PROFILE.md source       : $profile_src"
+    log "  chassis.config.yaml source      : $config_src"
+}
+
+# first_existing <path...> - echo the first path arg that exists; empty if none.
+first_existing() {
+    local p
+    for p in "$@"; do
+        if [[ -e "$p" ]]; then
+            printf '%s' "$p"
+            return 0
+        fi
+    done
+    return 0
+}
+
+# ============================================================
+# 2. Scaffold CUSTOMER_HOME (first install only)
+# ============================================================
+
+scaffold_customer_home() {
+    step "2/14" "Scaffold CUSTOMER_HOME"
+
+    # Per issue #6: never overwrite anything inside CUSTOMER_HOME on re-bootstrap.
+    # Only create the dir structure if it doesn't already exist.
+    if [[ -d "$CUSTOMER_HOME" && -f "$CUSTOMER_HOME/.bootstrap-marker" ]]; then
+        log "  $CUSTOMER_HOME already scaffolded, skipping (re-bootstrap path)"
+        return 0
+    fi
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log "  [dry-run] would create $CUSTOMER_HOME and standard subdirs"
+        return 0
+    fi
+
+    local subdirs=(
+        scripts
+        state
+        scheduled-tasks
+        memory
+        briefings
+        logs
+        logs/scheduled
+        logs/telemetry
+        data
+        temp
+        launchd
+    )
+    for d in "${subdirs[@]}"; do
+        mkdir -p "$CUSTOMER_HOME/$d"
+    done
+
+    # Marker so re-runs know scaffolding already happened.
+    cat > "$CUSTOMER_HOME/.bootstrap-marker" <<EOF
+# Behalf.bot CUSTOMER_HOME bootstrap marker (issue #6).
+# Presence signals to bootstrap.sh that this customer dir has been initialised.
+# Re-bootstrap will NOT overwrite anything else inside CUSTOMER_HOME while this
+# marker is present. Delete the marker to force re-scaffold (which still only
+# creates absent subdirs - existing customer state is never clobbered).
+bootstrapped_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+chassis_home: $CHASSIS_HOME
+EOF
+    log "  ✓ scaffolded $CUSTOMER_HOME"
 }
 
 # ============================================================
@@ -114,9 +238,9 @@ validate_environment() {
 # ============================================================
 
 hydrate_env() {
-    step "2/12" "Hydrate .env from password manager"
+    step "3/14" "Hydrate .env from password manager"
 
-    local env_file="$CHASSIS_HOME/.env"
+    local env_file="$CUSTOMER_HOME/.env"
     if [[ -f "$env_file" ]]; then
         log "  $env_file exists; idempotent re-run will skip prompts for already-set values"
     fi
@@ -164,7 +288,7 @@ EOF
 # ============================================================
 
 validate_install_artifacts() {
-    step "3/12" "Validate INSTALL_PROFILE + chassis.config.yaml"
+    step "4/14" "Validate INSTALL_PROFILE + chassis.config.yaml"
 
     log "TODO: lint INSTALL_PROFILE.md for required sections"
     log "TODO: validate chassis.config.yaml against schema (yq + json-schema OR python jsonschema)"
@@ -184,7 +308,7 @@ validate_install_artifacts() {
 # ============================================================
 
 hydrate_mcp_json() {
-    step "4/12" "Hydrate .mcp.json from template"
+    step "5/14" "Hydrate .mcp.json from template"
 
     log "TODO: jq-based template-substitution from .mcp.json.template"
     log "  - Read chassis.config.yaml.modules.* flags"
@@ -196,7 +320,7 @@ hydrate_mcp_json() {
 }
 
 hydrate_claude_md() {
-    step "5/12" "Hydrate CLAUDE.md from template"
+    step "6/14" "Hydrate CLAUDE.md from template"
 
     log "TODO: sed-based template-substitution from chassis/CLAUDE.md.template"
     log "  Read INSTALL_PROFILE.md + chassis.config.yaml for {{PLACEHOLDER}} values:"
@@ -205,14 +329,14 @@ hydrate_claude_md() {
     log "    {{PRIMARY_CHANNEL}}, {{OPS_CHANNEL}}, {{BRIEFINGS_CHANNEL}}"
     log "    {{SECOND_BRAIN_BACKEND}}, {{INSTALLER_GITHUB_OWNER}}, etc."
     log "  Append per-plugin '## Plugin: <name>' sections from each enabled plugin's CLAUDE-section template"
-    log "  Write hydrated CLAUDE.md at \$CHASSIS_HOME/CLAUDE.md"
+    log "  Write hydrated CLAUDE.md at \$CUSTOMER_HOME/CLAUDE.md"
 }
 
 initialize_heartbeats() {
-    step "6/12" "Initialize HEARTBEATS.md"
+    step "7/14" "Initialize HEARTBEATS.md"
 
     local template="$CHASSIS_HOME/chassis/HEARTBEATS.md.template"
-    local rendered="$CHASSIS_HOME/HEARTBEATS.md"
+    local rendered="$CUSTOMER_HOME/HEARTBEATS.md"
 
     if [[ ! -f "$template" ]]; then
         log "  ERROR: $template missing - chassis install incomplete"
@@ -247,8 +371,35 @@ initialize_heartbeats() {
 # 8. Activate enabled plugins
 # ============================================================
 
+render_customer_scripts() {
+    step "8/14" "Render customer-side scripts from chassis templates"
+
+    local renderer="$CHASSIS_HOME/chassis/scripts/bootstrap-customer-scripts.sh"
+    if [[ ! -x "$renderer" ]]; then
+        log "  WARN: $renderer missing or not executable - skipping script render"
+        log "        Without this step, customer-side restart/watchdog scripts"
+        log "        will be absent until the install is patched. See issue #6."
+        return 0
+    fi
+
+    # BOT_NAME resolution lives inside the renderer; if it can't determine one
+    # it falls back to literal 'bot'. Installers should set BOT_NAME explicitly
+    # in their environment (or in chassis.config.yaml) for a clean render.
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log "  [dry-run] would run: $renderer --plists"
+        return 0
+    fi
+
+    if ! CUSTOMER_HOME="$CUSTOMER_HOME" CHASSIS_HOME="$CHASSIS_HOME" \
+        bash "$renderer" --plists 2>&1 | tee -a "$TRANSCRIPT"; then
+        log "  ERROR: bootstrap-customer-scripts.sh failed - investigate before continuing"
+        return 1
+    fi
+    log "  ✓ customer-side scripts + plists rendered"
+}
+
 activate_plugins() {
-    step "7/12" "Activate enabled plugins"
+    step "9/14" "Activate enabled plugins"
 
     log "TODO: for each plugin in plugins/ directory:"
     log "  - Read its openclaw.plugin.json"
@@ -257,14 +408,14 @@ activate_plugins() {
     log "  - Write chassis-env.sh that the launchd/systemd unit sources"
     log ""
     log "Per-plugin chassis-env.sh exports (V1-known):"
-    log "  whatsapp: CHASSIS_WHATSAPP_SAFE=\$CHASSIS_HOME/plugins/whatsapp/scripts/wacli-safe.sh"
+    log "  whatsapp: CHASSIS_WHATSAPP_SAFE=\$CHASSIS_PLUGINS_ROOT/whatsapp/scripts/wacli-safe.sh"
     log "  bfl:      BFL_ARCHIVE_DIR=<from config>"
     log "  dating:   SOCIAL_CHANNEL_ID=<from config>"
     log "  etc."
     log ""
     log "Plugin trigger merge (per chassis/scripts/merge-plugin-triggers.sh):"
     log "  - Reads contracts.triggers from each enabled plugin's openclaw.plugin.json"
-    log "  - Writes merged registry to \$CHASSIS_HOME/chassis/triggers.yaml"
+    log "  - Writes merged registry to \$CUSTOMER_HOME/triggers.yaml"
     log "  - Read by chassis/scripts/dispatch-trigger.sh on every inbound message"
     log "  - Re-run any time a plugin is enabled/disabled or its manifest changes"
 }
@@ -274,7 +425,7 @@ activate_plugins() {
 # ============================================================
 
 seed_memory() {
-    step "8/12" "Seed memory entries from INSTALL_PROFILE"
+    step "10/14" "Seed memory entries from INSTALL_PROFILE"
 
     log "TODO: per docs/memory-seeding.md — generate seed entries from interview signals"
     log ""
@@ -300,7 +451,7 @@ seed_memory() {
 # ============================================================
 
 install_os_deps() {
-    step "9/12" "Install OS-level dependencies"
+    step "11/14" "Install OS-level dependencies"
 
     if [[ "$SKIP_DEPS" == "true" ]]; then
         log "  SKIP_DEPS=true; assuming installer pre-installed everything"
@@ -336,17 +487,18 @@ install_os_deps() {
 # ============================================================
 
 setup_dispatcher_unit() {
-    step "10/12" "Set up dispatcher launchd / systemd unit"
+    step "12/14" "Set up dispatcher launchd / systemd unit"
 
     log "TODO: detect OS (macOS vs Linux) + emit appropriate unit:"
     log ""
-    log "macOS — write /Library/LaunchDaemons/com.behalfbot.heartbeat-dispatcher.plist"
-    log "  (LaunchDaemons survive reboots per lesson #26; LaunchAgents need GUI session)"
-    log "  UserName=<installer>"
-    log "  StartInterval=900 (every 15 min)"
-    log "  EnvironmentVariables: CHASSIS_HOME, INSTANCE_NAME, plus chassis-env.sh sourcing"
-    log "  ProgramArguments: bash -c 'source \$CHASSIS_HOME/chassis-env.sh && exec \$CHASSIS_HOME/chassis/scheduled-tasks/heartbeat-dispatcher.sh'"
-    log "  StandardOutPath / StandardErrorPath: \$CHASSIS_HOME/logs/scheduled/launchd-stdout.log"
+    log "macOS — chassis ships a plist template at chassis/launchd/"
+    log "  com.behalfbot.heartbeat-dispatcher.plist.template. The earlier"
+    log "  render_customer_scripts step (with --plists) writes the rendered"
+    log "  copy into \$CUSTOMER_HOME/launchd/. From there:"
+    log "    ln -sf \$CUSTOMER_HOME/launchd/com.behalfbot.heartbeat-dispatcher.plist \\"
+    log "         ~/Library/LaunchAgents/"
+    log "    launchctl bootstrap gui/\$(id -u) ~/Library/LaunchAgents/com.behalfbot.heartbeat-dispatcher.plist"
+    log "  Containerized installs do NOT need this plist - docker compose handles cadence."
     log ""
     log "Linux — write /etc/systemd/system/behalfbot-heartbeat-dispatcher.{service,timer}"
     log "  (system-scope, NOT --user, per lesson #26)"
@@ -358,7 +510,7 @@ setup_dispatcher_unit() {
     log "  IMPORTANT: embed Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin"
     log "    in the .service file — systemd strips PATH, uv run silently fails without it (#35)"
     log "  timer OnCalendar=*:0/15 (every 15 min)"
-    log "  Restart=on-failure; ConditionPathExists=\$CHASSIS_HOME"
+    log "  Restart=on-failure; ConditionPathExists=\$CUSTOMER_HOME"
     log ""
     log "Both: load + enable + start; verify with first-tick log entry"
 }
@@ -368,7 +520,7 @@ setup_dispatcher_unit() {
 # ============================================================
 
 run_smoke_tests() {
-    step "11/12" "Run smoke tests"
+    step "13/14" "Run smoke tests"
 
     log "TODO: per-plugin smoke checks:"
     log "  - chassis-core: dispatcher fires once + dry-runs every registered heartbeat"
@@ -388,7 +540,7 @@ run_smoke_tests() {
 # ============================================================
 
 report_status() {
-    step "12/12" "Install summary"
+    step "14/14" "Install summary"
 
     log ""
     log "Bootstrap transcript: $TRANSCRIPT"
@@ -406,16 +558,20 @@ report_status() {
 # ============================================================
 
 main() {
-    log "Behalf.bot bootstrap starting — CHASSIS_HOME=$CHASSIS_HOME"
-    log "Dry-run: $DRY_RUN | Skip-deps: $SKIP_DEPS"
-    log "Transcript: $TRANSCRIPT"
+    log "Behalf.bot bootstrap starting"
+    log "  CHASSIS_HOME (chassis tree)   : $CHASSIS_HOME"
+    log "  CUSTOMER_HOME (customer state): $CUSTOMER_HOME"
+    log "  Dry-run: $DRY_RUN | Skip-deps: $SKIP_DEPS"
+    log "  Transcript: $TRANSCRIPT"
 
     validate_environment
+    scaffold_customer_home
     hydrate_env
     validate_install_artifacts
     hydrate_mcp_json
     hydrate_claude_md
     initialize_heartbeats
+    render_customer_scripts
     activate_plugins
     seed_memory
     install_os_deps

--- a/chassis/launchd/com.behalfbot.discord-restart.plist.template
+++ b/chassis/launchd/com.behalfbot.discord-restart.plist.template
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.behalfbot.${BOT_NAME}-discord-restart.plist - chassis-rendered template.
+
+  Generated from chassis/launchd/com.behalfbot.discord-restart.plist.template
+  by chassis/scripts/bootstrap-customer-scripts.sh.
+
+  Template variables (expanded at render time):
+    BOT_NAME            logical bot name (e.g. jax, asimov, ozzy)
+    CUSTOMER_HOME       per-customer state root (e.g. /Users/<user>/.behalfbot)
+    CHASSIS_HOME        chassis git tree root (e.g. /Users/<user>/behalfbot)
+    HOMEBREW_PREFIX     /opt/homebrew on Apple Silicon, /usr/local on Intel
+    USER                installer's macOS short name
+    NODE_BIN_PATH       optional - extra node bin dir, e.g. ${HOMEBREW_PREFIX}/opt/node@22/bin
+
+  Restart cadence: daily at 05:00 local time. Matches the upstream Sean install
+  which has run successfully for months. Drop to 03:00 if you want a quieter
+  morning; rationale for "before-8am-briefing" is that the daily-briefing
+  heartbeat fires after the restart, so a fresh tmux session is in place.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.behalfbot.${BOT_NAME}-discord-restart</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>${CUSTOMER_HOME}/scripts/restart-${BOT_NAME}-discord.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>5</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>WorkingDirectory</key>
+    <string>${CHASSIS_HOME}</string>
+    <key>StandardErrorPath</key>
+    <string>${CUSTOMER_HOME}/logs/scheduled/discord-restart-stderr.log</string>
+    <key>StandardOutPath</key>
+    <string>${CUSTOMER_HOME}/logs/scheduled/discord-restart-stdout.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/${USER}/.local/bin:${HOMEBREW_PREFIX}/bin:${NODE_BIN_PATH}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin</string>
+        <key>HOME</key>
+        <string>/Users/${USER}</string>
+        <key>CUSTOMER_HOME</key>
+        <string>${CUSTOMER_HOME}</string>
+        <key>CHASSIS_HOME</key>
+        <string>${CHASSIS_HOME}</string>
+    </dict>
+</dict>
+</plist>

--- a/chassis/launchd/com.behalfbot.discord-watchdog.plist.template
+++ b/chassis/launchd/com.behalfbot.discord-watchdog.plist.template
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.behalfbot.${BOT_NAME}-discord-watchdog.plist - chassis-rendered template.
+
+  Generated from chassis/launchd/com.behalfbot.discord-watchdog.plist.template
+  by chassis/scripts/bootstrap-customer-scripts.sh.
+
+  Template variables - same set as the sibling restart plist (see comment
+  block in com.behalfbot.discord-restart.plist.template).
+
+  Cadence: every 30 minutes (StartInterval 1800). Restarts only fire when
+  the watchdog actually detects a dead session or an auth-failure pattern
+  in the tmux pane buffer - the wakeup itself is cheap, the bot stays up.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.behalfbot.${BOT_NAME}-discord-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>${CUSTOMER_HOME}/scripts/watchdog-${BOT_NAME}-discord.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>1800</integer>
+    <key>WorkingDirectory</key>
+    <string>${CHASSIS_HOME}</string>
+    <key>StandardErrorPath</key>
+    <string>${CUSTOMER_HOME}/logs/scheduled/watchdog-stderr.log</string>
+    <key>StandardOutPath</key>
+    <string>${CUSTOMER_HOME}/logs/scheduled/watchdog-stdout.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/${USER}/.local/bin:${HOMEBREW_PREFIX}/bin:${NODE_BIN_PATH}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin</string>
+        <key>HOME</key>
+        <string>/Users/${USER}</string>
+        <key>CUSTOMER_HOME</key>
+        <string>${CUSTOMER_HOME}</string>
+        <key>CHASSIS_HOME</key>
+        <string>${CHASSIS_HOME}</string>
+    </dict>
+</dict>
+</plist>

--- a/chassis/launchd/com.behalfbot.heartbeat-dispatcher.plist.template
+++ b/chassis/launchd/com.behalfbot.heartbeat-dispatcher.plist.template
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.behalfbot.heartbeat-dispatcher.plist - chassis-rendered template.
+
+  Generated from chassis/launchd/com.behalfbot.heartbeat-dispatcher.plist.template
+  by chassis/scripts/bootstrap-customer-scripts.sh. This is the macOS legacy
+  bare-metal path for the dispatcher loop. Container installs do NOT use this
+  plist - the dispatcher runs inside the chassis container per docker-compose.yml.
+
+  Only install this plist on macOS hosts running the chassis without the
+  container (the pre-containerization V1 layout). For containerized installs,
+  the LaunchAgent simply restarts the `behalfbot` compose stack on boot.
+
+  Template variables (expanded at render time):
+    CUSTOMER_HOME       per-customer state root
+    CHASSIS_HOME        chassis git tree root
+    INSTANCE_NAME       bot persona label (e.g. Jax, Asimov, Ozzy) - used in
+                        Discord notifications
+    USER                installer's macOS short name
+    USER_UID            installer's numeric UID
+    HOMEBREW_PREFIX     /opt/homebrew on Apple Silicon, /usr/local on Intel
+
+  Cadence: every 15 minutes (StartInterval 900). The dispatcher runs cheap
+  gather scripts on every tick; only fires `claude -p` when an actual work
+  condition is true. See chassis/scheduled-tasks/heartbeat-dispatcher.sh.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.behalfbot.heartbeat-dispatcher</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/zsh</string>
+        <string>-c</string>
+        <string>exec ${CHASSIS_HOME}/chassis/scheduled-tasks/heartbeat-dispatcher.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>900</integer>
+    <key>WorkingDirectory</key>
+    <string>${CUSTOMER_HOME}</string>
+    <key>StandardErrorPath</key>
+    <string>${CUSTOMER_HOME}/logs/scheduled/dispatcher-stderr.log</string>
+    <key>StandardOutPath</key>
+    <string>${CUSTOMER_HOME}/logs/scheduled/dispatcher-stdout.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/${USER}/.local/bin:${HOMEBREW_PREFIX}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin</string>
+        <key>HOME</key>
+        <string>/Users/${USER}</string>
+        <key>CUSTOMER_HOME</key>
+        <string>${CUSTOMER_HOME}</string>
+        <key>CHASSIS_HOME</key>
+        <string>${CHASSIS_HOME}</string>
+        <key>CHASSIS_ROOT</key>
+        <string>${CHASSIS_HOME}/chassis</string>
+        <key>CHASSIS_PLUGINS_ROOT</key>
+        <string>${CHASSIS_HOME}/plugins</string>
+        <key>INSTANCE_NAME</key>
+        <string>${INSTANCE_NAME}</string>
+    </dict>
+</dict>
+</plist>

--- a/chassis/scheduled-tasks/heartbeat-dispatcher.sh
+++ b/chassis/scheduled-tasks/heartbeat-dispatcher.sh
@@ -40,10 +40,15 @@
 
 set -euo pipefail
 
-# CHASSIS_HOME must be set by the install runbook. Fail loud if missing —
-# downstream code assumes paths relative to it. No default; chassis location
-# varies per installer.
+# Issue #6 customer-state split: customer-side state lives under CUSTOMER_HOME,
+# chassis code under CHASSIS_HOME. For legacy installs both vars point at the
+# same dir (the pre-#6 layout). New / post-migration installs separate them.
+# Prefer CUSTOMER_HOME for state/log/heartbeat paths; fall back to CHASSIS_HOME
+# for backward compat so existing containerized installs (where both are
+# /app/customer) continue working unchanged.
 : "${CHASSIS_HOME:?CHASSIS_HOME must be exported before running this dispatcher (set by launchd plist / systemd unit)}"
+: "${CUSTOMER_HOME:=$CHASSIS_HOME}"
+export CHASSIS_HOME CUSTOMER_HOME
 
 # Cross-platform timeout binary. macOS-Homebrew ships gnu coreutils as
 # `gtimeout`; Debian (and the chassis Linux container) ships it as `timeout`.
@@ -55,11 +60,11 @@ set -euo pipefail
 # macOS path and broke every claude invocation inside the container.
 TIMEOUT_CMD="$(command -v gtimeout 2>/dev/null || command -v timeout 2>/dev/null || echo timeout)"
 
-HEARTBEATS_FILE="$CHASSIS_HOME/HEARTBEATS.md"
-STATE_FILE="$CHASSIS_HOME/scheduled-tasks/heartbeat-state.json"
-CONSERVATION_FILE="$CHASSIS_HOME/scheduled-tasks/conservation-mode.json"
-LOCK_FILE="$CHASSIS_HOME/logs/scheduled/dispatcher.lock"
-LOG_DIR="$CHASSIS_HOME/logs/scheduled"
+HEARTBEATS_FILE="$CUSTOMER_HOME/HEARTBEATS.md"
+STATE_FILE="$CUSTOMER_HOME/scheduled-tasks/heartbeat-state.json"
+CONSERVATION_FILE="$CUSTOMER_HOME/scheduled-tasks/conservation-mode.json"
+LOCK_FILE="$CUSTOMER_HOME/logs/scheduled/dispatcher.lock"
+LOG_DIR="$CUSTOMER_HOME/logs/scheduled"
 DATE=$(date +%Y-%m-%d)
 LOG_FILE="$LOG_DIR/${DATE}-dispatcher.log"
 OLLAMA_MODEL="${OLLAMA_MODEL:-gemma2}"
@@ -74,10 +79,10 @@ mkdir -p "$LOG_DIR"
 # into literal KEY=VALUE pairs there. The raw .env has a hydration call
 # that fails silently inside the container (no Keychain / bw-unlock auth),
 # leaving every VW-backed secret unset. .env.baked has the literals.
-if [[ -f "$CHASSIS_HOME/.env.baked" ]]; then
-    source "$CHASSIS_HOME/.env.baked"
-elif [[ -f "$CHASSIS_HOME/.env" ]]; then
-    source "$CHASSIS_HOME/.env"
+if [[ -f "$CUSTOMER_HOME/.env.baked" ]]; then
+    source "$CUSTOMER_HOME/.env.baked"
+elif [[ -f "$CUSTOMER_HOME/.env" ]]; then
+    source "$CUSTOMER_HOME/.env"
 fi
 
 # CRITICAL: unset ANTHROPIC_API_KEY so `claude -p` invocations fall through
@@ -115,7 +120,7 @@ unset ANTHROPIC_API_KEY
 # exec'd, so anything it sets stays in the dispatcher's environment for
 # the rest of the run. Safe to leave absent — chassis canonical behavior
 # applies when the file doesn't exist.
-HOOKS_FILE="$CHASSIS_HOME/scheduled-tasks/dispatcher-hooks.sh"
+HOOKS_FILE="$CUSTOMER_HOME/scheduled-tasks/dispatcher-hooks.sh"
 if [[ -f "$HOOKS_FILE" ]]; then
     # shellcheck disable=SC1090
     source "$HOOKS_FILE"
@@ -521,11 +526,12 @@ list_heartbeats() {
 # --- Claude Invocation ---
 
 invoke_claude() {
-    local claude_input="$1" output_file="$2" model="$3" budget="$4" heartbeat_name="${5:-unknown}" cwd="${6:-$CHASSIS_HOME}"
+    local claude_input="$1" output_file="$2" model="$3" budget="$4" heartbeat_name="${5:-unknown}" cwd="${6:-$CUSTOMER_HOME}"
     # Timeout: 20 minutes per invocation (dating/briefing sessions need time for ADB/Playwright)
     # cwd: optional working directory for claude — heartbeats can scope to a sub-context
-    # like dating-context/ which has its own narrow CLAUDE.md. Defaults to $CHASSIS_HOME.
-    local telemetry_dir="$CHASSIS_HOME/logs/telemetry"
+    # like dating-context/ which has its own narrow CLAUDE.md. Defaults to $CUSTOMER_HOME
+    # (where the per-install CLAUDE.md and .mcp.json live, post issue #6).
+    local telemetry_dir="$CUSTOMER_HOME/logs/telemetry"
     local telemetry_file="$telemetry_dir/$DATE-usage.jsonl"
     local tmp_json="$LOG_DIR/.claude-out-$$.json"
     local start_ts exit_code end_ts wall_secs ts_iso
@@ -541,7 +547,7 @@ invoke_claude() {
             --max-budget-usd "$4" \
             --output-format json \
             > "$5" 2>> "$6"
-    ' -- "$claude_input" "$model" "$CHASSIS_HOME" "$budget" "$tmp_json" "$LOG_FILE" "$cwd"
+    ' -- "$claude_input" "$model" "$CUSTOMER_HOME" "$budget" "$tmp_json" "$LOG_FILE" "$cwd"
     exit_code=$?
 
     end_ts=$(date +%s)
@@ -705,7 +711,7 @@ run_output_validator() {
             --max-budget-usd 0.05 \
             --output-format json \
             > "$3" 2>> "$4"
-    ' -- "$validator_input" "$CHASSIS_HOME" "$validator_out" "$LOG_FILE" || {
+    ' -- "$validator_input" "$CUSTOMER_HOME" "$validator_out" "$LOG_FILE" || {
         log "VALIDATOR $name — haiku call failed or timed out, fail-open"
         rm -f "$validator_out"
         return 0
@@ -717,7 +723,7 @@ run_output_validator() {
         ts_iso=$(date +%Y-%m-%dT%H:%M:%S)
         cost_usd=$(jq -r '.cost_usd // .total_cost_usd // 0' "$validator_out" 2>/dev/null || echo 0)
         printf '%s\n' "{\"ts\":\"$ts_iso\",\"heartbeat\":\"${name}-validator\",\"model\":\"haiku\",\"cost_usd\":$cost_usd,\"input_tokens\":0,\"output_tokens\":0,\"cache_read_tokens\":0,\"cache_create_tokens\":0,\"wall_seconds\":0,\"exit_code\":0}" \
-            >> "$CHASSIS_HOME/logs/telemetry/$DATE-usage.jsonl" 2>> "$LOG_FILE" || true
+            >> "$CUSTOMER_HOME/logs/telemetry/$DATE-usage.jsonl" 2>> "$LOG_FILE" || true
 
         validator_result=$(jq -r '.result // ""' "$validator_out" 2>/dev/null || echo "")
     fi
@@ -770,7 +776,7 @@ run_output_validator() {
 # ship any recovery hooks; install-time activation is per-plugin.
 #
 # Source any installer-installed recovery hook scripts here.
-for _hook in "$CHASSIS_HOME/scheduled-tasks/recovery-hooks.d/"*.sh(N); do
+for _hook in "$CUSTOMER_HOME/scheduled-tasks/recovery-hooks.d/"*.sh(N); do
     # shellcheck disable=SC1090
     source "$_hook"
 done
@@ -847,7 +853,7 @@ main() {
         # Default model, budget, cwd, and criticality
         model=${model:-opus}
         budget=${budget:-5}
-        cwd=${cwd:-$CHASSIS_HOME}
+        cwd=${cwd:-$CUSTOMER_HOME}
         criticality=${criticality:-normal}
 
         # Conservation mode: skip non-critical heartbeats
@@ -869,7 +875,10 @@ main() {
         gather_cmd=$(get_config_multiline "$name" "gather")
         if [[ -n "$gather_cmd" ]]; then
             log "GATHER $name — running: $gather_cmd"
-            gathered_data=$(cd "$CHASSIS_HOME" && eval "$gather_cmd" 2>> "$LOG_FILE") || {
+            # Gather scripts execute with cwd=$CUSTOMER_HOME (state files,
+            # briefings, logs all live there). Scripts that need the chassis
+            # tree (chassis/scripts/...) reference $CHASSIS_HOME explicitly.
+            gathered_data=$(cd "$CUSTOMER_HOME" && eval "$gather_cmd" 2>> "$LOG_FILE") || {
                 log "ERROR $name — gather script failed"
                 set_state "$name" "last_checked" "$(date +%Y-%m-%dT%H:%M:%S)"
                 set_state "$name" "last_result" "gather_failed"
@@ -904,7 +913,19 @@ main() {
         fi
 
         # Fire Claude
-        local full_prompt_path="$CHASSIS_HOME/$prompt_file"
+        # prompt_file paths in HEARTBEATS.md may reference either chassis-side
+        # prompts (chassis/scheduled-tasks/*-prompt.md) or customer-side
+        # prompts (scheduled-tasks/*.md). Try CHASSIS_HOME first since most
+        # canonical prompts ship from chassis; fall back to CUSTOMER_HOME for
+        # per-install custom prompts.
+        local full_prompt_path
+        if [[ -f "$CHASSIS_HOME/$prompt_file" ]]; then
+            full_prompt_path="$CHASSIS_HOME/$prompt_file"
+        elif [[ -f "$CUSTOMER_HOME/$prompt_file" ]]; then
+            full_prompt_path="$CUSTOMER_HOME/$prompt_file"
+        else
+            full_prompt_path="$CHASSIS_HOME/$prompt_file"
+        fi
         if [[ ! -f "$full_prompt_path" ]]; then
             log "ERROR $name — prompt file not found: $full_prompt_path"
             set_state "$name" "last_result" "prompt_missing"
@@ -945,7 +966,7 @@ main() {
             continue
         fi
 
-        local output_dir="$CHASSIS_HOME/briefings"
+        local output_dir="$CUSTOMER_HOME/briefings"
         local output_file="$output_dir/${DATE}-${name}.md"
         mkdir -p "$output_dir"
 

--- a/chassis/scripts/_env.sh
+++ b/chassis/scripts/_env.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# _env.sh - canonical env-var resolution for the customer-state split (issue #6).
+#
+# Source this from any chassis-side script that needs to know where customer
+# state lives. It establishes the hard separation between:
+#
+#   CHASSIS_ROOT          - chassis source code root (read-only, disposable).
+#                           Container: /app/chassis (baked into image).
+#                           Host: ${CHASSIS_HOME}/chassis (under the chassis git
+#                           tree, e.g. ~/behalfbot/chassis).
+#
+#   CHASSIS_PLUGINS_ROOT  - plugins source root (read-only, disposable).
+#                           Container: /app/plugins (baked).
+#                           Host: ${CHASSIS_HOME}/plugins (e.g. ~/behalfbot/plugins).
+#
+#   CHASSIS_HOME          - HOST-side chassis git tree root, ONLY. Holds chassis/,
+#                           plugins/, bootstrap.sh, docker-compose.yml, Dockerfile.
+#                           Fully disposable. Re-pullable via git clone or docker
+#                           pull. Inside the container this var is bound to the
+#                           customer dir for backward compat (legacy scripts).
+#
+#   CUSTOMER_HOME         - customer state root. Survives reinstall. Holds .env,
+#                           CLAUDE.md, HEARTBEATS.md, scripts/, state/, logs/,
+#                           briefings/, memory/, data/, etc.
+#                           Container: /app/customer (bind-mounted from host).
+#                           Host (NEW installs):   ~/.behalfbot
+#                           Host (LEGACY installs, pre-#6): same as CHASSIS_HOME
+#                             (i.e. ~/behalfbot - customer state co-located).
+#
+# Backward-compat contract:
+#   - If CUSTOMER_HOME is unset, fall back to CHASSIS_HOME. This keeps every
+#     pre-#6 install working without changes - they continue pointing both vars
+#     at the same dir.
+#   - If CHASSIS_HOME is unset, fall back to CUSTOMER_HOME (e.g. when a script
+#     is sourced in a context that only knows about the customer side).
+#   - New code should prefer CUSTOMER_HOME for customer-side paths and
+#     CHASSIS_ROOT / CHASSIS_PLUGINS_ROOT for chassis-side paths.
+#
+# This file is idempotent - sourcing it multiple times is fine.
+
+# Resolve CUSTOMER_HOME first because the rest derive from it in the legacy case.
+if [[ -z "${CUSTOMER_HOME:-}" ]]; then
+    if [[ -n "${CHASSIS_HOME:-}" ]]; then
+        # Legacy install: customer state co-located with chassis tree.
+        export CUSTOMER_HOME="$CHASSIS_HOME"
+    elif [[ -d "$HOME/.behalfbot" ]]; then
+        # New install layout: customer state at ~/.behalfbot
+        export CUSTOMER_HOME="$HOME/.behalfbot"
+    elif [[ -d "/app/customer" ]]; then
+        # In-container default
+        export CUSTOMER_HOME="/app/customer"
+    fi
+fi
+
+# CHASSIS_HOME is the chassis tree on host. In container land we keep it
+# aliased to CUSTOMER_HOME for backward compat (existing chassis scripts
+# treat $CHASSIS_HOME/.env etc. as customer-side - those paths happen to
+# still resolve correctly when CHASSIS_HOME points at /app/customer).
+if [[ -z "${CHASSIS_HOME:-}" ]]; then
+    if [[ -n "${CUSTOMER_HOME:-}" ]]; then
+        export CHASSIS_HOME="$CUSTOMER_HOME"
+    fi
+fi
+
+# Chassis source root. On host this lives under the chassis git tree; in
+# container it's baked at /app/chassis. Allow override via existing env.
+if [[ -z "${CHASSIS_ROOT:-}" ]]; then
+    if [[ -d "/app/chassis" ]]; then
+        export CHASSIS_ROOT="/app/chassis"
+    elif [[ -n "${CHASSIS_HOME:-}" && -d "$CHASSIS_HOME/chassis" ]]; then
+        export CHASSIS_ROOT="$CHASSIS_HOME/chassis"
+    fi
+fi
+
+if [[ -z "${CHASSIS_PLUGINS_ROOT:-}" ]]; then
+    if [[ -d "/app/plugins" ]]; then
+        export CHASSIS_PLUGINS_ROOT="/app/plugins"
+    elif [[ -n "${CHASSIS_HOME:-}" && -d "$CHASSIS_HOME/plugins" ]]; then
+        export CHASSIS_PLUGINS_ROOT="$CHASSIS_HOME/plugins"
+    fi
+fi

--- a/chassis/scripts/bake-env.sh
+++ b/chassis/scripts/bake-env.sh
@@ -47,11 +47,16 @@
 
 set -euo pipefail
 
-: "${CHASSIS_HOME:?CHASSIS_HOME must be set (export to the install root that holds .env)}"
+# Issue #6: customer state - including .env / .env.baked - lives under
+# CUSTOMER_HOME. CHASSIS_HOME is kept as the legacy fallback so pre-#6
+# installs continue working without re-export.
+: "${CHASSIS_HOME:?CHASSIS_HOME must be set (export to the chassis tree root)}"
+: "${CUSTOMER_HOME:=$CHASSIS_HOME}"
+export CHASSIS_HOME CUSTOMER_HOME
 
 DRY_RUN="${DRY_RUN:-false}"
-SRC_ENV="$CHASSIS_HOME/.env"
-DST_BAKED="$CHASSIS_HOME/.env.baked"
+SRC_ENV="$CUSTOMER_HOME/.env"
+DST_BAKED="$CUSTOMER_HOME/.env.baked"
 
 if [[ ! -f "$SRC_ENV" ]]; then
     echo "ERR: $SRC_ENV not found" >&2
@@ -168,20 +173,21 @@ fi
 # <v1-reference-install>#697 + scrollinondubs/new-jaxity#49 for context.
 #
 # Path-shaped vars overridden here:
-#   CUSTOMER_HOME        -> $CHASSIS_HOME              (install root)
-#   REPO                 -> $CHASSIS_HOME              (legacy alias)
-#   MANIFEST             -> $CHASSIS_HOME/data/vaultwarden-migration-manifest.json
+#   CUSTOMER_HOME        -> $CUSTOMER_HOME             (host customer-state root)
+#   CHASSIS_HOME         -> $CHASSIS_HOME              (host chassis tree root)
+#   REPO                 -> $CHASSIS_HOME              (legacy alias for chassis tree)
+#   MANIFEST             -> $CUSTOMER_HOME/data/vaultwarden-migration-manifest.json
 #   CUSTOMER_CLAUDE_DIR  -> $HOME/.claude              (user's ~/.claude, install-agnostic)
 #
 # Strategy: strip these keys from APP_VARS, then append derived values. Loud
 # log so operators see what was overridden (in case a customer was relying on
 # a custom value).
-PATH_KEYS_REGEX='^(CUSTOMER_HOME|REPO|MANIFEST|CUSTOMER_CLAUDE_DIR)='
+PATH_KEYS_REGEX='^(CUSTOMER_HOME|CHASSIS_HOME|REPO|MANIFEST|CUSTOMER_CLAUDE_DIR)='
 PATH_ORIGINALS=$(echo "$APP_VARS" | grep -E "$PATH_KEYS_REGEX" | sort -u)
 if [[ -n "$PATH_ORIGINALS" ]]; then
     while IFS= read -r line; do
         key="${line%%=*}"
-        echo "INFO: overriding host-path var '$key' from \$CHASSIS_HOME/\$HOME (was: ${line#*=})" >&2
+        echo "INFO: overriding host-path var '$key' from host env (was: ${line#*=})" >&2
     done <<< "$PATH_ORIGINALS"
 fi
 
@@ -191,9 +197,10 @@ APP_VARS=$(echo "$APP_VARS" | grep -vE "$PATH_KEYS_REGEX" || true)
 # points at the host user's ~/.claude (Claude Code's data dir), not the
 # install root. The container reads these via env_file at boot.
 APP_VARS="$APP_VARS
-CUSTOMER_HOME=$CHASSIS_HOME
+CUSTOMER_HOME=$CUSTOMER_HOME
+CHASSIS_HOME=$CHASSIS_HOME
 REPO=$CHASSIS_HOME
-MANIFEST=$CHASSIS_HOME/data/vaultwarden-migration-manifest.json
+MANIFEST=$CUSTOMER_HOME/data/vaultwarden-migration-manifest.json
 CUSTOMER_CLAUDE_DIR=$HOME/.claude"
 
 n_keys=$(echo "$APP_VARS" | grep -c '^[A-Z]' || true)

--- a/chassis/scripts/bootstrap-customer-scripts.sh
+++ b/chassis/scripts/bootstrap-customer-scripts.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# bootstrap-customer-scripts.sh - render per-customer scripts and LaunchAgent
+# plists from chassis-shipped templates into $CUSTOMER_HOME.
+#
+# Invoked by:
+#   - bootstrap.sh (first install) - scaffolds the script set
+#   - migrate-customer-state.sh (existing-install migration) - back-fills
+#     anything missing during the customer-state move
+#   - manually after a chassis pull when a template has changed
+#
+# Idempotent: re-running re-renders every template, overwriting prior renders.
+# That's the intended behavior - the rendered scripts are chassis-managed
+# artifacts that live on the CUSTOMER side of the split (so they survive
+# CHASSIS_HOME teardown) but their canonical source-of-truth is in the
+# chassis tree under chassis/scripts/templates/ and chassis/launchd/.
+#
+# Env contract (any of these can be in the environment, .env, or
+# chassis.config.yaml; .env wins over yaml, env wins over both):
+#   CUSTOMER_HOME       required - per-customer state root
+#   CHASSIS_HOME        required - chassis git tree root
+#   BOT_NAME            required - logical bot name (jax, asimov, ozzy)
+#   TMUX_SESSION_NAME   default: ${BOT_NAME}-discord
+#   INSTANCE_NAME       default: BOT_NAME (capitalised)
+#   CLAUDE_CHANNELS     default: plugin:discord@claude-plugins-official
+#   HOMEBREW_PREFIX     default: /opt/homebrew on Apple Silicon, else /usr/local
+#   NODE_BIN_PATH       optional extra node bin dir
+#
+# Usage:
+#   CUSTOMER_HOME=~/.behalfbot CHASSIS_HOME=~/behalfbot BOT_NAME=jax \
+#       bash chassis/scripts/bootstrap-customer-scripts.sh [--dry-run]
+#
+# Flags:
+#   --dry-run   show what would be rendered, write nothing.
+#   --plists    also render the LaunchAgent plists into $CUSTOMER_HOME/launchd/.
+#               (Default: scripts only - plists are macOS-specific and require
+#               an explicit follow-up `launchctl bootstrap` step.)
+
+set -euo pipefail
+
+# Resolve canonical env helper
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_env.sh"
+
+DRY_RUN="${DRY_RUN:-false}"
+RENDER_PLISTS=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run)  DRY_RUN=true ;;
+        --plists)   RENDER_PLISTS=true ;;
+        *)          echo "unknown arg: $arg" >&2; exit 2 ;;
+    esac
+done
+
+: "${CUSTOMER_HOME:?CUSTOMER_HOME must be set}"
+: "${CHASSIS_HOME:?CHASSIS_HOME must be set}"
+: "${BOT_NAME:?BOT_NAME must be set (e.g. jax, asimov, ozzy)}"
+
+TMUX_SESSION_NAME="${TMUX_SESSION_NAME:-${BOT_NAME}-discord}"
+INSTANCE_NAME="${INSTANCE_NAME:-${BOT_NAME}}"
+CLAUDE_CHANNELS="${CLAUDE_CHANNELS:-plugin:discord@claude-plugins-official}"
+
+# Detect homebrew prefix on macOS; default to /opt/homebrew for Apple Silicon
+# which is the modern reference shape.
+if [[ -z "${HOMEBREW_PREFIX:-}" ]]; then
+    if [[ -d "/opt/homebrew/bin" ]]; then
+        HOMEBREW_PREFIX="/opt/homebrew"
+    elif [[ -d "/usr/local/Homebrew" ]]; then
+        HOMEBREW_PREFIX="/usr/local"
+    else
+        HOMEBREW_PREFIX="/usr/local"
+    fi
+fi
+
+# NODE_BIN_PATH is optional. If unset, default to homebrew's node@22 keg.
+# Either resolves; one of them existing is enough.
+NODE_BIN_PATH="${NODE_BIN_PATH:-${HOMEBREW_PREFIX}/opt/node@22/bin}"
+
+USER_UID="${USER_UID:-$(id -u)}"
+USER_NAME="${USER:-$(id -un)}"
+
+TEMPLATES_DIR="${CHASSIS_ROOT:-$CHASSIS_HOME/chassis}/scripts/templates"
+LAUNCHD_DIR="${CHASSIS_ROOT:-$CHASSIS_HOME/chassis}/launchd"
+OUT_SCRIPTS="$CUSTOMER_HOME/scripts"
+OUT_PLISTS="$CUSTOMER_HOME/launchd"
+
+mkdir -p "$OUT_SCRIPTS"
+if [[ "$RENDER_PLISTS" == "true" ]]; then
+    mkdir -p "$OUT_PLISTS"
+fi
+
+# render_template <template_path> <output_path>
+# Substitutes ${BOT_NAME}, ${TMUX_SESSION_NAME}, ${CUSTOMER_HOME},
+# ${CHASSIS_HOME}, ${CLAUDE_CHANNELS}, ${INSTANCE_NAME}, ${HOMEBREW_PREFIX},
+# ${NODE_BIN_PATH}, ${USER}, ${USER_UID} via sed. Anything not in this list
+# is passed through verbatim - templates are responsible for not including
+# accidental ${...} tokens that would silently survive.
+render_template() {
+    local src="$1" dst="$2"
+    if [[ ! -f "$src" ]]; then
+        echo "ERROR: template missing: $src" >&2
+        return 1
+    fi
+
+    local rendered
+    rendered=$(sed \
+        -e "s|\${BOT_NAME}|${BOT_NAME}|g" \
+        -e "s|\${TMUX_SESSION_NAME}|${TMUX_SESSION_NAME}|g" \
+        -e "s|\${CUSTOMER_HOME}|${CUSTOMER_HOME}|g" \
+        -e "s|\${CHASSIS_HOME}|${CHASSIS_HOME}|g" \
+        -e "s|\${CLAUDE_CHANNELS}|${CLAUDE_CHANNELS}|g" \
+        -e "s|\${INSTANCE_NAME}|${INSTANCE_NAME}|g" \
+        -e "s|\${HOMEBREW_PREFIX}|${HOMEBREW_PREFIX}|g" \
+        -e "s|\${NODE_BIN_PATH}|${NODE_BIN_PATH}|g" \
+        -e "s|\${USER}|${USER_NAME}|g" \
+        -e "s|\${USER_UID}|${USER_UID}|g" \
+        "$src")
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "[dry-run] would render $src -> $dst"
+        return 0
+    fi
+
+    printf '%s\n' "$rendered" > "$dst"
+    chmod +x "$dst" 2>/dev/null || true
+    echo "rendered $dst"
+}
+
+# Per-bot script renderers
+render_template "$TEMPLATES_DIR/restart-discord.sh.template" \
+    "$OUT_SCRIPTS/restart-${BOT_NAME}-discord.sh"
+render_template "$TEMPLATES_DIR/watchdog-discord.sh.template" \
+    "$OUT_SCRIPTS/watchdog-${BOT_NAME}-discord.sh"
+
+if [[ "$RENDER_PLISTS" == "true" ]]; then
+    render_template "$LAUNCHD_DIR/com.behalfbot.discord-restart.plist.template" \
+        "$OUT_PLISTS/com.behalfbot.${BOT_NAME}-discord-restart.plist"
+    render_template "$LAUNCHD_DIR/com.behalfbot.discord-watchdog.plist.template" \
+        "$OUT_PLISTS/com.behalfbot.${BOT_NAME}-discord-watchdog.plist"
+    render_template "$LAUNCHD_DIR/com.behalfbot.heartbeat-dispatcher.plist.template" \
+        "$OUT_PLISTS/com.behalfbot.heartbeat-dispatcher.plist"
+fi
+
+if [[ "$DRY_RUN" != "true" ]]; then
+    echo ""
+    echo "Customer-side scripts rendered into: $OUT_SCRIPTS"
+    if [[ "$RENDER_PLISTS" == "true" ]]; then
+        echo "Customer-side plists rendered into:  $OUT_PLISTS"
+        echo ""
+        echo "Next: link the plists into ~/Library/LaunchAgents and load them:"
+        echo "  ln -sf $OUT_PLISTS/com.behalfbot.${BOT_NAME}-discord-restart.plist ~/Library/LaunchAgents/"
+        echo "  ln -sf $OUT_PLISTS/com.behalfbot.${BOT_NAME}-discord-watchdog.plist ~/Library/LaunchAgents/"
+        echo "  launchctl bootstrap gui/${USER_UID} ~/Library/LaunchAgents/com.behalfbot.${BOT_NAME}-discord-restart.plist"
+        echo "  launchctl bootstrap gui/${USER_UID} ~/Library/LaunchAgents/com.behalfbot.${BOT_NAME}-discord-watchdog.plist"
+    fi
+fi

--- a/chassis/scripts/bootstrap-mcp-config.sh
+++ b/chassis/scripts/bootstrap-mcp-config.sh
@@ -60,6 +60,10 @@
 set -euo pipefail
 
 : "${CHASSIS_HOME:?CHASSIS_HOME must be set (export it before running, or invoke from the install runbook)}"
+# Issue #6: prefer CUSTOMER_HOME for .env / .mcp.json output; CHASSIS_HOME
+# fallback keeps legacy installs working.
+: "${CUSTOMER_HOME:=$CHASSIS_HOME}"
+export CHASSIS_HOME CUSTOMER_HOME
 
 # Resolve template relative to THIS script's location. Chassis is reachable
 # through two layouts:
@@ -71,8 +75,8 @@ set -euo pipefail
 # Either way, the template sits one directory above this script's parent.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEMPLATE="${SCRIPT_DIR%/scripts}/.mcp.json.template"
-TARGET="$CHASSIS_HOME/.mcp.json"
-ENV_FILE="$CHASSIS_HOME/.env"
+TARGET="$CUSTOMER_HOME/.mcp.json"
+ENV_FILE="$CUSTOMER_HOME/.env"
 
 FORCE=0
 DRY_RUN=0
@@ -139,9 +143,9 @@ for ph in "${PLACEHOLDERS[@]}"; do
     fi
 done
 
-# Shell-expand ${CHASSIS_HOME} (kept literal in the template so the file is
-# self-documenting). Only substitute the exact `${CHASSIS_HOME}` token.
-OUTPUT=$(printf '%s' "$OUTPUT" | sed "s|\${CHASSIS_HOME}|$CHASSIS_HOME|g")
+# Shell-expand ${CHASSIS_HOME} and ${CUSTOMER_HOME} (kept literal in the
+# template so the file is self-documenting). Only substitute the exact tokens.
+OUTPUT=$(printf '%s' "$OUTPUT" | sed -e "s|\${CHASSIS_HOME}|$CHASSIS_HOME|g" -e "s|\${CUSTOMER_HOME}|$CUSTOMER_HOME|g")
 
 # Drop the `_README` key from the top-level object and any `_role` / `_enable_when`
 # / `_install_note` keys from servers. They're documentation, not config — jq

--- a/chassis/scripts/migrate-customer-state.sh
+++ b/chassis/scripts/migrate-customer-state.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+# migrate-customer-state.sh - one-shot migration from the legacy pre-#6 layout
+# (customer state co-located with chassis tree at $CHASSIS_HOME) to the new
+# hard-split layout ($CHASSIS_HOME for chassis-disposable code,
+# $CUSTOMER_HOME for customer state that survives reinstall).
+#
+# Background: the chassis tree at $CHASSIS_HOME (e.g. ~/behalfbot) used to mix
+# chassis-managed code (chassis/, plugins/, bootstrap.sh, Dockerfile) with
+# customer state that must survive a reinstall (logs/, briefings/, state/,
+# scripts/, etc.). Only the gitignored dirs survived `rm -rf` + `git clone`;
+# anything customer-side that wasn't in .gitignore (notably scripts/ holding
+# restart-${BOT}-discord.sh) got nuked silently. Toby's install died for 14h
+# overnight on 2026-06-02 because of this exact failure mode. See issue #6.
+#
+# This script:
+#   1. Verifies $CUSTOMER_HOME does not already contain state (refuses if so)
+#   2. Creates the $CUSTOMER_HOME subdir layout
+#   3. mv's each customer-side artifact out of $CHASSIS_HOME into $CUSTOMER_HOME
+#   4. Re-renders launchd plists with new paths and reloads them
+#   5. Re-renders customer scripts (restart/watchdog) from chassis templates
+#   6. Prints a summary + any follow-up actions
+#
+# Idempotency: subsequent runs are a no-op once the target dir exists with a
+# state file. To re-run from scratch, blow away $CUSTOMER_HOME first.
+#
+# Flags:
+#   --dry-run            print every action without executing
+#   --customer-home P    override $CUSTOMER_HOME target (default: $HOME/.behalfbot)
+#   --chassis-home P     override $CHASSIS_HOME source (default: $HOME/behalfbot)
+#   --bot-name N         override $BOT_NAME (default: parsed from chassis.config.yaml)
+#   --skip-launchd       don't touch launchctl - useful on Linux installs or
+#                        when launchd state will be handled manually
+#
+# Exit codes:
+#   0  migration succeeded (or dry-run completed cleanly)
+#   2  refusing to migrate - target exists or source missing
+#   3  template-render step failed
+#   4  launchctl reload step failed
+
+set -euo pipefail
+
+DRY_RUN=false
+SKIP_LAUNCHD=false
+ARG_CUSTOMER_HOME=""
+ARG_CHASSIS_HOME=""
+ARG_BOT_NAME=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)         DRY_RUN=true; shift ;;
+        --skip-launchd)    SKIP_LAUNCHD=true; shift ;;
+        --customer-home)   ARG_CUSTOMER_HOME="$2"; shift 2 ;;
+        --chassis-home)    ARG_CHASSIS_HOME="$2"; shift 2 ;;
+        --bot-name)        ARG_BOT_NAME="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '1,40p' "$0" | sed 's/^# *//'
+            exit 0 ;;
+        *)
+            echo "unknown arg: $1" >&2
+            exit 2 ;;
+    esac
+done
+
+# Resolve source/target paths
+CHASSIS_HOME="${ARG_CHASSIS_HOME:-${CHASSIS_HOME:-$HOME/behalfbot}}"
+CUSTOMER_HOME="${ARG_CUSTOMER_HOME:-${CUSTOMER_HOME:-$HOME/.behalfbot}}"
+export CHASSIS_HOME CUSTOMER_HOME
+
+say() {
+    printf '%s\n' "$*"
+}
+
+run() {
+    if [[ "$DRY_RUN" == "true" ]]; then
+        say "  [dry-run] $*"
+        return 0
+    fi
+    "$@"
+}
+
+# Pretty-print a section header
+section() {
+    say ""
+    say "--- $* ---"
+}
+
+section "Migration plan"
+say "  Source (CHASSIS_HOME): $CHASSIS_HOME"
+say "  Target (CUSTOMER_HOME): $CUSTOMER_HOME"
+say "  Dry run: $DRY_RUN"
+say "  Skip launchd: $SKIP_LAUNCHD"
+
+if [[ ! -d "$CHASSIS_HOME" ]]; then
+    say "FATAL: source dir does not exist: $CHASSIS_HOME"
+    exit 2
+fi
+
+if [[ ! -d "$CHASSIS_HOME/chassis" ]]; then
+    say "FATAL: $CHASSIS_HOME does not look like a chassis tree (no chassis/ subdir)."
+    say "       Pass --chassis-home <path> to point at the right tree."
+    exit 2
+fi
+
+# Refuse-if-target-state-file-exists guard.
+STATE_FILE_TARGET="$CUSTOMER_HOME/.migrated-from-chassis-home"
+if [[ -f "$STATE_FILE_TARGET" ]]; then
+    say "Already migrated: $STATE_FILE_TARGET exists."
+    say "Re-run by removing $CUSTOMER_HOME first (after backing up if needed)."
+    exit 0
+fi
+
+# Derive BOT_NAME from chassis.config.yaml if not explicitly passed.
+BOT_NAME="${ARG_BOT_NAME:-${BOT_NAME:-}}"
+if [[ -z "$BOT_NAME" ]]; then
+    if [[ -f "$CHASSIS_HOME/chassis.config.yaml" ]]; then
+        BOT_NAME=$(awk -F': *' '/^  *(instance_name|bot_name):/ { gsub(/["'"'"']/, "", $2); print $2; exit }' "$CHASSIS_HOME/chassis.config.yaml" || true)
+    fi
+    BOT_NAME="${BOT_NAME:-bot}"
+fi
+export BOT_NAME
+
+section "Step 1: create CUSTOMER_HOME layout"
+CUSTOMER_SUBDIRS=(
+    scripts
+    state
+    scheduled-tasks
+    memory
+    briefings
+    logs
+    logs/scheduled
+    logs/telemetry
+    data
+    temp
+    launchd
+)
+for d in "${CUSTOMER_SUBDIRS[@]}"; do
+    run mkdir -p "$CUSTOMER_HOME/$d"
+    say "  created: $CUSTOMER_HOME/$d"
+done
+
+# Track what we moved so the summary at the end is concrete.
+MOVED_PATHS=()
+SKIPPED_PATHS=()
+
+# move_if_present <src-relative> [<dst-relative>]
+# Move $CHASSIS_HOME/<src-relative> to $CUSTOMER_HOME/<dst-relative or src-relative>.
+# Skips silently if the source doesn't exist.
+move_if_present() {
+    local src_rel="$1"
+    local dst_rel="${2:-$1}"
+    local src="$CHASSIS_HOME/$src_rel"
+    local dst="$CUSTOMER_HOME/$dst_rel"
+
+    if [[ ! -e "$src" ]]; then
+        SKIPPED_PATHS+=("$src_rel (absent)")
+        return 0
+    fi
+
+    if [[ -e "$dst" ]]; then
+        SKIPPED_PATHS+=("$src_rel (target $dst already exists)")
+        return 0
+    fi
+
+    # Ensure parent dir of dst exists.
+    local dst_parent
+    dst_parent="$(dirname "$dst")"
+    run mkdir -p "$dst_parent"
+
+    run mv "$src" "$dst"
+    MOVED_PATHS+=("$src_rel -> $dst_rel")
+}
+
+section "Step 2: move customer-side artifacts"
+
+# Customer dotfiles / config (top-level)
+move_if_present ".env"
+move_if_present ".env.baked"
+move_if_present ".mcp.json"
+move_if_present "CLAUDE.md"
+move_if_present "HEARTBEATS.md"
+move_if_present "chassis.config.yaml"
+move_if_present "INSTALL_PROFILE.md"
+move_if_present "triggers.yaml"
+
+# Customer-side directories
+move_if_present "scripts"
+move_if_present "state"
+move_if_present "scheduled-tasks"
+move_if_present "briefings"
+move_if_present "logs"
+move_if_present "data"
+move_if_present "temp"
+# Top-level memory/ on legacy installs (Sean's stack): the MCP memory graph
+# at memory/memory.jsonl. Newer layouts may not have this.
+move_if_present "memory"
+
+# Memory: was at chassis/memory/* in legacy installs. Move installer-specific
+# memory entries (lead_*, topic_*, feedback_*, project_*, reference_*,
+# student_*, user_*, task_*, MEMORY.md) - leave the chassis-tree memory/
+# directory structure (.gitkeep + non-installer scaffolding) alone, since
+# that's chassis-disposable.
+if [[ -d "$CHASSIS_HOME/chassis/memory" ]]; then
+    say "  inspecting $CHASSIS_HOME/chassis/memory for installer entries..."
+    run mkdir -p "$CUSTOMER_HOME/memory"
+    shopt -s nullglob
+    for pattern in MEMORY.md lead_*.md topic_*.md feedback_*.md project_*.md reference_*.md student_*.md user_*.md task_*.md installer/; do
+        for src in "$CHASSIS_HOME/chassis/memory/"$pattern; do
+            [[ -e "$src" ]] || continue
+            local_dst="$CUSTOMER_HOME/memory/$(basename "$src")"
+            if [[ -e "$local_dst" ]]; then
+                SKIPPED_PATHS+=("chassis/memory/$(basename "$src") (target exists)")
+                continue
+            fi
+            run mv "$src" "$local_dst"
+            MOVED_PATHS+=("chassis/memory/$(basename "$src") -> memory/$(basename "$src")")
+        done
+    done
+    shopt -u nullglob
+fi
+
+section "Step 3: re-render customer-side scripts from chassis templates"
+RENDER_RC=0
+BOOTSTRAP_SCRIPT="$CHASSIS_HOME/chassis/scripts/bootstrap-customer-scripts.sh"
+if [[ "$DRY_RUN" == "true" ]]; then
+    say "  [dry-run] would run: bash $BOOTSTRAP_SCRIPT --plists"
+else
+    if ! env BOT_NAME="$BOT_NAME" CUSTOMER_HOME="$CUSTOMER_HOME" CHASSIS_HOME="$CHASSIS_HOME" \
+        bash "$BOOTSTRAP_SCRIPT" --plists; then
+        RENDER_RC=1
+    fi
+fi
+
+if [[ $RENDER_RC -ne 0 ]]; then
+    say "ERROR: bootstrap-customer-scripts.sh failed"
+    say "  Migration partially applied; the moved artifacts are at $CUSTOMER_HOME"
+    say "  Inspect, fix the template render, then re-run bootstrap-customer-scripts.sh"
+    exit 3
+fi
+
+section "Step 4: reload LaunchAgent plists (macOS only)"
+if [[ "$SKIP_LAUNCHD" == "true" ]]; then
+    say "  skipped (--skip-launchd)"
+elif ! command -v launchctl >/dev/null 2>&1; then
+    say "  launchctl not in PATH - skipping (likely Linux install)"
+else
+    USER_UID="${USER_UID:-$(id -u)}"
+    PLIST_DIR="$CUSTOMER_HOME/launchd"
+    LA_DIR="$HOME/Library/LaunchAgents"
+
+    # Bootout any of the existing per-bot plists so the new ones load clean.
+    for legacy in \
+        "com.${BOT_NAME}.discord-restart" \
+        "com.${BOT_NAME}.discord-watchdog" \
+        "com.${BOT_NAME}.heartbeat-dispatcher" \
+        "com.behalfbot.${BOT_NAME}-discord-restart" \
+        "com.behalfbot.${BOT_NAME}-discord-watchdog" \
+        "com.behalfbot.heartbeat-dispatcher"; do
+        if launchctl print "gui/${USER_UID}/${legacy}" >/dev/null 2>&1; then
+            run launchctl bootout "gui/${USER_UID}/${legacy}" || true
+        fi
+    done
+
+    # Symlink new plists in and bootstrap them.
+    mkdir -p "$LA_DIR"
+    for plist in \
+        "com.behalfbot.${BOT_NAME}-discord-restart.plist" \
+        "com.behalfbot.${BOT_NAME}-discord-watchdog.plist"; do
+        src="$PLIST_DIR/$plist"
+        dst="$LA_DIR/$plist"
+        if [[ ! -f "$src" ]]; then
+            say "  WARNING: rendered plist missing at $src - skipping"
+            continue
+        fi
+        run ln -sf "$src" "$dst"
+        run launchctl bootstrap "gui/${USER_UID}" "$dst" || true
+        say "  loaded $dst"
+    done
+fi
+
+section "Step 5: write migration sentinel"
+if [[ "$DRY_RUN" != "true" ]]; then
+    cat > "$STATE_FILE_TARGET" <<EOF
+# Behalf.bot customer-state migration sentinel (issue #6).
+# Written by chassis/scripts/migrate-customer-state.sh.
+# Presence of this file marks the install as already migrated; re-running
+# the migration script is a no-op unless this file is removed first.
+migrated_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+chassis_home: $CHASSIS_HOME
+customer_home: $CUSTOMER_HOME
+bot_name: $BOT_NAME
+EOF
+fi
+
+section "Summary"
+say "  Moved:"
+if [[ ${#MOVED_PATHS[@]} -eq 0 ]]; then
+    say "    (nothing - all targets already present, or running dry-run mode)"
+else
+    for p in "${MOVED_PATHS[@]}"; do
+        say "    $p"
+    done
+fi
+say "  Skipped:"
+if [[ ${#SKIPPED_PATHS[@]} -eq 0 ]]; then
+    say "    (none)"
+else
+    for p in "${SKIPPED_PATHS[@]}"; do
+        say "    $p"
+    done
+fi
+
+say ""
+say "Post-migration follow-ups:"
+say "  - Update any host-side LaunchAgents that reference $CHASSIS_HOME/scripts/"
+say "    or $CHASSIS_HOME/logs/ paths and aren't covered by the chassis plist set."
+say "  - Update any cron entries similarly."
+say "  - Update CHASSIS_HOME-aware shell aliases / dotfile snippets to also set"
+say "    CUSTOMER_HOME=$CUSTOMER_HOME."
+say "  - Verify the discord-watchdog plist fires successfully:"
+say "      tail -f $CUSTOMER_HOME/logs/scheduled/watchdog.log"
+say "  - Verify the heartbeat-dispatcher (containerized installs: docker compose"
+say "    logs chassis; bare-metal: $CUSTOMER_HOME/logs/scheduled/<date>-dispatcher.log)."
+say ""
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    say "DRY-RUN complete. Nothing was changed."
+else
+    say "Migration complete."
+fi

--- a/chassis/scripts/templates/restart-discord.sh.template
+++ b/chassis/scripts/templates/restart-discord.sh.template
@@ -1,0 +1,64 @@
+#!/bin/bash
+# restart-${BOT_NAME}-discord.sh - chassis-rendered template.
+#
+# Kills and restarts the ${TMUX_SESSION_NAME} tmux session with a fresh
+# Claude Code process. Invoked daily by the discord-restart LaunchAgent and
+# on-demand by the discord-watchdog LaunchAgent.
+#
+# Generated from chassis/scripts/templates/restart-discord.sh.template by
+# chassis/scripts/bootstrap-customer-scripts.sh. Do NOT edit the rendered copy
+# directly - the chassis bootstrap can re-render it, clobbering local edits.
+# Customise the template if a per-install behavior change is needed, or open
+# an issue on scrollinondubs/behalfbot.
+#
+# Template variables (expanded at render time):
+#   BOT_NAME            - logical bot name (e.g. jax, asimov, ozzy)
+#   TMUX_SESSION_NAME   - tmux session label (typically ${BOT_NAME}-discord)
+#   CUSTOMER_HOME       - per-customer state root (e.g. ~/.behalfbot)
+#   CHASSIS_HOME        - chassis git tree root (e.g. ~/behalfbot)
+#   CLAUDE_CHANNELS     - --channels flag value (default plugin:discord@claude-plugins-official)
+
+set -euo pipefail
+
+LOG_DIR="${CUSTOMER_HOME}/logs/scheduled"
+LOG_FILE="$LOG_DIR/discord-restart.log"
+mkdir -p "$LOG_DIR"
+
+timestamp() { date '+%Y-%m-%d %H:%M:%S'; }
+
+echo "[$(timestamp)] Discord session restart starting for ${BOT_NAME}..." >> "$LOG_FILE"
+
+# Kill existing session if present
+if tmux has-session -t "${TMUX_SESSION_NAME}" 2>/dev/null; then
+    echo "[$(timestamp)] Killing existing ${TMUX_SESSION_NAME} session" >> "$LOG_FILE"
+    tmux kill-session -t "${TMUX_SESSION_NAME}"
+    sleep 2
+else
+    echo "[$(timestamp)] No existing ${TMUX_SESSION_NAME} session found" >> "$LOG_FILE"
+fi
+
+# Start new session.
+#
+# Working dir is CHASSIS_HOME so claude resolves CLAUDE.md from there. The
+# chassis tree contains the canonical CLAUDE.md.template; customer's rendered
+# CLAUDE.md lives under CUSTOMER_HOME but is symlinked / referenced via the
+# chassis tree at install time. See chassis/scripts/bootstrap-customer-scripts.sh
+# for the wiring.
+#
+# Per chassis OAuth-rotation rule: no forced "claude --print ping" token
+# refresh here - it rotates the Anthropic OAuth refresh-token server-side
+# and invalidates peer claude processes still holding the old one. The OAuth
+# bridge sync handles freshness via lazy-refresh-on-use plus bidirectional
+# file<->keychain propagation (chassis/scripts/sync-claude-oauth-bridge.sh,
+# 30 min StartInterval).
+tmux new-session -s "${TMUX_SESSION_NAME}" -d \
+    "cd '${CHASSIS_HOME}' && claude --channels '${CLAUDE_CHANNELS}' --dangerously-skip-permissions"
+
+sleep 2
+
+if tmux has-session -t "${TMUX_SESSION_NAME}" 2>/dev/null; then
+    echo "[$(timestamp)] ${TMUX_SESSION_NAME} session restarted successfully" >> "$LOG_FILE"
+else
+    echo "[$(timestamp)] ERROR: Failed to start ${TMUX_SESSION_NAME} session" >> "$LOG_FILE"
+    exit 1
+fi

--- a/chassis/scripts/templates/watchdog-discord.sh.template
+++ b/chassis/scripts/templates/watchdog-discord.sh.template
@@ -1,0 +1,50 @@
+#!/bin/bash
+# watchdog-${BOT_NAME}-discord.sh - chassis-rendered template.
+#
+# Monitors the ${TMUX_SESSION_NAME} tmux session for auth failures and
+# restarts it via the sibling restart script when needed. Runs every 30
+# minutes via the discord-watchdog LaunchAgent.
+#
+# Generated from chassis/scripts/templates/watchdog-discord.sh.template by
+# chassis/scripts/bootstrap-customer-scripts.sh. Do NOT edit the rendered copy.
+#
+# Template variables (expanded at render time):
+#   BOT_NAME            - logical bot name
+#   TMUX_SESSION_NAME   - tmux session label
+#   CUSTOMER_HOME       - per-customer state root
+
+set -euo pipefail
+
+LOG_DIR="${CUSTOMER_HOME}/logs/scheduled"
+LOG_FILE="$LOG_DIR/watchdog.log"
+RESTART_SCRIPT="${CUSTOMER_HOME}/scripts/restart-${BOT_NAME}-discord.sh"
+mkdir -p "$LOG_DIR"
+
+timestamp() { date '+%Y-%m-%d %H:%M:%S'; }
+
+# Defensive: refuse to run if the restart script is missing rather than
+# silently retry every 30 min with exit 127 (the Toby case study, #6).
+if [[ ! -x "$RESTART_SCRIPT" ]]; then
+    echo "[$(timestamp)] FATAL: restart script missing at $RESTART_SCRIPT" >> "$LOG_FILE"
+    echo "[$(timestamp)]   This watchdog cannot recover the session without it." >> "$LOG_FILE"
+    echo "[$(timestamp)]   Re-render via: bash \$CHASSIS_HOME/chassis/scripts/bootstrap-customer-scripts.sh" >> "$LOG_FILE"
+    exit 2
+fi
+
+# Check if session exists
+if ! tmux has-session -t "${TMUX_SESSION_NAME}" 2>/dev/null; then
+    echo "[$(timestamp)] Session missing - restarting" >> "$LOG_FILE"
+    bash "$RESTART_SCRIPT"
+    exit 0
+fi
+
+# Capture recent pane output and check for auth failure indicators
+PANE_OUTPUT=$(tmux capture-pane -t "${TMUX_SESSION_NAME}" -p -S -50 2>/dev/null)
+
+if echo "$PANE_OUTPUT" | grep -qiE "Not logged in|Please run /login|authentication.*failed|token.*expired"; then
+    echo "[$(timestamp)] Auth failure detected - restarting" >> "$LOG_FILE"
+    bash "$RESTART_SCRIPT"
+    exit 0
+fi
+
+echo "[$(timestamp)] Session healthy" >> "$LOG_FILE"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,16 @@ services:
       postgres:
         condition: service_healthy
     environment:
+      # Issue #6: hard-split between chassis-disposable code and customer
+      # state. CUSTOMER_HOME is the canonical name for the customer-state
+      # mount; CHASSIS_HOME is kept as an alias to the SAME path so legacy
+      # chassis scripts (which read $CHASSIS_HOME/.env, $CHASSIS_HOME/briefings,
+      # etc.) continue to work without modification. New / updated code should
+      # prefer CUSTOMER_HOME for customer-side paths and CHASSIS_ROOT /
+      # CHASSIS_PLUGINS_ROOT (defined in the Dockerfile ENV) for chassis-side
+      # code paths. The Dockerfile bakes /app/chassis + /app/plugins as
+      # read-only image layers; only /app/customer is bind-mounted.
+      CUSTOMER_HOME: /app/customer
       CHASSIS_HOME: /app/customer
       DISPATCHER_INTERVAL_SECONDS: ${DISPATCHER_INTERVAL_SECONDS:-900}
       # Postgres DSN seen from inside the chassis network. The chassis

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -20,7 +20,13 @@ set -euo pipefail
 
 : "${CHASSIS_ROOT:=/app/chassis}"
 : "${CHASSIS_PLUGINS_ROOT:=/app/plugins}"
-: "${CHASSIS_HOME:=/app/customer}"
+# Issue #6 customer-state split. CUSTOMER_HOME is the canonical name for the
+# customer-state mount inside the container; CHASSIS_HOME is kept as an alias
+# pointing at the SAME path so legacy chassis scripts (which read
+# $CHASSIS_HOME/.env, $CHASSIS_HOME/briefings, etc.) keep working untouched.
+: "${CUSTOMER_HOME:=/app/customer}"
+: "${CHASSIS_HOME:=$CUSTOMER_HOME}"
+export CUSTOMER_HOME CHASSIS_HOME CHASSIS_ROOT CHASSIS_PLUGINS_ROOT
 : "${DISPATCHER_INTERVAL_SECONDS:=900}"
 : "${DISPATCHER_SCRIPT:=$CHASSIS_ROOT/scheduled-tasks/heartbeat-dispatcher.sh}"
 
@@ -33,7 +39,9 @@ log() {
 
 ensure_customer_layout() {
     # Bind-mount may be empty on first run. Don't clobber existing state.
-    mkdir -p "$CHASSIS_HOME"/{briefings,logs/scheduled,scheduled-tasks,state,data,memory,plugins,temp}
+    # Use CUSTOMER_HOME (which equals CHASSIS_HOME in the container) so the
+    # naming matches the new issue #6 semantics.
+    mkdir -p "$CUSTOMER_HOME"/{briefings,logs/scheduled,scheduled-tasks,state,data,memory,plugins,temp,scripts}
 }
 
 source_env() {


### PR DESCRIPTION
## Summary

Hard-splits customer state from the chassis tree so the chassis container / git tree becomes fully disposable. Closes #6 (the Toby case study where a fresh `git clone` overwrote `~/behalfbot/scripts/` and Asimov went silent for 14h overnight).

Three new env vars:

- `CHASSIS_HOME` (host: `~/behalfbot`) - chassis tree only. Fully disposable. `rm -rf && git clone` safe.
- `CUSTOMER_HOME` (host: `~/.behalfbot`, default) - customer state. NEVER touched by reinstall. Holds `.env`, `CLAUDE.md`, `HEARTBEATS.md`, `scripts/` (restart/watchdog), `state/`, `briefings/`, `logs/`, `memory/`, `data/`, etc.
- `CHASSIS_ROOT` / `CHASSIS_PLUGINS_ROOT` already existed; now they're the canonical names for chassis source code paths (`$CHASSIS_HOME/chassis/` and `$CHASSIS_HOME/plugins/` on host; `/app/chassis` and `/app/plugins` in container).

Container `CHASSIS_HOME` stays aliased to `CUSTOMER_HOME` (both `/app/customer`) so every existing chassis script that reads `$CHASSIS_HOME/.env`, `$CHASSIS_HOME/logs`, etc. continues to work unchanged. Backward compat fallback (`CUSTOMER_HOME:=$CHASSIS_HOME`) at the top of every touched script keeps pre-#6 installs operational until the migration script runs.

## Design choice

`CHASSIS_HOME` and `CUSTOMER_HOME` are SEPARATE env vars (not a rename). Pre-#6 installs had them point at the same dir; post-#6 they're physically distinct trees. The split is enforced at the file-system level (CHASSIS_HOME contains zero customer state) and at the CI level (workflow guard fails if customer-state paths are ever committed to the chassis tree). In container land both vars are aliased to `/app/customer` because the chassis tree there lives at `/app/chassis` (read-only, baked into the image) and never gets co-located with state in the first place.

The chassis ships parameterised templates for the per-bot restart / watchdog scripts and the LaunchAgent plists. Templates expand on first install (via `bootstrap.sh`) and on migration (via `migrate-customer-state.sh`). The watchdog template adds a defensive guard: if the rendered restart script is missing it logs `FATAL` and exits 2 instead of silently retrying every 30 min with `exit 127` (the exact Toby failure mode).

## Files changed

| Path | LOC |
|---|---|
| `chassis/scripts/_env.sh` (new) | 81 |
| `chassis/scripts/bootstrap-customer-scripts.sh` (new) | 156 |
| `chassis/scripts/migrate-customer-state.sh` (new) | 329 |
| `chassis/scripts/templates/restart-discord.sh.template` (new) | 64 |
| `chassis/scripts/templates/watchdog-discord.sh.template` (new) | 50 |
| `chassis/launchd/com.behalfbot.discord-restart.plist.template` (new) | 57 |
| `chassis/launchd/com.behalfbot.discord-watchdog.plist.template` (new) | 46 |
| `chassis/launchd/com.behalfbot.heartbeat-dispatcher.plist.template` (new) | 65 |
| `.github/workflows/no-customer-state-in-chassis.yml` (new) | 97 |
| `bootstrap.sh` | +252 / -55 |
| `chassis/scheduled-tasks/heartbeat-dispatcher.sh` | +51 / -18 |
| `chassis/scripts/bake-env.sh` | +18 / -9 |
| `chassis/scripts/bootstrap-mcp-config.sh` | +9 / -5 |
| `docker-compose.yml` | +10 |
| `docker/entrypoint.sh` | +10 / -2 |
| `Dockerfile` | +1 |
| `.env.example` | +7 / -3 |
| `.gitignore` | +28 / -6 |
| `INSTALL_PROFILE.md` | +2 / -2 |
| `README.md` | +49 |

Total: 1,330 insertions, 97 deletions across 20 files. Split into 5 commits for review.

## Migration plan (three installs, in dogfood order)

### 1. Sean (the V1 reference install) - dogfood first

```
cd /Users/jax/work/new-jaxity
bash chassis/scripts/migrate-customer-state.sh --dry-run --bot-name jax
# Inspect the dry-run output, confirm expected moves
bash chassis/scripts/migrate-customer-state.sh --bot-name jax
# Watchdog plist runs every 30 min - check ~/.behalfbot/logs/scheduled/watchdog.log
# Heartbeat dispatcher runs every 15 min (container) - check docker logs chassis
```

After Sean's stack soaks for 24h with no regressions, proceed to:

### 2. Toby (the case study install)

Toby's stack was already in a broken state (the failure that motivated #6). Use the migration script as the recovery path - moves the surviving customer artifacts to `~/.behalfbot/`, then re-renders the restart + watchdog scripts that were deleted in the original chassis re-clone. Discord LaunchAgent recovers immediately.

```
ssh asimov@tobys-macbook-pro
cd ~/behalfbot
bash chassis/scripts/migrate-customer-state.sh --dry-run --bot-name asimov
bash chassis/scripts/migrate-customer-state.sh --bot-name asimov
```

### 3. Ben (fatboy)

Lowest-priority migration (his stack is healthy and not exhibiting the issue). Run after Sean + Toby soak clean for 48h.

```
ssh b@fatboy
cd ~/behalfbot
bash chassis/scripts/migrate-customer-state.sh --dry-run --bot-name ozzy
bash chassis/scripts/migrate-customer-state.sh --bot-name ozzy
```

## Migration script dry-run output (Sean stack)

The migration script was dry-run against `/Users/jax/work/new-jaxity` with target `/tmp/dryrun-sean`. Sample summary:

```
--- Summary ---
  Moved:
    .env -> .env
    .env.baked -> .env.baked
    .mcp.json -> .mcp.json
    CLAUDE.md -> CLAUDE.md
    HEARTBEATS.md -> HEARTBEATS.md
    chassis.config.yaml -> chassis.config.yaml
    INSTALL_PROFILE.md -> INSTALL_PROFILE.md
    scripts -> scripts
    state -> state
    scheduled-tasks -> scheduled-tasks
    briefings -> briefings
    logs -> logs
    data -> data
    temp -> temp
    memory -> memory
  Skipped:
    triggers.yaml (absent)
```

Sentinel `~/.behalfbot/.migrated-from-chassis-home` is written at the end so reruns are no-ops.

## Test plan

- [ ] CI: shellcheck on `chassis/scripts/_env.sh`, `bootstrap-customer-scripts.sh`, `migrate-customer-state.sh`, `bootstrap.sh`, `bake-env.sh`, `bootstrap-mcp-config.sh`, `docker/entrypoint.sh` - all green locally at `-S error`
- [ ] CI: new `no-customer-state-in-chassis.yml` workflow passes against the current tree (verified locally)
- [ ] `plutil -lint` clean on all three rendered LaunchAgent plists
- [ ] `bash bootstrap.sh --dry-run` with a fresh `CUSTOMER_HOME` does not touch the target dir (verified locally)
- [ ] `bash chassis/scripts/migrate-customer-state.sh --dry-run` against the Sean stack prints expected mv list (verified - see Summary block above)
- [ ] After ratification: run live migration on Sean's stack, verify watchdog + dispatcher come up healthy
- [ ] After Sean soak: same on Toby's stack
- [ ] After Toby soak: same on Ben's stack

## What this PR does NOT do

Plugin-level scripts (under `plugins/*/`) still reference `$CHASSIS_HOME` for customer-side paths. They keep working because `CHASSIS_HOME == CUSTOMER_HOME` in the container and because legacy host installs (pre-migration) have both pointing at the same dir. Migrating those to `CUSTOMER_HOME` lands in follow-up PRs once this lands. The same applies to the dating subagent CLAUDE.md and the various plugin gather scripts.

Closes #6.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>