### PR TITLE
fix(oauth-bridge): replace literal placeholder with KEYCHAIN_ACCOUNT (#12)

### DIFF
--- a/chassis/scripts/sync-claude-oauth-bridge.sh
+++ b/chassis/scripts/sync-claude-oauth-bridge.sh
@@ -107,7 +107,7 @@ if [[ "$KC_EXPIRES" -lt "$FILE_EXPIRES" ]]; then
     fi
     # security add-generic-password -U updates the existing item in place,
     # preserving the service/account labels.
-    if security add-generic-password -U -s "Claude Code-credentials" -a <v1-reference-install> -w "$FILE_JSON" 2>/dev/null; then
+    if security add-generic-password -U -s "Claude Code-credentials" -a "$KEYCHAIN_ACCOUNT" -w "$FILE_JSON" 2>/dev/null; then
         log "reverse-synced: file expiresAt=$FILE_EXPIRES → keychain (was $KC_EXPIRES)"
         exit 0
     else


### PR DESCRIPTION
Partial fix for #12. Replaces the literal `<v1-reference-install>` placeholder with the `KEYCHAIN_ACCOUNT` variable so the `security add-generic-password` call actually receives the account argument and reverse-sync works.

Architecture work (diagnostics + serialized refresh) tracked separately in #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)