### PR TITLE
fix(launchd): promote GUI-independent host jobs to LaunchDaemons (#14)

### DIFF
--- a/chassis/launchd/com.behalfbot.discord-restart.plist.template
+++ b/chassis/launchd/com.behalfbot.discord-restart.plist.template
@@ -7,23 +7,41 @@
   Generated from chassis/launchd/com.behalfbot.discord-restart.plist.template
   by chassis/scripts/bootstrap-customer-scripts.sh.
 
+  DOMAIN: LaunchDaemon (system-level, /Library/LaunchDaemons/).
+  Promoted from user LaunchAgent in #14 so it survives unattended reboots
+  on installer Macs that don't auto-login. This job only `docker exec`s
+  the chassis container - no GUI/Aqua session needed. See chassis docs:
+  "LaunchDaemon vs LaunchAgent - which to use" for the decision rule.
+
   Template variables (expanded at render time):
     BOT_NAME            logical bot name (e.g. jax, asimov, ozzy)
     CUSTOMER_HOME       per-customer state root (e.g. /Users/<user>/.behalfbot)
     CHASSIS_HOME        chassis git tree root (e.g. /Users/<user>/behalfbot)
     HOMEBREW_PREFIX     /opt/homebrew on Apple Silicon, /usr/local on Intel
-    USER                installer's macOS short name
+    USER                installer's macOS short name (also used as UserName)
     NODE_BIN_PATH       optional - extra node bin dir, e.g. ${HOMEBREW_PREFIX}/opt/node@22/bin
 
   Restart cadence: daily at 05:00 local time. Matches the upstream Sean install
   which has run successfully for months. Drop to 03:00 if you want a quieter
   morning; rationale for "before-8am-briefing" is that the daily-briefing
   heartbeat fires after the restart, so a fresh tmux session is in place.
+
+  Daemon-specific notes:
+    - UserName/GroupName pin execution to the installer's user, NOT root.
+      Without these, the daemon runs as root and breaks file-perm assumptions
+      in the restart script (which writes to logs under ${CUSTOMER_HOME}).
+    - All paths must be absolute. Daemons can't rely on `~` / `$HOME` shell
+      expansion the same way user agents can; the template substitutes
+      `/Users/${USER}` explicitly.
 -->
 <plist version="1.0">
 <dict>
     <key>Label</key>
     <string>com.behalfbot.${BOT_NAME}-discord-restart</string>
+    <key>UserName</key>
+    <string>${USER}</string>
+    <key>GroupName</key>
+    <string>staff</string>
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>

--- a/chassis/launchd/com.behalfbot.discord-watchdog.plist.template
+++ b/chassis/launchd/com.behalfbot.discord-watchdog.plist.template
@@ -7,17 +7,34 @@
   Generated from chassis/launchd/com.behalfbot.discord-watchdog.plist.template
   by chassis/scripts/bootstrap-customer-scripts.sh.
 
+  DOMAIN: LaunchDaemon (system-level, /Library/LaunchDaemons/).
+  Promoted from user LaunchAgent in #14 so it survives unattended reboots
+  on installer Macs that don't auto-login. This job only `docker exec`s
+  the chassis container - no GUI/Aqua session needed. See chassis docs:
+  "LaunchDaemon vs LaunchAgent - which to use" for the decision rule.
+
   Template variables - same set as the sibling restart plist (see comment
   block in com.behalfbot.discord-restart.plist.template).
 
   Cadence: every 30 minutes (StartInterval 1800). Restarts only fire when
   the watchdog actually detects a dead session or an auth-failure pattern
   in the tmux pane buffer - the wakeup itself is cheap, the bot stays up.
+
+  Daemon-specific notes:
+    - UserName/GroupName pin execution to the installer's user, NOT root.
+      Without these, the daemon runs as root and breaks file-perm assumptions
+      in the watchdog script (writes logs under ${CUSTOMER_HOME}, talks to
+      the user's Docker socket).
+    - All paths must be absolute - no `~` / `$HOME` expansion shortcuts.
 -->
 <plist version="1.0">
 <dict>
     <key>Label</key>
     <string>com.behalfbot.${BOT_NAME}-discord-watchdog</string>
+    <key>UserName</key>
+    <string>${USER}</string>
+    <key>GroupName</key>
+    <string>staff</string>
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>

--- a/chassis/launchd/com.behalfbot.heartbeat-dispatcher.plist.template
+++ b/chassis/launchd/com.behalfbot.heartbeat-dispatcher.plist.template
@@ -4,6 +4,19 @@
 <!--
   com.behalfbot.heartbeat-dispatcher.plist - chassis-rendered template.
 
+  ============================================================================
+  DEPRECATED (2026-06-03, chassis#14): the dispatcher now runs inside the
+  chassis Docker container as a `while true; do dispatcher.sh; sleep 900;
+  done` loop (see docker-compose.yml). This host-side plist is retained
+  only for the pre-containerization V1 bare-metal install path, which no
+  longer ships as a supported layout.
+
+  Do NOT promote this template to a LaunchDaemon (chassis#14 would otherwise
+  cover it). If you find yourself reaching for this plist on a new install,
+  use the containerized path instead - it's the supported way to run the
+  dispatcher on macOS now. Slated for full removal in a follow-up cleanup.
+  ============================================================================
+
   Generated from chassis/launchd/com.behalfbot.heartbeat-dispatcher.plist.template
   by chassis/scripts/bootstrap-customer-scripts.sh. This is the macOS legacy
   bare-metal path for the dispatcher loop. Container installs do NOT use this

--- a/chassis/scripts/bootstrap-customer-scripts.sh
+++ b/chassis/scripts/bootstrap-customer-scripts.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
-# bootstrap-customer-scripts.sh - render per-customer scripts and LaunchAgent
-# plists from chassis-shipped templates into $CUSTOMER_HOME.
+# bootstrap-customer-scripts.sh - render per-customer scripts and launchd
+# plists from chassis-shipped templates into $CUSTOMER_HOME, then (optionally)
+# install them into the right launchd domain.
+#
+# Per chassis#14, chassis-shipped host plists split into two domains:
+#   - LaunchDaemon (/Library/LaunchDaemons/, system-level)  - survives
+#     unattended reboot, no GUI/Aqua session needed. Requires sudo to install.
+#     Default for jobs that only docker-exec / hit network / run headless.
+#   - LaunchAgent  (~/Library/LaunchAgents/, user-level)    - needs an Aqua
+#     session, dies silently across an unattended reboot. Use only for jobs
+#     that genuinely touch the display (Android emulator, Playwright Chromium).
 #
 # Invoked by:
 #   - bootstrap.sh (first install) - scaffolds the script set
@@ -30,10 +39,15 @@
 #       bash chassis/scripts/bootstrap-customer-scripts.sh [--dry-run]
 #
 # Flags:
-#   --dry-run   show what would be rendered, write nothing.
-#   --plists    also render the LaunchAgent plists into $CUSTOMER_HOME/launchd/.
-#               (Default: scripts only - plists are macOS-specific and require
-#               an explicit follow-up `launchctl bootstrap` step.)
+#   --dry-run    show what would be rendered, write nothing.
+#   --plists     also render the launchd plists into $CUSTOMER_HOME/launchd/.
+#                (Default: scripts only - plists are macOS-specific and require
+#                an explicit follow-up activation step, see --activate-plists.)
+#   --activate-plists
+#                after rendering, actually install the plists into the right
+#                launchd domain (LaunchDaemons or LaunchAgents) and bootstrap
+#                them. This will prompt for sudo for daemon-domain plists.
+#                Implies --plists. No-op on non-macOS hosts.
 
 set -euo pipefail
 
@@ -44,11 +58,13 @@ source "$SCRIPT_DIR/_env.sh"
 
 DRY_RUN="${DRY_RUN:-false}"
 RENDER_PLISTS=false
+ACTIVATE_PLISTS=false
 for arg in "$@"; do
     case "$arg" in
-        --dry-run)  DRY_RUN=true ;;
-        --plists)   RENDER_PLISTS=true ;;
-        *)          echo "unknown arg: $arg" >&2; exit 2 ;;
+        --dry-run)          DRY_RUN=true ;;
+        --plists)           RENDER_PLISTS=true ;;
+        --activate-plists)  RENDER_PLISTS=true; ACTIVATE_PLISTS=true ;;
+        *)                  echo "unknown arg: $arg" >&2; exit 2 ;;
     esac
 done
 
@@ -137,8 +153,122 @@ if [[ "$RENDER_PLISTS" == "true" ]]; then
         "$OUT_PLISTS/com.behalfbot.${BOT_NAME}-discord-restart.plist"
     render_template "$LAUNCHD_DIR/com.behalfbot.discord-watchdog.plist.template" \
         "$OUT_PLISTS/com.behalfbot.${BOT_NAME}-discord-watchdog.plist"
+    # The heartbeat-dispatcher plist is deprecated as of chassis#14 (the
+    # dispatcher now runs inside the chassis container). Still rendered for
+    # the legacy bare-metal V1 install path; do NOT activate it as a daemon.
     render_template "$LAUNCHD_DIR/com.behalfbot.heartbeat-dispatcher.plist.template" \
         "$OUT_PLISTS/com.behalfbot.heartbeat-dispatcher.plist"
+fi
+
+# install_plist <rendered-plist-path> <agent|daemon>
+# Install a rendered plist into the correct launchd domain and bootstrap it.
+#   agent:   ~/Library/LaunchAgents/, gui/<uid> domain, no sudo.
+#   daemon:  /Library/LaunchDaemons/, system domain, requires sudo.
+# Re-runs are idempotent: bootouts any existing job at the same label first,
+# then re-bootstraps the fresh copy.
+install_plist() {
+    local src="$1" type="$2"
+    if [[ ! -f "$src" ]]; then
+        echo "  WARN: plist not found, skipping: $src" >&2
+        return 0
+    fi
+
+    local label
+    label="$(basename "$src" .plist)"
+
+    case "$type" in
+        agent)
+            local la_dir="$HOME/Library/LaunchAgents"
+            local dst
+            dst="$la_dir/$(basename "$src")"
+            if [[ "$DRY_RUN" == "true" ]]; then
+                echo "  [dry-run] install agent: $src -> $dst"
+                echo "  [dry-run] launchctl bootout gui/${USER_UID}/${label} (if loaded)"
+                echo "  [dry-run] launchctl bootstrap gui/${USER_UID} $dst"
+                return 0
+            fi
+            mkdir -p "$la_dir"
+            ln -sf "$src" "$dst"
+            if launchctl print "gui/${USER_UID}/${label}" >/dev/null 2>&1; then
+                launchctl bootout "gui/${USER_UID}/${label}" || true
+            fi
+            launchctl bootstrap "gui/${USER_UID}" "$dst" || true
+            echo "  loaded agent: $dst"
+            ;;
+        daemon)
+            local ld_dir="/Library/LaunchDaemons"
+            local dst
+            dst="$ld_dir/$(basename "$src")"
+            if [[ "$DRY_RUN" == "true" ]]; then
+                echo "  [dry-run] install daemon: sudo cp $src $dst"
+                echo "  [dry-run] sudo chown root:wheel $dst && sudo chmod 644 $dst"
+                echo "  [dry-run] sudo launchctl bootout system/${label} (if loaded)"
+                echo "  [dry-run] sudo launchctl bootstrap system $dst"
+                return 0
+            fi
+            sudo cp "$src" "$dst"
+            sudo chown root:wheel "$dst"
+            sudo chmod 644 "$dst"
+            if sudo launchctl print "system/${label}" >/dev/null 2>&1; then
+                sudo launchctl bootout "system/${label}" || true
+            fi
+            sudo launchctl bootstrap system "$dst" || true
+            echo "  loaded daemon: $dst"
+            ;;
+        *)
+            echo "  ERROR: install_plist: unknown type '$type' (expected agent|daemon)" >&2
+            return 2
+            ;;
+    esac
+}
+
+# DOMAIN MAP for chassis-shipped host plists. Update this list when adding
+# new chassis-side plists. See docs section "LaunchDaemon vs LaunchAgent -
+# which to use" for the decision rule.
+#
+# Format: "<plist-basename> <agent|daemon>". Plists not listed here are
+# rendered but not auto-installed; the operator activates them manually.
+CHASSIS_PLIST_DOMAINS=(
+    "com.behalfbot.${BOT_NAME}-discord-restart.plist daemon"
+    "com.behalfbot.${BOT_NAME}-discord-watchdog.plist daemon"
+    # heartbeat-dispatcher.plist deliberately NOT listed - deprecated per #14.
+)
+
+if [[ "$ACTIVATE_PLISTS" == "true" ]]; then
+    if [[ "$(uname -s)" != "Darwin" ]]; then
+        echo "  --activate-plists requested but host is not macOS; skipping."
+    else
+        # Pre-flight sudo prompt so the operator isn't surprised mid-loop.
+        daemon_count=0
+        for entry in "${CHASSIS_PLIST_DOMAINS[@]}"; do
+            # shellcheck disable=SC2086
+            set -- $entry
+            [[ "${2:-}" == "daemon" ]] && daemon_count=$((daemon_count + 1))
+        done
+        if [[ "$daemon_count" -gt 0 && "$DRY_RUN" != "true" ]]; then
+            echo ""
+            echo "About to install $daemon_count LaunchDaemon(s) into /Library/LaunchDaemons/."
+            echo "This requires sudo. You may be prompted for your password now."
+            # Touch sudo once up front so the rest of the loop runs without
+            # additional prompts (within sudo's default timestamp window).
+            sudo -v || {
+                echo "  sudo refused; skipping daemon installation." >&2
+                ACTIVATE_PLISTS=false
+            }
+        fi
+    fi
+fi
+
+if [[ "$ACTIVATE_PLISTS" == "true" && "$(uname -s)" == "Darwin" ]]; then
+    echo ""
+    echo "Activating chassis-shipped host plists..."
+    for entry in "${CHASSIS_PLIST_DOMAINS[@]}"; do
+        # shellcheck disable=SC2086
+        set -- $entry
+        plist_name="$1"
+        plist_type="${2:-agent}"
+        install_plist "$OUT_PLISTS/$plist_name" "$plist_type"
+    done
 fi
 
 if [[ "$DRY_RUN" != "true" ]]; then
@@ -146,11 +276,23 @@ if [[ "$DRY_RUN" != "true" ]]; then
     echo "Customer-side scripts rendered into: $OUT_SCRIPTS"
     if [[ "$RENDER_PLISTS" == "true" ]]; then
         echo "Customer-side plists rendered into:  $OUT_PLISTS"
-        echo ""
-        echo "Next: link the plists into ~/Library/LaunchAgents and load them:"
-        echo "  ln -sf $OUT_PLISTS/com.behalfbot.${BOT_NAME}-discord-restart.plist ~/Library/LaunchAgents/"
-        echo "  ln -sf $OUT_PLISTS/com.behalfbot.${BOT_NAME}-discord-watchdog.plist ~/Library/LaunchAgents/"
-        echo "  launchctl bootstrap gui/${USER_UID} ~/Library/LaunchAgents/com.behalfbot.${BOT_NAME}-discord-restart.plist"
-        echo "  launchctl bootstrap gui/${USER_UID} ~/Library/LaunchAgents/com.behalfbot.${BOT_NAME}-discord-watchdog.plist"
+        if [[ "$ACTIVATE_PLISTS" != "true" ]]; then
+            echo ""
+            echo "Next: activate the plists into the right launchd domain."
+            echo "      (chassis#14: discord-restart + discord-watchdog are now"
+            echo "       LaunchDaemons so they survive unattended reboots.)"
+            echo ""
+            echo "      Easiest: re-run this script with --activate-plists, which"
+            echo "      handles the sudo-cp-bootstrap dance for daemons and the"
+            echo "      symlink-bootstrap dance for agents."
+            echo ""
+            echo "      Or manually, for each daemon:"
+            echo "        sudo cp $OUT_PLISTS/com.behalfbot.${BOT_NAME}-discord-restart.plist  /Library/LaunchDaemons/"
+            echo "        sudo cp $OUT_PLISTS/com.behalfbot.${BOT_NAME}-discord-watchdog.plist /Library/LaunchDaemons/"
+            echo "        sudo chown root:wheel /Library/LaunchDaemons/com.behalfbot.${BOT_NAME}-discord-{restart,watchdog}.plist"
+            echo "        sudo chmod 644       /Library/LaunchDaemons/com.behalfbot.${BOT_NAME}-discord-{restart,watchdog}.plist"
+            echo "        sudo launchctl bootstrap system /Library/LaunchDaemons/com.behalfbot.${BOT_NAME}-discord-restart.plist"
+            echo "        sudo launchctl bootstrap system /Library/LaunchDaemons/com.behalfbot.${BOT_NAME}-discord-watchdog.plist"
+        fi
     fi
 fi

--- a/chassis/scripts/migrate-customer-state.sh
+++ b/chassis/scripts/migrate-customer-state.sh
@@ -237,7 +237,7 @@ if [[ $RENDER_RC -ne 0 ]]; then
     exit 3
 fi
 
-section "Step 4: reload LaunchAgent plists (macOS only)"
+section "Step 4: reload launchd plists (macOS only)"
 if [[ "$SKIP_LAUNCHD" == "true" ]]; then
     say "  skipped (--skip-launchd)"
 elif ! command -v launchctl >/dev/null 2>&1; then
@@ -246,8 +246,12 @@ else
     USER_UID="${USER_UID:-$(id -u)}"
     PLIST_DIR="$CUSTOMER_HOME/launchd"
     LA_DIR="$HOME/Library/LaunchAgents"
+    LD_DIR="/Library/LaunchDaemons"
 
     # Bootout any of the existing per-bot plists so the new ones load clean.
+    # Check both the gui/<uid> domain (legacy LaunchAgent install) and the
+    # system domain (LaunchDaemon, post-#14). Either may be in flight on a
+    # mid-upgrade install.
     for legacy in \
         "com.${BOT_NAME}.discord-restart" \
         "com.${BOT_NAME}.discord-watchdog" \
@@ -258,22 +262,51 @@ else
         if launchctl print "gui/${USER_UID}/${legacy}" >/dev/null 2>&1; then
             run launchctl bootout "gui/${USER_UID}/${legacy}" || true
         fi
+        if sudo -n launchctl print "system/${legacy}" >/dev/null 2>&1; then
+            run sudo launchctl bootout "system/${legacy}" || true
+        fi
+        # Remove any stale agent symlink that points at the old per-customer
+        # plist - we're moving these to the daemon domain.
+        if [[ -L "$LA_DIR/${legacy}.plist" ]]; then
+            run rm -f "$LA_DIR/${legacy}.plist"
+        fi
     done
 
-    # Symlink new plists in and bootstrap them.
-    mkdir -p "$LA_DIR"
+    # Promote discord-restart + discord-watchdog to LaunchDaemons (chassis#14)
+    # so they survive unattended reboots without a GUI login.
+    say ""
+    say "  Promoting discord-restart + discord-watchdog to LaunchDaemons."
+    say "  This requires sudo. You may be prompted for your password."
+    if [[ "$DRY_RUN" != "true" ]]; then
+        sudo -v || {
+            say "  WARNING: sudo refused - daemons not installed; falling back to manual step."
+            say "          Re-run with sudo cached, or install manually:"
+            say "            sudo cp $PLIST_DIR/com.behalfbot.${BOT_NAME}-discord-{restart,watchdog}.plist /Library/LaunchDaemons/"
+            say "            sudo chown root:wheel /Library/LaunchDaemons/com.behalfbot.${BOT_NAME}-discord-{restart,watchdog}.plist"
+            say "            sudo chmod 644       /Library/LaunchDaemons/com.behalfbot.${BOT_NAME}-discord-{restart,watchdog}.plist"
+            say "            sudo launchctl bootstrap system /Library/LaunchDaemons/com.behalfbot.${BOT_NAME}-discord-restart.plist"
+            say "            sudo launchctl bootstrap system /Library/LaunchDaemons/com.behalfbot.${BOT_NAME}-discord-watchdog.plist"
+            SKIP_DAEMON_INSTALL=true
+        }
+    fi
+
     for plist in \
         "com.behalfbot.${BOT_NAME}-discord-restart.plist" \
         "com.behalfbot.${BOT_NAME}-discord-watchdog.plist"; do
         src="$PLIST_DIR/$plist"
-        dst="$LA_DIR/$plist"
+        dst="$LD_DIR/$plist"
         if [[ ! -f "$src" ]]; then
             say "  WARNING: rendered plist missing at $src - skipping"
             continue
         fi
-        run ln -sf "$src" "$dst"
-        run launchctl bootstrap "gui/${USER_UID}" "$dst" || true
-        say "  loaded $dst"
+        if [[ "${SKIP_DAEMON_INSTALL:-false}" == "true" ]]; then
+            continue
+        fi
+        run sudo cp "$src" "$dst"
+        run sudo chown root:wheel "$dst"
+        run sudo chmod 644 "$dst"
+        run sudo launchctl bootstrap system "$dst" || true
+        say "  loaded daemon: $dst"
     done
 fi
 

--- a/docs/launchd-domains.md
+++ b/docs/launchd-domains.md
@@ -1,0 +1,128 @@
+# LaunchDaemon vs LaunchAgent — which to use
+
+> Decision rule for every chassis-shipped (and plugin-shipped) host-side
+> `launchd` plist on macOS. Wrong choice silently breaks unattended reboot
+> recovery. Right choice is usually "daemon". See chassis#14 for the incident
+> that drove this.
+
+## TL;DR
+
+| Domain | Path | Loads at | Needs GUI? | Survives unattended reboot? |
+|---|---|---|---|---|
+| **LaunchDaemon** (system) | `/Library/LaunchDaemons/` | Boot | No | **Yes** |
+| LaunchAgent (user)        | `~/Library/LaunchAgents/` | First GUI/Aqua login | Yes (implicitly) | No |
+
+**Default: LaunchDaemon.** Only fall back to LaunchAgent if the job genuinely
+needs a display, an Aqua-session-only resource (some keychain items,
+Cmd+Space integrations), or a GUI app's running process tree.
+
+## Why this matters
+
+A LaunchAgent in `~/Library/LaunchAgents/` only loads after the user logs into
+the macOS GUI. On an unattended Mac (one that reboots overnight or while the
+installer is traveling, with auto-login disabled), the user-session never
+materialises — every chassis-shipped LaunchAgent silently fails to register.
+The chassis Docker container keeps running because Docker Desktop is a system
+service, but every host-side scheduled job stops firing.
+
+That's exactly what happened on 2026-06-03 (chassis#14): the install Mac
+rebooted around 09:43 with no console login, every `com.<bot>.*` agent stayed
+dormant, and the 10:00 dating swipe slot got skipped. The failure was silent
+because no telemetry reports it.
+
+LaunchDaemons load at boot, no login required. They run as the user named in
+`UserName`, not as root, so file-permission expectations still hold.
+
+## When to use which
+
+Use **LaunchDaemon** if the job:
+
+- Does `docker exec` against the chassis container
+- Hits the network (HTTP poll, MQTT subscriber, webhook receiver)
+- Runs a headless Python/Node process (`uvicorn`, a script, a watcher)
+- Syncs files between two paths
+- Calls `launchctl bootout` / `launchctl bootstrap` on something else
+
+Use **LaunchAgent** only if the job:
+
+- Drives an Android emulator (needs Aqua to render the AVD window)
+- Drives a Playwright Chromium / Firefox / WebKit instance (each browser
+  needs an Aqua context — `headless: true` does *not* exempt you from this
+  on macOS, despite what the name suggests)
+- Touches `pasteboard`, `screencapture`, or any AppKit API that requires
+  the user's `WindowServer` session
+- Talks to a GUI app via Apple Events / AppleScript
+
+If you're not sure, default to daemon and try it. If the job fails because it
+can't find an Aqua resource, then it's an agent.
+
+## Daemon plist requirements (vs agent plist)
+
+Agents and daemons share the same XML structure, but daemons must include
+two extra keys and observe a few path constraints:
+
+```xml
+<key>UserName</key>
+<string>${USER}</string>
+<key>GroupName</key>
+<string>staff</string>
+```
+
+Without `UserName`, the daemon runs as `root`. Anything that writes to the
+user's home dir or talks to the user-owned Docker socket then breaks with
+permission errors. `staff` is the default user-group on macOS.
+
+Path constraints:
+
+- All paths must be **absolute**. No `~`, no `$HOME` expansion shortcuts.
+  Template substitution should produce `/Users/<installer>` literally.
+- `EnvironmentVariables` should set `HOME=/Users/<installer>` explicitly.
+- `WorkingDirectory` likewise — absolute, not `~`.
+
+## How chassis installs them
+
+`chassis/scripts/bootstrap-customer-scripts.sh` renders the templates from
+`chassis/launchd/*.plist.template` into `${CUSTOMER_HOME}/launchd/`, then —
+when invoked with `--activate-plists` — installs each rendered plist into
+the correct domain:
+
+- **Daemon-domain** plists: `sudo cp` to `/Library/LaunchDaemons/`,
+  `sudo chown root:wheel`, `sudo chmod 644`, `sudo launchctl bootstrap
+  system <plist>`.
+- **Agent-domain** plists: `ln -sf` into `~/Library/LaunchAgents/`,
+  `launchctl bootstrap gui/$(id -u) <plist>`.
+
+A single sudo prompt fires at the start of the activation pass (the script
+calls `sudo -v` to cache credentials) so installers aren't surprised by
+multiple `Password:` prompts mid-run.
+
+The domain for each chassis-shipped plist is encoded in the `CHASSIS_PLIST_DOMAINS`
+array at the bottom of `bootstrap-customer-scripts.sh`. To add a new
+host-side plist:
+
+1. Drop the template in `chassis/launchd/com.behalfbot.<name>.plist.template`.
+2. Add `render_template` and `install_plist` entries in the renderer.
+3. Add `"com.behalfbot.${BOT_NAME}-<name>.plist <agent|daemon>"` to
+   `CHASSIS_PLIST_DOMAINS`.
+
+For daemon-domain plists, also add `UserName` / `GroupName` keys in the
+template and make sure all paths are absolute.
+
+## Current chassis-shipped host plists
+
+| Plist | Domain | Why |
+|---|---|---|
+| `com.behalfbot.<bot>-discord-restart` | **Daemon** | `docker exec` only - no GUI needed |
+| `com.behalfbot.<bot>-discord-watchdog` | **Daemon** | `docker exec` only - no GUI needed |
+| `com.behalfbot.heartbeat-dispatcher` | **Deprecated** | Dispatcher runs inside the chassis container now (see `docker-compose.yml`). Template retained for the legacy bare-metal V1 install path; do not promote to daemon. |
+
+Plugins ship their own plists separately. The dating plugin's
+`plugins/dating/scheduled-tasks/dating-swipe.plist.template` stays as a
+LaunchAgent because the Android emulator and Playwright Chromium it drives
+both need an Aqua session — see that plugin's README for the trade-off note.
+
+## Related
+
+- chassis#14 — original incident and fix discussion.
+- `docs/LESSONS_FROM_V1.md` — running ledger of install-time failures.
+- `chassis/scripts/bootstrap-customer-scripts.sh` — the renderer + installer.

--- a/docs/plugins/dating.md
+++ b/docs/plugins/dating.md
@@ -105,6 +105,22 @@ Reference install (scrollinondubs/new-jaxity, post-2026-05-25 cutover):
 
 Future state: if/when the chassis runtime grows native "host-resident plugin" support (RPC bridge, container-side stubs that delegate to a host helper daemon), the dating plugin can move back under the container dispatcher. Until then, this is the supported pattern for installs that want dating.
 
+### Trade-off: dating swipes run as user LaunchAgents (not LaunchDaemons)
+
+Most chassis-shipped host plists were promoted to **LaunchDaemons** in chassis#14 so they survive an unattended Mac reboot (no GUI login required to boot the job). Dating-swipe plists are the exception — they stay as user LaunchAgents in `~/Library/LaunchAgents/` because:
+
+- The Android emulator window is an Aqua-session resource — qemu/AndroidStudio needs `WindowServer` to render the AVD. Without a logged-in GUI session, the emulator binary won't start.
+- Playwright Chromium on macOS likewise needs an Aqua session even in `headless: true` mode (Chromium's launcher path on darwin assumes a `WindowServer` connection during init).
+
+Consequence: **if your install Mac reboots while you're away and you don't have auto-login enabled, the day's missed swipe slots are lost — they don't replay.** Each slot fires once at its scheduled time; if nothing was loaded to fire it, the slot just doesn't happen.
+
+Your two mitigations:
+
+1. **Keep the Mac logged in.** Don't reboot when you're not present, and don't let the OS auto-reboot for updates (System Settings → General → Software Update → Automatic Updates → off for "Restart automatically").
+2. **Enable auto-login.** System Settings → Users & Groups → Automatic login → pick your user. The Mac boots straight into Aqua without password entry, so the LaunchAgent loads on reboot. The security trade-off is that anyone with physical access skips the login prompt. Your call.
+
+See `docs/launchd-domains.md` for the broader LaunchDaemon vs LaunchAgent decision rule and the chassis#14 incident context.
+
 ## Architecture
 
 Three layers of separation:


### PR DESCRIPTION
Closes #14.

## Summary

Host LaunchAgents in `~/Library/LaunchAgents/` silently fail to load after an unattended Mac reboot (no GUI/Aqua session means user agents never bootstrap). Promote chassis-shipped host plists that don't actually need a display to system-level LaunchDaemons in `/Library/LaunchDaemons/` so they load at boot regardless of login state.

Per the table in #14, chassis owns three host plist templates. This PR addresses the two that are GUI-independent. The third (`heartbeat-dispatcher`) is already retired post-containerization (the dispatcher loop runs inside the chassis container per `docker-compose.yml`), so it gets a deprecation note instead of a daemon promotion.

| Plist | Decision | Why |
|---|---|---|
| `com.behalfbot.<bot>-discord-restart` | **Daemon** | `docker exec` only - no GUI |
| `com.behalfbot.<bot>-discord-watchdog` | **Daemon** | `docker exec` only - no GUI |
| `com.behalfbot.heartbeat-dispatcher` | Deprecated | Runs inside the chassis container now |

## Files changed

- `chassis/launchd/com.behalfbot.discord-restart.plist.template` - added `UserName` / `GroupName` keys (so the daemon runs as the installer user, not root), updated header to call out the daemon domain and the chassis#14 rationale.
- `chassis/launchd/com.behalfbot.discord-watchdog.plist.template` - same daemon-domain changes.
- `chassis/launchd/com.behalfbot.heartbeat-dispatcher.plist.template` - added a deprecation header explaining containerization; not promoted.
- `chassis/scripts/bootstrap-customer-scripts.sh` - new `install_plist <plist> <agent|daemon>` helper, new `CHASSIS_PLIST_DOMAINS` map declaring per-plist domain, new `--activate-plists` flag that installs each rendered plist into the right launchd domain. One `sudo -v` pre-flight prompt up front so installers see a single password request, not a series of mid-loop prompts.
- `chassis/scripts/migrate-customer-state.sh` - reload step boots out the old gui/<uid> registration AND removes any stale agent symlink, then installs the daemon-domain copy via `sudo cp` / `chown root:wheel` / `chmod 644` / `launchctl bootstrap system`. Gracefully degrades if sudo is refused (prints the manual command set and continues).
- `docs/launchd-domains.md` - **new doc** covering the LaunchDaemon vs LaunchAgent decision rule, daemon-specific plist requirements (`UserName`, absolute paths, no `~` shortcuts), and the procedure for adding new chassis-shipped host plists.
- `docs/plugins/dating.md` - added trade-off note in the existing "Runtime: host-resident, not in-container" section explaining why dating-swipe plists stay as user LaunchAgents (Aqua-bound Android emulator + Playwright Chromium) and what that means for unattended reboots (missed swipe slots are lost; mitigations are "keep the Mac logged in" or "enable auto-login").

## Behaviour changes installers should know about

- **First-install sudo prompt:** `bootstrap-customer-scripts.sh --activate-plists` and `migrate-customer-state.sh` now prompt for sudo once when installing the daemon-domain plists. Pre-flight `sudo -v` so it's one prompt at the top, not multiple mid-loop. This is explicitly called out in the issue as acceptable.
- **Re-install bootouts:** the migrate script now checks both `gui/<uid>` and `system/` domains for stale registrations of the old labels, so a mid-upgrade install with the old LaunchAgent copy still loaded doesn't end up with the daemon and agent both registered.
- **No live activation in this PR.** The plist content + installer code lands here; actual activation of the new daemons happens on the next install or `bootstrap-customer-scripts.sh --activate-plists` run on each install Mac. This PR is deliberately code-only; no live launchd bootstrap was executed during development.

## Scope notes

- **Out of scope (separate follow-up issue):** the ~20 per-install `com.jax.*.plist` files under `scrollinondubs/new-jaxity` `scheduled-tasks/`. Those live in a different repo and will be migrated under a separate issue referencing this PR.
- **Dating + comfyui plugin plists deliberately not migrated.** They need an Aqua session for the Android emulator + Playwright Chromium / GPU. The trade-off is documented in `docs/plugins/dating.md` under "Trade-off: dating swipes run as user LaunchAgents (not LaunchDaemons)".

## Validation

- `plutil -lint` on each rendered template (after substituting test values for `${BOT_NAME}`, `${USER}`, etc.) - all three plists pass.
- `bash -n` on both modified shell scripts - clean.
- `shellcheck -S error` (matching CI) - clean.
- Wet `--plists` and dry-run `--activate-plists` paths exercised against a `/tmp` `CUSTOMER_HOME` - render output checked for `UserName=<user>` / `GroupName=staff` keys.
- **Not validated:** live `sudo launchctl bootstrap system <plist>` on Sean's install - that's deliberately out of scope per the issue (don't touch live launchd state during the PR; activation happens on next install/upgrade).

## Test plan

- [ ] `cd /Users/<installer>/behalfbot && bash chassis/scripts/bootstrap-customer-scripts.sh --activate-plists` on a fresh install Mac. Confirm sudo prompts once, both daemon plists land in `/Library/LaunchDaemons/`, `sudo launchctl print system/com.behalfbot.<bot>-discord-restart` and `system/com.behalfbot.<bot>-discord-watchdog` both report loaded state.
- [ ] Reboot the install Mac without GUI login. Confirm both daemons load before any user login by running `sudo launchctl print system/com.behalfbot.<bot>-discord-watchdog` from an SSH session.
- [ ] Confirm the daemon-side scripts still write logs under `${CUSTOMER_HOME}/logs/scheduled/` (proves `UserName` correctly drops privileges to the installer user, not root).
- [ ] Soak 7 days on Sean's install before pushing to Toby + Ben (per #14 acceptance criteria).
- [ ] Open the new-jaxity-side follow-up issue to migrate `com.jax.*.plist` per the same convention.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>