### PR TITLE
fix(launchd): RunAtLoad=true on discord-restart daemon

### DIFF
--- a/chassis/launchd/com.behalfbot.discord-restart.plist.template
+++ b/chassis/launchd/com.behalfbot.discord-restart.plist.template
@@ -26,6 +26,13 @@
   morning; rationale for "before-8am-briefing" is that the daily-briefing
   heartbeat fires after the restart, so a fresh tmux session is in place.
 
+  RunAtLoad=true: also fire once when launchd bootstraps the daemon (i.e.
+  immediately post-boot). Without this, an unattended-reboot install waits
+  until the next 05:00 trigger for Discord-bot recovery - up to 24h of
+  Discord downtime. The restart script's docker-info retry loop handles
+  the Colima cold-boot race, so post-bootstrap firing is safe even when
+  the chassis container hasn't come up yet.
+
   Daemon-specific notes:
     - UserName/GroupName pin execution to the installer's user, NOT root.
       Without these, the daemon runs as root and breaks file-perm assumptions
@@ -47,6 +54,8 @@
         <string>/bin/bash</string>
         <string>${CUSTOMER_HOME}/scripts/restart-${BOT_NAME}-discord.sh</string>
     </array>
+    <key>RunAtLoad</key>
+    <true/>
     <key>StartCalendarInterval</key>
     <dict>
         <key>Hour</key>


### PR DESCRIPTION
## Summary

Add `<key>RunAtLoad</key><true/>` to `chassis/launchd/com.behalfbot.discord-restart.plist.template` so the daemon fires once immediately when launchd bootstraps it (post-boot), in addition to its existing daily 05:00 trigger.

## Why

On Sean's install at the 2026-06-03 12:13 reboot, the daemon registered correctly but never fired because the next scheduled trigger was 17 hours away. Sean had to SSH in and invoke the `jax-discord` tmux alias manually. The watchdog (separate daemon, `StartInterval=1800`) would have caught the dead session within 30 minutes, but that's still a 30-minute Discord-Jax outage on every unattended reboot.

Adding `RunAtLoad=true` makes the daemon self-heal immediately at boot. Combined with the docker-info retry loop already in `restart-jax-discord.sh` (which gracefully waits for Colima's VM to come up before invoking `docker exec`), this closes the last reboot-survival gap from chassis#14 / new-jaxity#145.

## What changed

- `chassis/launchd/com.behalfbot.discord-restart.plist.template`: 2-line plist key addition + matching comment-block paragraph in the header docstring explaining the rationale.

## Test plan

- [ ] `plutil -lint` on a rendered template with sample variable substitution: OK (verified locally pre-PR).
- [ ] Sean re-runs `bash chassis/scripts/bootstrap-customer-scripts.sh --activate-plists` post-merge to re-render + reload.
- [ ] Sean does another unattended-reboot test (`sudo shutdown -r now` from SSH, do not console-login, re-SSH and check `tmux ls`). Expect `jax-discord` tmux session to be alive within ~90s of SSH coming back (Colima VM boot + script retry loop).

## Related

- chassis#14 + chassis#15 - parent issue + initial daemon promotion PR
- new-jaxity#145 - per-install companion (merged 2026-06-03)
- new-jaxity#146 - Sean's per-install activation PR (merged 2026-06-03)

🤖 Generated with [Claude Code](https://claude.com/claude-code)