### PR TITLE
fix(installer): harden 6 install + migration friction points (#5)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -415,6 +415,42 @@ render_customer_scripts() {
     log "  ✓ customer-side scripts + plists rendered"
 }
 
+populate_discord_access() {
+    # chassis#5 item 1: auto-populate the Discord plugin's access.json with the
+    # install channel ID(s) + principal user_id at install time so the bot can
+    # respond in its channels without a manual `/discord:access group add ...`
+    # step. Sourced from .env vars (DISCORD_*_CHANNEL_ID + INSTALLER_DISCORD_USER_ID).
+    #
+    # No-ops cleanly if either INSTALLER_DISCORD_USER_ID or all the channel
+    # vars are unset (installer's homework not done yet) - the script prints a
+    # warning and returns 0 so bootstrap can continue.
+    step "8b/14" "Populate Discord channel access (chassis#5 item 1)"
+
+    local helper="$CHASSIS_HOME/chassis/scripts/bootstrap-discord-access.sh"
+    if [[ ! -x "$helper" ]]; then
+        log "  WARN: $helper missing or not executable - skipping discord-access bootstrap"
+        return 0
+    fi
+
+    # Source .env so the channel + user_id vars are in scope.
+    if [[ -f "$CUSTOMER_HOME/.env" ]]; then
+        # shellcheck disable=SC1091
+        set -a
+        source "$CUSTOMER_HOME/.env"
+        set +a
+    fi
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log "  [dry-run] would run: $helper --dry-run"
+        bash "$helper" --dry-run 2>&1 | tee -a "$TRANSCRIPT" || true
+        return 0
+    fi
+
+    if ! bash "$helper" 2>&1 | tee -a "$TRANSCRIPT"; then
+        log "  WARN: bootstrap-discord-access.sh exited non-zero (channels may need manual allowlist)"
+    fi
+}
+
 activate_plugins() {
     step "9/14" "Activate enabled plugins"
 
@@ -589,6 +625,7 @@ main() {
     hydrate_claude_md
     initialize_heartbeats
     render_customer_scripts
+    populate_discord_access
     activate_plugins
     seed_memory
     install_os_deps

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -451,6 +451,36 @@ populate_discord_access() {
     fi
 }
 
+preflight_bot_identity() {
+    # chassis#5 item 3: pre-flight check that the bot's outbound webhook
+    # identity (INSTANCE_NAME + per-channel webhook URLs) matches the
+    # configured identity.assistant.name in chassis.config.yaml BEFORE the
+    # first heartbeat fires. Without this, Toby's first morning briefing
+    # posted under the chassis maintainer's stale bot persona ("Captain
+    # Hook") instead of Asimov's persona.
+    step "8c/14" "Pre-flight: bot identity matches webhooks (chassis#5 item 3)"
+
+    local helper="$CHASSIS_HOME/chassis/scripts/preflight-bot-identity.sh"
+    if [[ ! -x "$helper" ]]; then
+        log "  WARN: $helper missing or not executable - skipping pre-flight"
+        return 0
+    fi
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log "  [dry-run] would run: $helper"
+        return 0
+    fi
+
+    if ! CUSTOMER_HOME="$CUSTOMER_HOME" CHASSIS_HOME="$CHASSIS_HOME" \
+        bash "$helper" 2>&1 | tee -a "$TRANSCRIPT"; then
+        log ""
+        log "  FAIL: bot-identity pre-flight blocked bootstrap completion."
+        log "  Resolve the items above (likely: set INSTANCE_NAME in .env,"
+        log "  configure the briefings/ops webhook URLs), then re-run bootstrap.sh."
+        return 1
+    fi
+}
+
 activate_plugins() {
     step "9/14" "Activate enabled plugins"
 
@@ -626,6 +656,7 @@ main() {
     initialize_heartbeats
     render_customer_scripts
     populate_discord_access
+    preflight_bot_identity
     activate_plugins
     seed_memory
     install_os_deps

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -317,6 +317,23 @@ hydrate_mcp_json() {
     log "  - Write hydrated .mcp.json (gitignored)"
     log ""
     log "Reference: docs/mcp-setup.md"
+
+    # chassis#5 item 6: until the full hydration step lands, guarantee that
+    # ${CUSTOMER_HOME}/.mcp.json exists with an empty mcpServers object so the
+    # heartbeat dispatcher's `claude -p --mcp-config ...` invocation does not
+    # crash on a fresh or post-migration install. The dispatcher has a defense-
+    # in-depth absence guard too; this ensures the canonical path always exists.
+    local mcp_file="$CUSTOMER_HOME/.mcp.json"
+    if [[ ! -f "$mcp_file" ]]; then
+        if [[ "$DRY_RUN" == "true" ]]; then
+            log "  [dry-run] would create $mcp_file with empty mcpServers"
+        else
+            printf '%s\n' '{"mcpServers": {}}' > "$mcp_file"
+            log "  ✓ wrote empty $mcp_file (placeholder until hydration TODO lands)"
+        fi
+    else
+        log "  $mcp_file exists, leaving untouched"
+    fi
 }
 
 hydrate_claude_md() {

--- a/chassis.config.yaml
+++ b/chassis.config.yaml
@@ -39,11 +39,23 @@ identity:
     #   "<agent-name> - <principal-full-name>'s AI assistant"
 
 # Discord channel mapping. Per-install Discord server topology. Channel IDs
-# are runtime-only; never in committed files. Bootstrap reads from .env vars
-# named DISCORD_PRIMARY_CHANNEL_ID, DISCORD_ALERTS_CHANNEL_ID,
-# DISCORD_OPS_CHANNEL_ID. Labels are user-facing strings for prompt prose
-# (e.g. "#<primary>", "#installer-devops"); they CAN live here since they're
-# non-secret display strings.
+# are runtime-only; never in committed files. Bootstrap reads from .env vars:
+#   DISCORD_PRIMARY_CHANNEL_ID    - daily-driver conversation channel. Marked
+#                                   `primary` in access.json (requireMention=false)
+#                                   per chassis#5 item 2 so the installer can talk
+#                                   to the bot without @-tagging it every time.
+#   DISCORD_ALERTS_CHANNEL_ID     - infra alerts
+#   DISCORD_OPS_CHANNEL_ID        - ops signals
+#   DISCORD_BRIEFINGS_CHANNEL_ID  - daily briefing target (optional)
+#   DISCORD_LEADS_CHANNEL_ID      - lead signals (optional)
+#   DISCORD_SOCIAL_CHANNEL_ID     - dating/social surface (optional)
+# Plus:
+#   INSTALLER_DISCORD_USER_ID     - principal's Discord user_id (snowflake).
+#                                   Allowlisted on every channel populated above.
+#                                   Required by chassis/scripts/bootstrap-discord-access.sh.
+#
+# Labels are user-facing strings for prompt prose (e.g. "#<primary>",
+# "#installer-devops"); they CAN live here since they're non-secret display strings.
 discord_channels:
   primary_label: <#primary-channel>         # E.g. "#<primary>". Daily-driver conversation channel.
   alerts_label: <#alerts-channel>           # E.g. "#installer-devops". Infrastructure alerts.

--- a/chassis/scheduled-tasks/heartbeat-dispatcher.sh
+++ b/chassis/scheduled-tasks/heartbeat-dispatcher.sh
@@ -545,13 +545,13 @@ invoke_claude() {
     # the heartbeat fails silently. Drop the flag when the file isn't there;
     # `claude -p` falls back to its default MCP config search (~/.claude/...).
     # bootstrap.sh writes an empty-{} .mcp.json so the file should exist on a
-    # clean install — this is defense in depth for the partial-restore case.
+    # clean install - this is defense in depth for the partial-restore case.
     local mcp_config_path="$CUSTOMER_HOME/.mcp.json"
     local mcp_flag=""
     if [[ -f "$mcp_config_path" ]]; then
         mcp_flag="--mcp-config $mcp_config_path"
     else
-        log "WARN $heartbeat_name — $mcp_config_path missing, invoking claude without --mcp-config"
+        log "WARN $heartbeat_name - $mcp_config_path missing, invoking claude without --mcp-config"
     fi
 
     $TIMEOUT_CMD 1200 /bin/zsh -c '

--- a/chassis/scheduled-tasks/heartbeat-dispatcher.sh
+++ b/chassis/scheduled-tasks/heartbeat-dispatcher.sh
@@ -539,15 +539,30 @@ invoke_claude() {
     mkdir -p "$telemetry_dir"
     start_ts=$(date +%s)
 
+    # chassis#5 item 6: guard against a missing .mcp.json. If the customer file
+    # is absent (post-migration, fresh install before bootstrap finished, etc.),
+    # passing --mcp-config <missing-path> crashes `claude -p` immediately and
+    # the heartbeat fails silently. Drop the flag when the file isn't there;
+    # `claude -p` falls back to its default MCP config search (~/.claude/...).
+    # bootstrap.sh writes an empty-{} .mcp.json so the file should exist on a
+    # clean install — this is defense in depth for the partial-restore case.
+    local mcp_config_path="$CUSTOMER_HOME/.mcp.json"
+    local mcp_flag=""
+    if [[ -f "$mcp_config_path" ]]; then
+        mcp_flag="--mcp-config $mcp_config_path"
+    else
+        log "WARN $heartbeat_name — $mcp_config_path missing, invoking claude without --mcp-config"
+    fi
+
     $TIMEOUT_CMD 1200 /bin/zsh -c '
         cd "$7" && echo "$1" | claude -p \
             --dangerously-skip-permissions \
             --model "$2" \
-            --mcp-config "$3/.mcp.json" \
+            ${=3} \
             --max-budget-usd "$4" \
             --output-format json \
             > "$5" 2>> "$6"
-    ' -- "$claude_input" "$model" "$CUSTOMER_HOME" "$budget" "$tmp_json" "$LOG_FILE" "$cwd"
+    ' -- "$claude_input" "$model" "$mcp_flag" "$budget" "$tmp_json" "$LOG_FILE" "$cwd"
     exit_code=$?
 
     end_ts=$(date +%s)
@@ -702,16 +717,25 @@ run_output_validator() {
     local validator_out="$LOG_DIR/.validator-out-$$.json"
     local validator_result
 
+    # Mirror chassis#5 item 6 mcp-config absence guard from invoke_claude. If
+    # the customer .mcp.json is missing, drop the flag rather than crashing the
+    # validator subprocess.
+    local mcp_config_path="$CUSTOMER_HOME/.mcp.json"
+    local mcp_flag=""
+    if [[ -f "$mcp_config_path" ]]; then
+        mcp_flag="--mcp-config $mcp_config_path"
+    fi
+
     # Run haiku validator; fail-open if it errors
     $TIMEOUT_CMD 120 /bin/zsh -c '
         echo "$1" | claude -p \
             --dangerously-skip-permissions \
             --model haiku \
-            --mcp-config "$2/.mcp.json" \
+            ${=2} \
             --max-budget-usd 0.05 \
             --output-format json \
             > "$3" 2>> "$4"
-    ' -- "$validator_input" "$CUSTOMER_HOME" "$validator_out" "$LOG_FILE" || {
+    ' -- "$validator_input" "$mcp_flag" "$validator_out" "$LOG_FILE" || {
         log "VALIDATOR $name — haiku call failed or timed out, fail-open"
         rm -f "$validator_out"
         return 0

--- a/chassis/scripts/bootstrap-discord-access.sh
+++ b/chassis/scripts/bootstrap-discord-access.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# chassis/scripts/bootstrap-discord-access.sh
+# ============================================
+# Populate the Claude Code Discord plugin's access.json with the install
+# channel ID + principal user_id at install time. Without this, the bot
+# joins the install Discord server but ignores every message because no
+# channel is allowlisted - Toby hit this on his Asimov install and had to
+# manually run `/discord:access group add ...` from inside the running
+# tmux session before the bot could function. See chassis#5 item 1.
+#
+# Inputs (read from env, typically sourced from $CUSTOMER_HOME/.env):
+#   INSTALLER_DISCORD_USER_ID   - principal Discord user_id (numeric, 17-19 digits)
+#                                 The human the agent works for. Allowlisted on
+#                                 every channel populated below. Required.
+#   DISCORD_PRIMARY_CHANNEL_ID  - daily-driver conversation channel. Marked as
+#                                 a "primary" channel (requireMention=false per
+#                                 chassis#5 item 2). Optional; skipped if unset.
+#   DISCORD_ALERTS_CHANNEL_ID   - infrastructure alerts channel. requireMention=true.
+#   DISCORD_OPS_CHANNEL_ID      - ops signal channel. requireMention=true.
+#   DISCORD_BRIEFINGS_CHANNEL_ID - daily briefing channel. requireMention=true.
+#   DISCORD_LEADS_CHANNEL_ID    - lead signals channel. requireMention=true.
+#   DISCORD_SOCIAL_CHANNEL_ID   - social/dating channel. requireMention=true.
+#
+# Output:
+#   $CLAUDE_ACCESS_FILE (default ~/.claude/channels/discord/access.json)
+#
+# Idempotency:
+#   - Re-running is safe. Existing entries are preserved unless they conflict
+#     (same channel_id with different allowlist). Conflicts cause a refusal
+#     unless --force is passed; in that case the configured value wins.
+#   - Channels not in env are left alone (not removed).
+#
+# Flags:
+#   --dry-run    print the resulting JSON without writing
+#   --force      overwrite conflicting entries
+#   --access-file PATH  override target file (default ~/.claude/channels/discord/access.json)
+
+set -euo pipefail
+
+DRY_RUN=false
+FORCE=false
+ACCESS_FILE="${CLAUDE_ACCESS_FILE:-$HOME/.claude/channels/discord/access.json}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)       DRY_RUN=true; shift ;;
+        --force)         FORCE=true; shift ;;
+        --access-file)   ACCESS_FILE="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '1,40p' "$0" | sed 's/^# *//'
+            exit 0 ;;
+        *)
+            echo "unknown arg: $1" >&2
+            exit 2 ;;
+    esac
+done
+
+if [[ -z "${INSTALLER_DISCORD_USER_ID:-}" ]]; then
+    echo "ERROR: INSTALLER_DISCORD_USER_ID not set in environment" >&2
+    echo "  Set it in \$CUSTOMER_HOME/.env (sourced before this script runs)." >&2
+    echo "  Source: principal's Discord user_id (right-click their name in" >&2
+    echo "  Discord with Developer Mode on -> Copy User ID)." >&2
+    exit 2
+fi
+
+# Validate the user_id shape - Discord IDs are snowflakes, 17-19 numeric digits.
+if ! [[ "$INSTALLER_DISCORD_USER_ID" =~ ^[0-9]{17,20}$ ]]; then
+    echo "ERROR: INSTALLER_DISCORD_USER_ID does not look like a Discord snowflake id: $INSTALLER_DISCORD_USER_ID" >&2
+    echo "  Expected 17-20 numeric digits." >&2
+    exit 2
+fi
+
+# Collect declared channels into a structured list:
+#   <channel_id> <key> <require_mention>
+declare -a CHANNEL_ROWS
+if [[ -n "${DISCORD_PRIMARY_CHANNEL_ID:-}" ]]; then
+    CHANNEL_ROWS+=("$DISCORD_PRIMARY_CHANNEL_ID primary false")
+fi
+if [[ -n "${DISCORD_ALERTS_CHANNEL_ID:-}" ]]; then
+    CHANNEL_ROWS+=("$DISCORD_ALERTS_CHANNEL_ID alerts true")
+fi
+if [[ -n "${DISCORD_OPS_CHANNEL_ID:-}" ]]; then
+    CHANNEL_ROWS+=("$DISCORD_OPS_CHANNEL_ID ops true")
+fi
+if [[ -n "${DISCORD_BRIEFINGS_CHANNEL_ID:-}" ]]; then
+    CHANNEL_ROWS+=("$DISCORD_BRIEFINGS_CHANNEL_ID briefings true")
+fi
+if [[ -n "${DISCORD_LEADS_CHANNEL_ID:-}" ]]; then
+    CHANNEL_ROWS+=("$DISCORD_LEADS_CHANNEL_ID leads true")
+fi
+if [[ -n "${DISCORD_SOCIAL_CHANNEL_ID:-}" ]]; then
+    CHANNEL_ROWS+=("$DISCORD_SOCIAL_CHANNEL_ID social true")
+fi
+
+if [[ ${#CHANNEL_ROWS[@]} -eq 0 ]]; then
+    echo "WARN: no DISCORD_*_CHANNEL_ID env vars set - nothing to populate" >&2
+    echo "  Set DISCORD_PRIMARY_CHANNEL_ID at minimum, plus any other channel" >&2
+    echo "  keys you want allowlisted. See chassis.config.yaml.discord_channels." >&2
+    exit 0
+fi
+
+# Ensure parent dir exists for the access file.
+ACCESS_DIR="$(dirname "$ACCESS_FILE")"
+if [[ "$DRY_RUN" != "true" ]]; then
+    mkdir -p "$ACCESS_DIR"
+fi
+
+# Seed the file with a minimal allowlist policy if it doesn't already exist.
+# Schema mirrors the discord@claude-plugins-official plugin's expected layout
+# (channels keyed by id, allow array of user_ids, requireMention bool, policy
+# field at the root level).
+if [[ ! -f "$ACCESS_FILE" ]]; then
+    INITIAL_JSON='{"policy": "allowlist", "channels": {}}'
+else
+    INITIAL_JSON="$(cat "$ACCESS_FILE")"
+fi
+
+# Validate that the existing file is JSON before we try to merge into it.
+# Catches the "previous run wrote garbage" path early.
+if ! echo "$INITIAL_JSON" | jq empty >/dev/null 2>&1; then
+    echo "ERROR: $ACCESS_FILE exists but is not valid JSON. Refusing to overwrite." >&2
+    echo "  Inspect, fix, or rm $ACCESS_FILE and re-run." >&2
+    exit 3
+fi
+
+# Build the new state. For each declared channel:
+#   - If absent, add it with allow=[$INSTALLER_DISCORD_USER_ID], requireMention per key
+#   - If present and identical, leave alone
+#   - If present and different and --force, overwrite
+#   - If present and different and no --force, refuse with a clear message
+CURRENT_JSON="$INITIAL_JSON"
+for row in "${CHANNEL_ROWS[@]}"; do
+    # shellcheck disable=SC2206
+    parts=($row)
+    chan_id="${parts[0]}"
+    chan_key="${parts[1]}"
+    require_mention="${parts[2]}"
+
+    existing=$(echo "$CURRENT_JSON" | jq --arg id "$chan_id" '.channels[$id] // null')
+
+    if [[ "$existing" != "null" ]]; then
+        existing_require=$(echo "$existing" | jq -r '.requireMention // false')
+        existing_has_user=$(echo "$existing" | jq --arg uid "$INSTALLER_DISCORD_USER_ID" \
+            '(.allow // []) | index($uid) != null')
+        if [[ "$existing_require" == "$require_mention" && "$existing_has_user" == "true" ]]; then
+            echo "  unchanged: $chan_key ($chan_id) already allowlisted with requireMention=$require_mention"
+            continue
+        fi
+        if [[ "$FORCE" != "true" ]]; then
+            echo "REFUSE: $chan_key ($chan_id) already in $ACCESS_FILE with different config." >&2
+            echo "  existing: $existing" >&2
+            echo "  configured: requireMention=$require_mention, allow=[$INSTALLER_DISCORD_USER_ID]" >&2
+            echo "  Pass --force to overwrite, or hand-edit $ACCESS_FILE." >&2
+            exit 4
+        fi
+        echo "  overwriting (--force): $chan_key ($chan_id) requireMention=$require_mention"
+    else
+        echo "  adding: $chan_key ($chan_id) requireMention=$require_mention"
+    fi
+
+    CURRENT_JSON=$(echo "$CURRENT_JSON" | jq \
+        --arg id "$chan_id" \
+        --arg key "$chan_key" \
+        --arg uid "$INSTALLER_DISCORD_USER_ID" \
+        --argjson require "$require_mention" \
+        '.channels[$id] = {
+            key: $key,
+            allow: [$uid],
+            requireMention: $require
+        }')
+done
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo ""
+    echo "--- DRY-RUN: would write to $ACCESS_FILE ---"
+    echo "$CURRENT_JSON" | jq .
+    exit 0
+fi
+
+# Atomic write: stage to tmp then mv.
+TMP="${ACCESS_FILE}.tmp.$$"
+echo "$CURRENT_JSON" | jq . > "$TMP"
+mv "$TMP" "$ACCESS_FILE"
+chmod 600 "$ACCESS_FILE"
+
+echo "✓ wrote $ACCESS_FILE (${#CHANNEL_ROWS[@]} channel entries, principal user_id=$INSTALLER_DISCORD_USER_ID)"

--- a/chassis/scripts/first-boot-announce.sh
+++ b/chassis/scripts/first-boot-announce.sh
@@ -66,12 +66,26 @@ fi
 
 EMITTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
+# chassis#5 item 3: sanity-check INSTANCE_NAME against the live Discord bot
+# username. If they disagree, the first briefing will post under the wrong
+# persona (e.g. "Captain Hook" instead of "Asimov"). Log loud so the
+# installer sees the mismatch in the first-boot log before the dispatcher
+# starts firing scheduled posts.
+IDENTITY_WARNING=""
+if [[ -n "$BOT_USERNAME" && -n "${INSTANCE_NAME:-}" && "$INSTANCE_NAME" != "$BOT_USERNAME" ]]; then
+    IDENTITY_WARNING="WARNING: INSTANCE_NAME=${INSTANCE_NAME} does not match Discord bot username=${BOT_USERNAME}. Outbound webhooks will display '${INSTANCE_NAME}' as the sender but the bot account itself is registered as '${BOT_USERNAME}'. Fix INSTANCE_NAME in .env to match before the first heartbeat fires, or rename the Discord bot to match INSTANCE_NAME."
+    log "BEHALFBOT_FIRST_BOOT: $IDENTITY_WARNING"
+fi
+
 # Build the three-line message (or a degraded version when ID unavailable).
 if [[ -n "$BOT_USER_ID" ]]; then
     OAUTH_URL="https://discord.com/oauth2/authorize?client_id=${BOT_USER_ID}&scope=bot+applications.commands&permissions=379968"
     LINE1="Behalfbot connected as ${BOT_USERNAME} (Discord user ID: ${BOT_USER_ID}). Share this with Sean to add me to the install channel."
     LINE2="OAuth invite URL: ${OAUTH_URL}"
     LINE3="Once added: run \`/discord:access group add <channel_id> --no-mention --allow <SEAN_ID>,<JAXBOT_ID>\` on this host to allowlist the channel."
+    if [[ -n "$IDENTITY_WARNING" ]]; then
+        LINE3="${LINE3}\n\n${IDENTITY_WARNING}"
+    fi
 else
     LINE1="BEHALFBOT_FIRST_BOOT: DISCORD_BOT_TOKEN not set or Discord API call failed. Set DISCORD_BOT_TOKEN in .env and recheck."
     LINE2="Once the token is set, delete ${SENTINEL} and restart the container to re-emit."
@@ -104,7 +118,15 @@ jq -n \
     --arg emitted_at "$EMITTED_AT" \
     --arg bot_user_id "$BOT_USER_ID" \
     --arg bot_username "$BOT_USERNAME" \
-    '{emitted_at: $emitted_at, bot_user_id: $bot_user_id, bot_username: $bot_username}' \
+    --arg instance_name "${INSTANCE_NAME:-}" \
+    --arg identity_warning "$IDENTITY_WARNING" \
+    '{
+        emitted_at: $emitted_at,
+        bot_user_id: $bot_user_id,
+        bot_username: $bot_username,
+        instance_name: $instance_name,
+        identity_warning: $identity_warning
+    }' \
     > "$SENTINEL"
 
 log "first-boot announce complete - sentinel written at $SENTINEL"

--- a/chassis/scripts/migrate-from-old-clone.sh
+++ b/chassis/scripts/migrate-from-old-clone.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# chassis/scripts/migrate-from-old-clone.sh
+# =========================================
+# Post-rename / chassis-subtree-re-anchor migration helper. Restores customer
+# state from a backup of the OLD chassis clone into the NEW clone WITHOUT
+# stomping any file the chassis subtree owns.
+#
+# Why this exists (chassis#5 item 5): on 2026-06-01 the chassis repo was
+# renamed and several installers (Toby first, Ben pending) had to re-clone
+# the chassis tree. The recommended workflow was:
+#   1. tar up the old clone
+#   2. rm -rf the clone dir
+#   3. git clone the new repo URL
+#   4. restore the customer-side files from the tarball
+# Step 4 was a hand-written restore loop pinned to a hard-coded allowlist:
+#   .env, .env.baked, install-profile.md, chassis.config.yaml, CLAUDE.md,
+#   HEARTBEATS.md, chassis-compose.override.yml, data/, state/, briefings/,
+#   memory/, logs/, backups/.
+# That list MISSED: scheduled-tasks/, .mcp.json, skills/, plugins/, scripts/.
+# Toby's first heartbeat after the re-clone failed with
+#   "scheduled-tasks/<name>.sh: no such file or directory"
+# and the install was offline for 14 hours.
+#
+# This script uses the INVERSE approach: everything in the backup is restored
+# EXCEPT what the new chassis subtree authoritatively provides. The exclude
+# list mirrors the chassis tree's top-level contents, plus the git metadata
+# of the new clone.
+#
+# Inputs:
+#   --backup-dir PATH   absolute path to the old-clone backup root. Required.
+#   --target-dir PATH   absolute path to the new clone root. Default: $PWD.
+#   --dry-run           print every restore action without executing
+#   --force             overwrite existing files in target without prompting
+#                       (default: skip with a notice; --force is destructive)
+#   --yes               skip the confirmation prompt before destructive ops
+#
+# Exit codes:
+#   0  restore succeeded (or dry-run completed cleanly)
+#   2  bad args / source missing / refusing to touch a non-chassis target
+#   3  rsync failed
+#   4  user aborted the confirmation prompt
+
+set -euo pipefail
+
+BACKUP_DIR=""
+TARGET_DIR="${PWD}"
+DRY_RUN=false
+FORCE=false
+YES=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --backup-dir)   BACKUP_DIR="$2"; shift 2 ;;
+        --target-dir)   TARGET_DIR="$2"; shift 2 ;;
+        --dry-run)      DRY_RUN=true; shift ;;
+        --force)        FORCE=true; shift ;;
+        --yes)          YES=true; shift ;;
+        -h|--help)
+            sed -n '1,60p' "$0" | sed 's/^# *//'
+            exit 0 ;;
+        *)
+            echo "unknown arg: $1" >&2
+            exit 2 ;;
+    esac
+done
+
+say() { printf '%s\n' "$*"; }
+
+if [[ -z "$BACKUP_DIR" ]]; then
+    say "ERROR: --backup-dir is required" >&2
+    say "Usage: $0 --backup-dir /path/to/old-clone-backup --target-dir /path/to/new-clone" >&2
+    exit 2
+fi
+
+if [[ ! -d "$BACKUP_DIR" ]]; then
+    say "ERROR: backup dir does not exist: $BACKUP_DIR" >&2
+    exit 2
+fi
+
+if [[ ! -d "$TARGET_DIR" ]]; then
+    say "ERROR: target dir does not exist: $TARGET_DIR" >&2
+    exit 2
+fi
+
+# Strip trailing slashes so rsync semantics are predictable.
+BACKUP_DIR="${BACKUP_DIR%/}"
+TARGET_DIR="${TARGET_DIR%/}"
+
+# Sanity check: the target must look like a chassis clone (chassis/ subdir +
+# bootstrap.sh). Refusing to write into a non-chassis tree prevents an
+# accidental --target-dir typo from clobbering an unrelated dir.
+if [[ ! -d "$TARGET_DIR/chassis" || ! -f "$TARGET_DIR/bootstrap.sh" ]]; then
+    say "ERROR: $TARGET_DIR does not look like a chassis clone" >&2
+    say "  Expected to find: chassis/ subdir + bootstrap.sh at the root." >&2
+    exit 2
+fi
+
+# Sanity check: the backup must also look like a chassis clone (or post-#6
+# customer dir). At a bare minimum we expect ONE of these to be present:
+# .env, chassis.config.yaml, HEARTBEATS.md, CLAUDE.md.
+HAS_CUSTOMER_FILE=false
+for marker in .env chassis.config.yaml HEARTBEATS.md CLAUDE.md install-profile.md INSTALL_PROFILE.md; do
+    if [[ -e "$BACKUP_DIR/$marker" ]]; then
+        HAS_CUSTOMER_FILE=true
+        break
+    fi
+done
+if [[ "$HAS_CUSTOMER_FILE" != "true" ]]; then
+    say "ERROR: $BACKUP_DIR does not look like a chassis clone backup" >&2
+    say "  Expected at least one of: .env, chassis.config.yaml, HEARTBEATS.md, CLAUDE.md, install-profile.md" >&2
+    exit 2
+fi
+
+# The EXCLUDE list = everything the new chassis subtree authoritatively
+# provides. Anything in the backup matching these paths is left alone so the
+# new chassis wins. Everything else gets restored.
+#
+# Mirrors the chassis tree's top-level layout (see ls chassis/ in the repo):
+#   - chassis/ subtree itself (all chassis-managed code lives here)
+#   - bootstrap.sh + Dockerfile + docker-compose.yml + INSTALL_PROFILE.md
+#     (chassis-versioned defaults; the customer-edited INSTALL_PROFILE.md
+#     lives at install-profile.md per docs/SELF_INSTALL.md so the casing
+#     difference matters)
+#   - docker/ + docs/ + .github/ + LICENSE + README.md + requirements.txt
+#   - The new clone's .git/ - never overwrite git metadata.
+EXCLUDES=(
+    ".git/"
+    "chassis/"
+    "Dockerfile"
+    "docker-compose.yml"
+    "docker/"
+    "INSTALL_PROFILE.md"
+    "LICENSE"
+    "README.md"
+    "requirements.txt"
+    ".env.example"
+    ".dockerignore"
+    ".gitignore"
+    ".github/"
+)
+
+# Plus: any chassis-tracked file at the top level of the new tree should not
+# be clobbered by a backup version. Build the exclude list dynamically from
+# what's actually present in the new tree so future additions to the chassis
+# subtree are handled automatically.
+mapfile -t TOP_LEVEL < <(ls -1A "$TARGET_DIR" 2>/dev/null || true)
+DYNAMIC_EXCLUDES=()
+for entry in "${TOP_LEVEL[@]}"; do
+    # Skip dirs/files that are explicitly customer-side per our model.
+    case "$entry" in
+        .env|.env.baked|.mcp.json|CLAUDE.md|HEARTBEATS.md|chassis.config.yaml|install-profile.md|chassis-compose.override.yml|scripts|scheduled-tasks|plugins|skills|state|data|briefings|memory|logs|backups|temp|launchd|state.json|.bootstrap-marker)
+            continue
+            ;;
+    esac
+    DYNAMIC_EXCLUDES+=("$entry")
+done
+
+# Verify rsync is available; it carries the heavy lifting for the actual
+# copy + the EXCLUDE filter.
+if ! command -v rsync >/dev/null 2>&1; then
+    say "ERROR: rsync not in PATH - install it before running this migration." >&2
+    exit 2
+fi
+
+# Build rsync flag list.
+RSYNC_FLAGS=(-a)
+if [[ "$DRY_RUN" == "true" ]]; then
+    RSYNC_FLAGS+=(-vn)
+else
+    RSYNC_FLAGS+=(-v)
+fi
+
+# Default behavior: --ignore-existing (skip files already present in the
+# target). --force overrides that to overwrite.
+if [[ "$FORCE" == "true" ]]; then
+    RSYNC_FLAGS+=(--itemize-changes)
+else
+    RSYNC_FLAGS+=(--ignore-existing)
+fi
+
+# Compose --exclude args for the static list + dynamic list.
+EXCLUDE_FLAGS=()
+for e in "${EXCLUDES[@]}" "${DYNAMIC_EXCLUDES[@]}"; do
+    EXCLUDE_FLAGS+=(--exclude="$e")
+done
+
+say "==================================================="
+say "Chassis migration restore (chassis#5 item 5)"
+say "==================================================="
+say "  Backup source (old clone): $BACKUP_DIR"
+say "  Target (new clone):        $TARGET_DIR"
+say "  Dry run:                   $DRY_RUN"
+say "  Force-overwrite existing:  $FORCE"
+say ""
+say "Excluded from restore (chassis-managed, new clone wins):"
+for e in "${EXCLUDES[@]}" "${DYNAMIC_EXCLUDES[@]}"; do
+    say "    - $e"
+done
+say ""
+
+if [[ "$DRY_RUN" != "true" && "$YES" != "true" ]]; then
+    say "About to restore customer files from $BACKUP_DIR -> $TARGET_DIR"
+    if [[ "$FORCE" == "true" ]]; then
+        say "  WARNING: --force is on; existing files in target will be OVERWRITTEN."
+    fi
+    printf 'Type yes to proceed, anything else to abort: '
+    read -r reply
+    if [[ "$reply" != "yes" ]]; then
+        say "Aborted by user."
+        exit 4
+    fi
+fi
+
+# Run rsync. Trailing slash on src so we copy the contents of $BACKUP_DIR,
+# not the dir itself.
+RC=0
+rsync "${RSYNC_FLAGS[@]}" "${EXCLUDE_FLAGS[@]}" "$BACKUP_DIR"/ "$TARGET_DIR"/ || RC=$?
+
+if [[ $RC -ne 0 ]]; then
+    say "" >&2
+    say "rsync exited non-zero ($RC) - inspect the output above" >&2
+    exit 3
+fi
+
+say ""
+say "==================================================="
+say "Restore complete."
+say "==================================================="
+say ""
+say "Post-restore checklist:"
+say "  1. Verify the chassis subtree at $TARGET_DIR/chassis is at the SHA you expected:"
+say "       cd $TARGET_DIR && git log -1 --oneline chassis/"
+say "  2. Confirm critical customer files are present:"
+say "       ls -la $TARGET_DIR/{.env,chassis.config.yaml,CLAUDE.md,HEARTBEATS.md,.mcp.json}"
+say "       ls -d $TARGET_DIR/{scheduled-tasks,skills,plugins,scripts,data,state,briefings,memory,logs}"
+say "  3. Run bootstrap.sh in re-bootstrap mode to re-render anything that"
+say "     references chassis paths (launchd plists, customer scripts):"
+say "       cd $TARGET_DIR && CHASSIS_HOME=\$(pwd) bash bootstrap.sh"
+say "  4. Smoke-test the dispatcher in DRY_RUN mode before re-enabling the"
+say "     launchd unit:"
+say "       DRY_RUN=true bash $TARGET_DIR/chassis/scheduled-tasks/heartbeat-dispatcher.sh"
+say "  5. Watch the first dispatcher tick after re-enable to confirm the"
+say "     telemetry pipeline still works:"
+say "       tail -f $TARGET_DIR/logs/scheduled/\$(date +%Y-%m-%d)-dispatcher.log"
+say ""
+if [[ "$DRY_RUN" == "true" ]]; then
+    say "(dry-run: nothing was actually changed)"
+fi

--- a/chassis/scripts/preflight-bot-identity.sh
+++ b/chassis/scripts/preflight-bot-identity.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# chassis/scripts/preflight-bot-identity.sh
+# =========================================
+# Pre-flight check: verify the bot's outbound identity matches what's
+# configured for this install BEFORE the first heartbeat fires.
+#
+# Why this exists (chassis#5 item 3): Toby's first morning briefing on
+# Asimov posted to Discord under the chassis maintainer's bot persona
+# ("Captain Hook") instead of Asimov's persona. The briefing webhook
+# went out with INSTANCE_NAME unset, so post-to-channel.sh defaulted
+# to "Behalf.bot" - but the underlying Discord webhook itself was a
+# carry-over from a different install and DISPLAYED a stale name.
+# The fix is two-part:
+#   1. Ensure INSTANCE_NAME is set + matches chassis.config.yaml's
+#      identity.assistant.name before the dispatcher starts.
+#   2. Verify every configured webhook URL still hits the right bot
+#      (or at least warn loudly when it cannot be verified).
+#
+# This script is a "warn early, fail informatively" pre-flight. It does
+# NOT mutate webhook config - just inspects + reports. Failures here block
+# bootstrap completion so the installer fixes them before the first
+# heartbeat fires under the wrong identity.
+#
+# Inputs:
+#   CUSTOMER_HOME (required)  - to read .env + chassis.config.yaml from
+#   CHASSIS_HOME  (required)  - to source post-to-channel.sh paths
+#
+# Exit codes:
+#   0  all configured webhooks pass the identity check
+#   1  one or more webhooks mismatch the expected identity
+#   2  config could not be loaded (missing chassis.config.yaml or .env)
+
+set -euo pipefail
+
+: "${CUSTOMER_HOME:?CUSTOMER_HOME must be set}"
+: "${CHASSIS_HOME:?CHASSIS_HOME must be set}"
+
+CONFIG_FILE="$CUSTOMER_HOME/chassis.config.yaml"
+ENV_FILE="$CUSTOMER_HOME/.env"
+
+# Fall back to CHASSIS_HOME locations during the transitional window when
+# CUSTOMER_HOME is being separated out (legacy installs).
+if [[ ! -f "$CONFIG_FILE" && -f "$CHASSIS_HOME/chassis.config.yaml" ]]; then
+    CONFIG_FILE="$CHASSIS_HOME/chassis.config.yaml"
+fi
+if [[ ! -f "$ENV_FILE" && -f "$CHASSIS_HOME/.env" ]]; then
+    ENV_FILE="$CHASSIS_HOME/.env"
+fi
+
+say() {
+    printf '%s\n' "$*"
+}
+
+# Extract identity.assistant.name from chassis.config.yaml. The YAML schema
+# is shallow enough that awk is sufficient - no need to drag in yq/python.
+# Format expected:
+#   identity:
+#     ...
+#     assistant:
+#       name: <agent-name>
+extract_assistant_name() {
+    awk '
+        /^identity:/ { in_identity = 1; next }
+        in_identity && /^  assistant:/ { in_assistant = 1; next }
+        in_identity && in_assistant && /^    name:/ {
+            sub(/^    name: */, "")
+            sub(/ *#.*$/, "")
+            gsub(/^"|"$|^'\''|'\''$/, "")
+            print
+            exit
+        }
+        in_identity && /^[^ ]/ && !/^identity:/ { exit }
+        in_assistant && /^  [^ ]/ && !/^  assistant:/ { in_assistant = 0 }
+    ' "$1"
+}
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+    say "ERROR: chassis.config.yaml not found at $CONFIG_FILE" >&2
+    exit 2
+fi
+
+EXPECTED_NAME=$(extract_assistant_name "$CONFIG_FILE")
+if [[ -z "$EXPECTED_NAME" || "$EXPECTED_NAME" == "<agent-name>" ]]; then
+    say "WARN: identity.assistant.name not configured in $CONFIG_FILE" >&2
+    say "  Fill in identity.assistant.name before the first heartbeat fires," >&2
+    say "  otherwise outbound posts default to the chassis 'Behalf.bot' label." >&2
+    exit 1
+fi
+
+# Source the env file so webhook URLs + INSTANCE_NAME are in scope.
+if [[ -f "$ENV_FILE" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+    set +a
+fi
+
+# Check INSTANCE_NAME matches assistant.name. INSTANCE_NAME is what
+# post-to-channel.sh and the heartbeat dispatcher pass as the webhook
+# `username` field - this is the visible sender label in Discord.
+INSTANCE_OK=true
+if [[ -z "${INSTANCE_NAME:-}" ]]; then
+    say "FAIL: INSTANCE_NAME not set in $ENV_FILE" >&2
+    say "  Expected: INSTANCE_NAME=$EXPECTED_NAME" >&2
+    say "  Without this, every outbound webhook posts as 'Behalf.bot'." >&2
+    INSTANCE_OK=false
+elif [[ "$INSTANCE_NAME" != "$EXPECTED_NAME" ]]; then
+    say "FAIL: INSTANCE_NAME mismatch (env=$INSTANCE_NAME, expected=$EXPECTED_NAME)" >&2
+    say "  Update $ENV_FILE so INSTANCE_NAME matches identity.assistant.name." >&2
+    INSTANCE_OK=false
+else
+    say "  ✓ INSTANCE_NAME=$INSTANCE_NAME matches identity.assistant.name"
+fi
+
+# Resolve each known webhook key + check that the URL is set. We can't easily
+# verify what name Discord shows on the webhook server-side from a shell
+# script (would need a probe POST + read-back, which is noisy on installs
+# already in flight). But we CAN catch the more common failure mode where
+# the webhook env var isn't set at all - which produces the silent fallback
+# to chassis defaults that Toby hit.
+INSTANCE_PREFIX=""
+if [[ -n "${INSTANCE_NAME:-}" ]]; then
+    INSTANCE_PREFIX="$(printf '%s' "$INSTANCE_NAME" | tr '[:lower:]' '[:upper:]')_"
+fi
+
+WEBHOOK_OK=true
+for key in BRIEFINGS OPS LEADS SOCIAL ALERTS; do
+    prefixed="${INSTANCE_PREFIX}${key}_WEBHOOK_URL"
+    bare="${key}_WEBHOOK_URL"
+    if [[ -n "${!prefixed:-}" ]]; then
+        say "  ✓ $prefixed configured"
+    elif [[ -n "${!bare:-}" ]]; then
+        say "  ✓ $bare configured (no INSTANCE_NAME prefix)"
+    else
+        case "$key" in
+            BRIEFINGS|OPS)
+                say "FAIL: neither $prefixed nor $bare is set" >&2
+                say "  $key webhook required for chassis briefings/ops surface." >&2
+                WEBHOOK_OK=false
+                ;;
+            *)
+                say "  (skip) $key webhook unset - optional, only needed if the matching plugin is active"
+                ;;
+        esac
+    fi
+done
+
+if [[ "$INSTANCE_OK" == "true" && "$WEBHOOK_OK" == "true" ]]; then
+    say ""
+    say "✓ bot-identity pre-flight OK (instance=$INSTANCE_NAME)"
+    exit 0
+fi
+
+say "" >&2
+say "Bot-identity pre-flight FAILED. Fix the items above and re-run bootstrap." >&2
+say "Without these, the first heartbeat will post under a wrong/default bot persona." >&2
+exit 1

--- a/docs/SELF_INSTALL.md
+++ b/docs/SELF_INSTALL.md
@@ -197,3 +197,29 @@ DRY_RUN=true bash chassis/scheduled-tasks/heartbeat-dispatcher.sh
 ```
 
 Once the first dispatcher tick after re-enable lands cleanly in your ops channel, delete the `.bak` backup. The migration script is idempotent - re-running it after a partial restore is safe.
+
+---
+
+## Discord channel access + `requireMention` toggle
+
+The Discord plugin at `~/.claude/channels/discord/access.json` controls which channels the bot reads from and whether it ignores messages that do not @-tag it. The chassis populates this file automatically during `bootstrap.sh` via `chassis/scripts/bootstrap-discord-access.sh` using the `DISCORD_*_CHANNEL_ID` env vars + `INSTALLER_DISCORD_USER_ID`. Default per-channel behavior:
+
+| Channel key (env var) | `requireMention` |
+|---|---|
+| `DISCORD_PRIMARY_CHANNEL_ID` | `false` - natural conversation, no @-tag needed |
+| `DISCORD_ALERTS_CHANNEL_ID` | `true` |
+| `DISCORD_OPS_CHANNEL_ID` | `true` |
+| `DISCORD_BRIEFINGS_CHANNEL_ID` | `true` |
+| `DISCORD_LEADS_CHANNEL_ID` | `true` |
+| `DISCORD_SOCIAL_CHANNEL_ID` | `true` |
+
+The primary channel intentionally defaults to `requireMention: false` because that is where the installer expects to talk to the bot conversationally. Every other channel defaults to `true` so the bot stays quiet unless explicitly addressed - the safer choice for shared, multi-participant channels.
+
+If you want to flip a channel between the two modes after bootstrap, edit `~/.claude/channels/discord/access.json` directly or use the plugin's slash command from a running Claude Code session:
+
+```
+/discord:access group add <channel_id> --no-mention --allow <user_id>   # requireMention=false
+/discord:access group add <channel_id> --mention    --allow <user_id>   # requireMention=true
+```
+
+After editing, restart any long-running `claude --channels` tmux session so it picks up the new state.

--- a/docs/SELF_INSTALL.md
+++ b/docs/SELF_INSTALL.md
@@ -150,3 +150,50 @@ After Step 5 completes:
 - **OpenClaw plugins:** the chassis is OpenClaw-compatible - any plugin from https://clawhub.ai drops in cleanly
 
 If you get stuck, the managed-install option at https://behalf.bot has a maintainer drive the steps over SSH. Hand them your install repo, they finish the bootstrap, you take ownership at signoff.
+
+---
+
+## Migrating an existing install to a re-anchored chassis
+
+If you already have a running install and need to re-anchor the chassis subtree (e.g. the upstream chassis repo was renamed or moved), the canonical sequence is:
+
+```bash
+# 1. Tar up the old clone as a complete backup.
+tar czf ~/install-backup-$(date +%Y%m%d).tgz -C $HOME <your-install-name>
+
+# 2. Move the old clone aside (do NOT delete it yet - the restore step needs it).
+mv ~/<your-install-name> ~/<your-install-name>.bak
+
+# 3. Re-clone your install repo (the one that vendors the chassis subtree).
+git clone https://github.com/<your-namespace>/<your-install-name>.git
+cd ~/<your-install-name>
+
+# 4. Re-add the chassis subtree at the new remote URL if it changed.
+#    Skip this step if only your install repo moved and the chassis remote is the same.
+git subtree pull --prefix=chassis https://github.com/scrollinondubs/behalfbot.git main --squash
+
+# 5. Restore customer files from the backup using the helper script. It uses
+#    an INVERSE allowlist so anything the new chassis subtree provides is
+#    preserved, and everything else (.env, .mcp.json, scheduled-tasks/,
+#    skills/, plugins/, scripts/, data/, state/, briefings/, memory/, etc.)
+#    is restored from the backup. Always start with --dry-run.
+bash chassis/scripts/migrate-from-old-clone.sh \
+    --backup-dir ~/<your-install-name>.bak \
+    --target-dir ~/<your-install-name> \
+    --dry-run
+
+# Review the dry-run output, then run for real:
+bash chassis/scripts/migrate-from-old-clone.sh \
+    --backup-dir ~/<your-install-name>.bak \
+    --target-dir ~/<your-install-name>
+
+# 6. Re-run bootstrap.sh so customer-side scripts (launchd plists, watchdogs)
+#    pick up the new chassis paths.
+CHASSIS_HOME=$(pwd) bash bootstrap.sh
+
+# 7. Smoke-test the dispatcher in dry-run before re-enabling the launchd
+#    unit:
+DRY_RUN=true bash chassis/scheduled-tasks/heartbeat-dispatcher.sh
+```
+
+Once the first dispatcher tick after re-enable lands cleanly in your ops channel, delete the `.bak` backup. The migration script is idempotent - re-running it after a partial restore is safe.

--- a/docs/SELF_INSTALL.md
+++ b/docs/SELF_INSTALL.md
@@ -223,3 +223,23 @@ If you want to flip a channel between the two modes after bootstrap, edit `~/.cl
 ```
 
 After editing, restart any long-running `claude --channels` tmux session so it picks up the new state.
+
+---
+
+## macOS host prereq: Full Disk Access
+
+**macOS installs only.** Linux + Windows installs can skip this section.
+
+The chassis dispatcher runs inside a long-lived `tmux` session and reads from `$CUSTOMER_HOME` (under your home dir) on every tick. Recent macOS releases prompt for Full Disk Access the first time a binary in a tmux pane reads from a path the system considers protected. The prompt fires on every fresh tmux session, which can interrupt the install flow into a permission-popup loop.
+
+Fix it once, before you start the install:
+
+1. Open **System Settings -> Privacy & Security -> Full Disk Access**.
+2. Click the **+** button and grant Full Disk Access to:
+   - **Terminal.app** (or iTerm2 / Ghostty / whichever terminal you actually use)
+   - **tmux** - browse to the binary directly. Homebrew on Apple Silicon ships it at `/opt/homebrew/bin/tmux`; on Intel Macs it's `/usr/local/bin/tmux`. Use `which tmux` to confirm the path on your host.
+3. Restart the terminal app so the change takes effect.
+
+Granting Full Disk Access to your terminal + tmux suppresses the popup loop for the entire install flow. Without these grants, the install still proceeds but the popups appear every time `bootstrap.sh`, `tmux`, or the dispatcher reads a config file under `~/.behalfbot/` or `~/.claude/`.
+
+This is a macOS-only prereq. The chassis itself does not require Full Disk Access on any other OS.


### PR DESCRIPTION
## What this PR fixes

Six install-time and migration-time gaps logged in scrollinondubs/behalfbot#5. Each item lands as its own commit so they review independently. Commits are ordered by the priority sequence specified in the issue (item 6 -> 1 -> 3 -> 5 -> 2 -> 4), reading the git log chronologically gives that same order.

| Issue # | Summary | Resolution |
|---|---|---|
| 6 | `.mcp.json` missing crashes dispatcher | Code: bootstrap writes empty `{"mcpServers": {}}`; dispatcher drops `--mcp-config` when file absent (defense in depth) |
| 1 | Discord channel access not configured | Code: new `bootstrap-discord-access.sh` auto-populates `~/.claude/channels/discord/access.json` from `DISCORD_*_CHANNEL_ID` env vars + `INSTALLER_DISCORD_USER_ID` |
| 3 | First briefing posts under wrong bot identity | Code: new `preflight-bot-identity.sh` asserts `INSTANCE_NAME` matches `identity.assistant.name` before bootstrap completes; `first-boot-announce.sh` warns when live Discord username and `INSTANCE_NAME` disagree |
| 5 | Migration restore loop missed `scheduled-tasks/`, `.mcp.json`, `skills/`, `plugins/`, `scripts/` | Code: new `migrate-from-old-clone.sh` uses inverse allowlist (restore everything EXCEPT what the new chassis subtree owns). Docs: SELF_INSTALL.md migration section walks the canonical sequence |
| 2 | `requireMention: true` on every channel (UX friction) | Code (via item 1) + docs: primary channel gets `requireMention: false`, every other channel keeps the safer `true` default. Documented toggle in SELF_INSTALL.md |
| 4 | macOS Full Disk Access popup loop | Docs: SELF_INSTALL.md gets a macOS-scoped prereq section explaining how to grant Full Disk Access to Terminal.app + tmux before install starts |

## Files changed by item

- **Item 6 (mcp.json absence)** - `bootstrap.sh`, `chassis/scheduled-tasks/heartbeat-dispatcher.sh`
- **Item 1 (discord access bootstrap)** - `bootstrap.sh`, `chassis/scripts/bootstrap-discord-access.sh` (new), `chassis.config.yaml`
- **Item 3 (bot identity preflight)** - `bootstrap.sh`, `chassis/scripts/first-boot-announce.sh`, `chassis/scripts/preflight-bot-identity.sh` (new)
- **Item 5 (migration script)** - `chassis/scripts/migrate-from-old-clone.sh` (new), `docs/SELF_INSTALL.md`
- **Item 2 (requireMention docs)** - `docs/SELF_INSTALL.md`
- **Item 4 (macOS Full Disk Access)** - `docs/SELF_INSTALL.md`

Plus one trailing `style(installer)` commit that swaps two em dashes for ` - ` in code comments added by item 6 (chassis style: no em dashes anywhere).

## Why this matters now

Ben is mid-cutover on his ozzy@fatboy install and about to re-clone the chassis. Item 5's `migrate-from-old-clone.sh` directly addresses the same failure mode that took Asimov offline for 14 hours on 2026-06-01 (restore loop missed `scheduled-tasks/`, `.mcp.json`, `skills/`, `plugins/`, `scripts/`). Merging this PR before Ben's cutover lets him use the helper script with `--dry-run` first instead of repeating Toby's hand-typed restore loop.

Items 1 and 3 affect every new install going forward. Items 2, 4, and 6 are smaller but real friction points that compound across installs.

## Concerns + follow-up issues

- **Plugin-side `requireMention` default is unchanged.** The discord plugin's own default for new entries stays `true`. The chassis-side `bootstrap-discord-access.sh` writes `false` for the primary channel based on which env var the channel ID came from. If a future install adds a new channel via `/discord:access group add ...` (slash command at runtime), it gets `true` by default. The doc-only fallback the brief allows is what landed; a deeper architectural change to surface a clean hook from the plugin would belong upstream in `claude-plugins-official/discord`.
- **`first-boot-announce.sh` cannot verify webhook server-side identity** without a probe POST + read-back. The pre-flight catches the more common failure mode (`INSTANCE_NAME` unset or mismatched) but cannot prove that an already-configured webhook URL still points at the right Discord channel. A noisier probe could land as a follow-up if installs keep hitting this.
- **The `--mcp-config` absence guard in the dispatcher relies on zsh word-splitting via `${=var}`.** The original invocation was already zsh-specific (`#!/bin/zsh`). The change preserves that and uses `${=mcp_flag}` to let an empty string expand to zero arguments. If the file is moved to bash later, this needs a rewrite to an array-based argv builder.

## Activation steps (for Sean's pre-cutover test)

After merge, the changes activate automatically on the next install or upgrade. To test on Sean's install BEFORE Ben's cutover:

1. **Pull the merged main into Sean's chassis subtree:**
   ```bash
   cd ~/.behalfbot
   git subtree pull --prefix=chassis https://github.com/scrollinondubs/behalfbot.git main --squash
   ```
2. **Test item 6 (mcp-config absence guard):**
   ```bash
   # Temporarily rename .mcp.json and dry-run the dispatcher
   mv ~/.behalfbot/.mcp.json ~/.behalfbot/.mcp.json.bak
   DRY_RUN=true bash ~/.behalfbot/chassis/scheduled-tasks/heartbeat-dispatcher.sh
   # Expect: "WARN ... .mcp.json missing, invoking claude without --mcp-config" in the log,
   # NOT an immediate crash. Then restore:
   mv ~/.behalfbot/.mcp.json.bak ~/.behalfbot/.mcp.json
   ```
3. **Test item 3 (bot-identity preflight):**
   ```bash
   CUSTOMER_HOME=~/.behalfbot CHASSIS_HOME=~/behalfbot \
     bash ~/behalfbot/chassis/scripts/preflight-bot-identity.sh
   # Expect: green "INSTANCE_NAME matches identity.assistant.name" + green webhook checks.
   ```
4. **Test item 1 (discord access populate) in dry-run:**
   ```bash
   source ~/.behalfbot/.env
   bash ~/behalfbot/chassis/scripts/bootstrap-discord-access.sh --dry-run
   # Expect: the JSON it would write, showing the primary channel with requireMention=false
   # and other channels with requireMention=true.
   ```
5. **Test item 5 (migration restore) in dry-run against a throwaway dir:**
   ```bash
   mkdir -p /tmp/migrate-test/chassis
   touch /tmp/migrate-test/bootstrap.sh
   cp ~/behalfbot/Dockerfile /tmp/migrate-test/
   # Use the actual ~/.behalfbot as the "backup" source for the dry-run:
   bash ~/behalfbot/chassis/scripts/migrate-from-old-clone.sh \
     --backup-dir ~/.behalfbot \
     --target-dir /tmp/migrate-test \
     --dry-run
   # Expect: a list of files that WOULD be copied, none of them chassis-internal.
   rm -rf /tmp/migrate-test
   ```
6. **Read SELF_INSTALL.md** to confirm the macOS Full Disk Access + requireMention sections render cleanly.

If any step fails or behaves unexpectedly, that is a bug in this PR. Merge gates on items 5 and 1 working since those are what Ben's cutover hits first.

## Test plan checklist

- [ ] `bash -n` clean on every modified shell script
- [ ] `shellcheck -S error` clean on every modified shell script
- [ ] `python3 -c "import yaml; yaml.safe_load(open('chassis.config.yaml'))"` clean (verified locally via `uv run --with pyyaml`)
- [ ] No em dashes in added content (verified via `git diff main..HEAD | grep '^+' | grep -- '—'`)
- [ ] Migration script refuses to operate against non-chassis targets
- [ ] Discord access script refuses to overwrite mismatched entries without `--force`
- [ ] Bot-identity preflight fails informatively when INSTANCE_NAME is unset