### PR TITLE
fix(chassis): bake-env host-path leak + docker-info retry in templates (#16)

### DIFF
--- a/chassis/scripts/bake-env.sh
+++ b/chassis/scripts/bake-env.sh
@@ -144,7 +144,7 @@ COMPOSE_MANAGED_VARS_REGEX='^(CHASSIS_PG_DSN|CHASSIS_PG_HOST|CHASSIS_PG_PORT|CHA
 # Operators sometimes export these intentionally for a different purpose; the
 # WARN makes it visible that bake-env stripped them rather than silently
 # losing the var.
-TOXIC_PRESENT=$(echo "$NEW_VARS" | grep -E '^[A-Z][A-Z0-9_]+=' | grep -E "$TOXIC_VARS_REGEX" | sed 's/=.*$//' | sort -u)
+TOXIC_PRESENT=$(echo "$NEW_VARS" | grep -E '^[A-Z][A-Z0-9_]+=' | grep -E "$TOXIC_VARS_REGEX" | sed 's/=.*$//' | sort -u || true)
 if [[ -n "$TOXIC_PRESENT" ]]; then
     while IFS= read -r toxic_var; do
         echo "WARN: dispatcher-toxic var '$toxic_var' present at bake time; excluded from .env.baked (see chassis/scripts/bake-env.sh TOXIC_VARS_REGEX)" >&2
@@ -158,48 +158,52 @@ if [[ -z "$APP_VARS" ]]; then
     exit 2
 fi
 
-# Host-path overrides. CUSTOMER_HOME / REPO / MANIFEST / CUSTOMER_CLAUDE_DIR
-# must reflect the install root the bake is being run for, NOT whatever the
-# customer's .env hardcoded from a previous install location. This makes the
-# same .env portable across install roots — bake-env stamps the right paths
-# at bake time based on $CHASSIS_HOME (install root) and $HOME (user).
+# Host-path overrides. CUSTOMER_HOME / CHASSIS_HOME / REPO are deliberately
+# NOT re-appended after stripping - inside the chassis container these vars
+# are set authoritatively by compose's `environment:` block to /app/customer
+# (the bind-mount destination). If they were in .env.baked, the entrypoint's
+# source_env step would re-source after compose env has been applied,
+# overwriting the container path with whatever host path the bake recorded.
+# The dispatcher would then `cd "$CUSTOMER_HOME"` to a host path that doesn't
+# exist inside the container and every gather script would fail with "no
+# such file or directory". Concrete incident 2026-06-03 (Ben's fatboy
+# cutover): all gather scripts failed-loop on `cd: /home/ozzy/ben-install`
+# because that host path doesn't exist in the chassis container. Fix is to
+# strip and NOT re-append - compose's environment block already owns the
+# container-side values.
 #
-# Without this, moving an install from $CHASSIS_HOME to $HOME/work/
-# new-jaxity required a manual rewrite of .env before re-baking, and any
-# missed key caused the chassis container to mount the WRONG host directory
-# (silent wrong-bind-mount). Confirmed during the 2026-05-24 Phase 6 cutover
-# attempt — chassis came up healthy but bind-mount source was the old path
-# because the baked CUSTOMER_HOME still pointed at $CHASSIS_HOME. See
-# <v1-reference-install>#697 + scrollinondubs/new-jaxity#49 for context.
+# MANIFEST + CUSTOMER_CLAUDE_DIR stay overridden because:
+#   - MANIFEST: derived from CUSTOMER_HOME, only read by host-side migration
+#     scripts (vaultwarden-migration-manifest.json lives on host).
+#   - CUSTOMER_CLAUDE_DIR: $HOME/.claude is the user's Claude Code data dir
+#     on the HOST; compose interpolates it as a bind-mount source. The
+#     container side of that mount is /home/chassis/.claude regardless.
 #
-# Path-shaped vars overridden here:
-#   CUSTOMER_HOME        -> $CUSTOMER_HOME             (host customer-state root)
-#   CHASSIS_HOME         -> $CHASSIS_HOME              (host chassis tree root)
-#   REPO                 -> $CHASSIS_HOME              (legacy alias for chassis tree)
-#   MANIFEST             -> $CUSTOMER_HOME/data/vaultwarden-migration-manifest.json
-#   CUSTOMER_CLAUDE_DIR  -> $HOME/.claude              (user's ~/.claude, install-agnostic)
-#
-# Strategy: strip these keys from APP_VARS, then append derived values. Loud
-# log so operators see what was overridden (in case a customer was relying on
-# a custom value).
+# Without this strip-only behavior, moving an install from $CHASSIS_HOME to
+# $HOME/work/new-jaxity required a manual rewrite of .env before re-baking,
+# and any missed key caused the chassis container to mount the WRONG host
+# directory (silent wrong-bind-mount). Confirmed during the 2026-05-24
+# Phase 6 cutover attempt - chassis came up healthy but bind-mount source
+# was the old path because the baked CUSTOMER_HOME still pointed at
+# $CHASSIS_HOME. See <v1-reference-install>#697 + scrollinondubs/
+# new-jaxity#49 for context. The strip step still does that work; only the
+# re-append for the three container-overridden keys is removed.
 PATH_KEYS_REGEX='^(CUSTOMER_HOME|CHASSIS_HOME|REPO|MANIFEST|CUSTOMER_CLAUDE_DIR)='
 PATH_ORIGINALS=$(echo "$APP_VARS" | grep -E "$PATH_KEYS_REGEX" | sort -u)
 if [[ -n "$PATH_ORIGINALS" ]]; then
     while IFS= read -r line; do
         key="${line%%=*}"
-        echo "INFO: overriding host-path var '$key' from host env (was: ${line#*=})" >&2
+        echo "INFO: stripping host-path var '$key' from .env.baked (was: ${line#*=})" >&2
     done <<< "$PATH_ORIGINALS"
 fi
 
 APP_VARS=$(echo "$APP_VARS" | grep -vE "$PATH_KEYS_REGEX" || true)
 
-# Append the derived path values. CUSTOMER_CLAUDE_DIR uses $HOME because it
-# points at the host user's ~/.claude (Claude Code's data dir), not the
-# install root. The container reads these via env_file at boot.
+# Re-append only the keys that legitimately need to reach the container as
+# host paths (MANIFEST is host-side only; CUSTOMER_CLAUDE_DIR is interpolated
+# by compose). CUSTOMER_HOME / CHASSIS_HOME / REPO are intentionally absent -
+# see the comment block above.
 APP_VARS="$APP_VARS
-CUSTOMER_HOME=$CUSTOMER_HOME
-CHASSIS_HOME=$CHASSIS_HOME
-REPO=$CHASSIS_HOME
 MANIFEST=$CUSTOMER_HOME/data/vaultwarden-migration-manifest.json
 CUSTOMER_CLAUDE_DIR=$HOME/.claude"
 

--- a/chassis/scripts/templates/restart-discord.sh.template
+++ b/chassis/scripts/templates/restart-discord.sh.template
@@ -3,6 +3,18 @@
 # PATH. On Linux the brew dir does not exist and this prefix is a harmless no-op.
 export PATH="/opt/homebrew/bin:$PATH"
 
+# Wait up to 90s for Docker daemon to be available (Colima VM boot on cold
+# start). Without this guard, a system-domain LaunchDaemon that races Colima
+# at reboot spawns tmux + claude before docker.sock exists; MCP plugins that
+# docker-exec the chassis container fail-loop until Colima catches up.
+# 30 iterations x 3s = 90s ceiling. First successful docker-info breaks early,
+# so a 15s Colima boot only waits 15s. Linux installs where docker is always
+# up (or N/A) succeed on first iteration. See chassis#16.
+for i in {1..30}; do
+    if docker info >/dev/null 2>&1; then break; fi
+    sleep 3
+done
+
 # restart-${BOT_NAME}-discord.sh - chassis-rendered template.
 #
 # Kills and restarts the ${TMUX_SESSION_NAME} tmux session with a fresh

--- a/chassis/scripts/templates/watchdog-discord.sh.template
+++ b/chassis/scripts/templates/watchdog-discord.sh.template
@@ -3,6 +3,17 @@
 # PATH. On Linux the brew dir does not exist and this prefix is a harmless no-op.
 export PATH="/opt/homebrew/bin:$PATH"
 
+# Wait up to 90s for Docker daemon to be available (Colima VM boot on cold
+# start). The watchdog itself doesn't docker-exec, but its restart-script
+# child does. Waiting here ensures the recovery path lands on a live docker
+# socket rather than tearing down + recreating a tmux session that would
+# fail-loop until Colima catches up. Linux installs no-op on iteration 1.
+# See chassis#16.
+for i in {1..30}; do
+    if docker info >/dev/null 2>&1; then break; fi
+    sleep 3
+done
+
 # watchdog-${BOT_NAME}-discord.sh - chassis-rendered template.
 #
 # Monitors the ${TMUX_SESSION_NAME} tmux session for auth failures and


### PR DESCRIPTION
## Summary

Two related fixes bundled per Sean's preference, surfaced during today's chassis cutover work:

1. **`bake-env.sh` host-path leak (new bug discovered during Ben's 2026-06-03 fatboy cutover).** The bake step was appending `CUSTOMER_HOME=$CUSTOMER_HOME`, `CHASSIS_HOME=$CHASSIS_HOME`, `REPO=$CHASSIS_HOME` to `.env.baked` with the values evaluated at bake time on the host. Inside the chassis container, compose's `environment:` block correctly sets these to `/app/customer`. But the entrypoint's `source_env` re-sources `.env.baked` AFTER compose env has been applied, so the host path overrides the container path. The dispatcher's `cd "$CUSTOMER_HOME"` then fails because that host path does not exist inside the container.

   Concrete failure mode on Ben's install: every gather script logged `cd: no such file or directory: /home/ozzy/ben-install` and was marked `ERROR ... gather script failed`. Sean's install hasn't hit this yet only because he is still on the older image where dispatcher uses `cd "$CHASSIS_HOME"` and his `.env.baked` happens to lack a `CHASSIS_HOME` line. Next `docker compose pull` on Sean's box will hit the same crash.

   Fix: strip the three container-overridden keys (`CUSTOMER_HOME`, `CHASSIS_HOME`, `REPO`) from `.env.baked` and DO NOT re-append. Compose's environment block owns them. Keep `MANIFEST` and `CUSTOMER_CLAUDE_DIR` re-appended because they have legitimate host-context uses.

2. **Docker-info retry loop in `discord-{restart,watchdog}` templates (chassis#16).** Bot daemons that fire at boot race Colima's VM startup; the rendered scripts spawned tmux + claude before docker.sock existed and the MCP plugins inside the claude session fail-loop. Adds a 90s ceiling, 3s polling docker-info wait at the top of both templates (after `export PATH`, before any other logic). Linux installs no-op on iteration 1.

   Pattern matches the on-disk hardening already landed in new-jaxity#146 - this PR upstreams it so the next `bootstrap-customer-scripts.sh` render doesn't regress.

Bonus catch: the `TOXIC_PRESENT` grep on line 147 of `bake-env.sh` lacked `|| true`. When the grep pipeline returned no matches, the script bailed under `set -e`. Ben's install had a local `|| true` patch for this; this PR upstreams it.

## Files

- `chassis/scripts/bake-env.sh` (host-path strip-only + grep guard)
- `chassis/scripts/templates/restart-discord.sh.template` (docker-info retry loop)
- `chassis/scripts/templates/watchdog-discord.sh.template` (docker-info retry loop)

## Test plan

- [ ] `bash -n` + `shellcheck -S error` on `bake-env.sh`: clean.
- [ ] Sean's activation post-merge: `git subtree pull --prefix=chassis ...` then re-bake `.env.baked` (clean shell, see below). Verify the new `.env.baked` has no `CUSTOMER_HOME` / `CHASSIS_HOME` / `REPO` lines.
- [ ] Sean's reboot test: after re-bake + container recreate, run `sudo shutdown -r now` from SSH, do NOT console-login, re-SSH and check `docker exec behalfbot tail /app/customer/logs/scheduled/2026-06-03-dispatcher.log` for clean `=== Dispatcher run complete ===` lines.

## Post-merge re-bake for Sean

```bash
cd ~/.behalfbot
env -i HOME=/Users/jax USER=jax PATH=/opt/homebrew/bin:/usr/bin:/bin \
  CHASSIS_HOME=$HOME/behalfbot CUSTOMER_HOME=$HOME/.behalfbot \
  bash ~/behalfbot/chassis/scripts/bake-env.sh
docker compose -f ~/behalfbot/docker-compose.yml -f chassis-compose.override.yml restart chassis
```

## Related

- chassis#15 - parent daemon-promotion PR
- chassis#16 - docker-info retry loop tracking issue (this PR closes it)
- new-jaxity#146 - per-install on-disk hardening that this PR upstreams

🤖 Generated with [Claude Code](https://claude.com/claude-code)