### PR TITLE
fix(bootstrap): pre-seed claude folder-trust for CUSTOMER_HOME (#21)

### DIFF
--- a/chassis/scripts/bootstrap-customer-scripts.sh
+++ b/chassis/scripts/bootstrap-customer-scripts.sh
@@ -148,6 +148,95 @@ render_template "$TEMPLATES_DIR/restart-discord.sh.template" \
 render_template "$TEMPLATES_DIR/watchdog-discord.sh.template" \
     "$OUT_SCRIPTS/watchdog-${BOT_NAME}-discord.sh"
 
+# Pre-seed Claude Code's per-directory folder-trust state for CUSTOMER_HOME.
+#
+# Claude Code stores folder-trust per absolute path in ~/.claude.json under
+# projects["<abs path>"].hasTrustDialogAccepted. --dangerously-skip-permissions
+# does NOT bypass this gate; it controls the per-tool permission classifier,
+# which only runs after trust is established. If CUSTOMER_HOME is not already
+# trusted, claude boots into an interactive trust prompt and parks forever -
+# the Discord tmux session stays alive (so the watchdog session-existence check
+# passes) but the bot never connects. Reported by Toby on asimov via #21.
+#
+# This step is idempotent: re-running merges fields rather than clobbering
+# unrelated state.
+preseed_claude_trust() {
+    local target_dir="$1"
+    local claude_config="$HOME/.claude.json"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "[dry-run] would pre-seed claude folder-trust for $target_dir in $claude_config"
+        return 0
+    fi
+
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "  WARN: python3 not on PATH; skipping claude-trust pre-seed for $target_dir" >&2
+        echo "        First Discord launch will hit the trust prompt and park." >&2
+        return 0
+    fi
+
+    if ! python3 - "$claude_config" "$target_dir" <<'PYEOF'
+import json
+import os
+import sys
+import tempfile
+
+config_path, target_dir = sys.argv[1], sys.argv[2]
+
+if os.path.exists(config_path):
+    try:
+        with open(config_path) as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"  ERROR: {config_path} is not valid JSON: {e}", file=sys.stderr)
+        print(f"         Refusing to overwrite. Fix or delete the file and re-run.", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(data, dict):
+        print(f"  ERROR: {config_path} top-level is not a JSON object; refusing to edit.", file=sys.stderr)
+        sys.exit(1)
+else:
+    data = {}
+
+projects = data.setdefault("projects", {})
+if not isinstance(projects, dict):
+    print(f"  ERROR: {config_path} 'projects' is not an object; refusing to edit.", file=sys.stderr)
+    sys.exit(1)
+
+entry = projects.setdefault(target_dir, {})
+if not isinstance(entry, dict):
+    print(f"  ERROR: {config_path} projects['{target_dir}'] is not an object; refusing to edit.", file=sys.stderr)
+    sys.exit(1)
+
+already_trusted = entry.get("hasTrustDialogAccepted") is True and entry.get("hasCompletedProjectOnboarding") is True
+entry["hasTrustDialogAccepted"] = True
+entry["hasCompletedProjectOnboarding"] = True
+
+tmp_fd, tmp_path = tempfile.mkstemp(prefix=".claude.json.", dir=os.path.dirname(config_path) or ".")
+try:
+    with os.fdopen(tmp_fd, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+    os.replace(tmp_path, config_path)
+except Exception:
+    try:
+        os.unlink(tmp_path)
+    except OSError:
+        pass
+    raise
+
+if already_trusted:
+    print(f"  claude folder-trust for {target_dir}: already set (no-op)")
+else:
+    print(f"  claude folder-trust for {target_dir}: pre-seeded in {config_path}")
+PYEOF
+    then
+        echo "  ERROR: claude-trust pre-seed for $target_dir failed; aborting bootstrap." >&2
+        return 1
+    fi
+}
+
+preseed_claude_trust "$CUSTOMER_HOME"
+
 if [[ "$RENDER_PLISTS" == "true" ]]; then
     render_template "$LAUNCHD_DIR/com.behalfbot.discord-restart.plist.template" \
         "$OUT_PLISTS/com.behalfbot.${BOT_NAME}-discord-restart.plist"


### PR DESCRIPTION
## Summary

Fix for #21: bootstrap now pre-seeds Claude Code's per-directory folder-trust state for `CUSTOMER_HOME` in `~/.claude.json`, so Discord launches never park on the first-run trust prompt.

- `--dangerously-skip-permissions` does **not** bypass the trust gate. Trust is stored per absolute path in `~/.claude.json` under `projects["<abs path>"].hasTrustDialogAccepted`.
- The `#6` CUSTOMER_HOME migration moved the Discord launch cwd to `${CUSTOMER_HOME}` (e.g. `~/.behalfbot`), a path no install had ever trusted - so every restart since #6 has been one trust-prompt away from a silent outage. Toby's `asimov` hit it; full reproduction and manual recovery procedure in his gist: https://gist.github.com/tobyzn/2e70b548e94d497b18f71b7ac6c9f407
- `bootstrap-customer-scripts.sh` now writes:

  ```json
  {
    "projects": {
      "<CUSTOMER_HOME>": {
        "hasTrustDialogAccepted": true,
        "hasCompletedProjectOnboarding": true
      }
    }
  }
  ```

  ...idempotently merged into `~/.claude.json` after the customer-side scripts are rendered.

## Edge cases handled

| Case | Behavior |
|---|---|
| `~/.claude.json` exists, valid JSON, no trust entry for CUSTOMER_HOME | Merge entry, preserve all other top-level keys |
| `~/.claude.json` exists, trust entry already present and correct | No-op (logs "already set") |
| `~/.claude.json` does not exist | Create minimal config with just the projects entry |
| `~/.claude.json` exists but is invalid JSON | Refuse, exit 1, prompt operator to fix or delete |
| `~/.claude.json` exists but `projects` is not an object | Refuse, exit 1 (rather than clobber) |
| `python3` not on PATH | Warn, skip pre-seed, continue bootstrap |
| `--dry-run` | Logs intent, writes nothing |

Write is atomic (`tempfile.mkstemp` + `os.replace`) so a partial write can't corrupt `~/.claude.json` if the process is interrupted mid-edit.

## Test

Manually verified all four primary cases against an isolated `$HOME` (valid-JSON merge, idempotent rerun, invalid JSON, no file). Output matches expectations; preexisting `~/.claude.json` keys are preserved across the merge.

## Scope

- This PR is the **causal fix** for #21 (eliminate the failure mode).
- A separate follow-up PR will harden the watchdog to detect "tmux alive but bot parked on a prompt" - covers any future variant of this class of bug. Splitting so each can land and roll back independently.
- The `restart-discord.sh.template` cwd/comment contradiction noted in Toby's gist is already resolved on `main` (comment now accurately says "Working dir is CUSTOMER_HOME"), no fix needed there.

## Credit

Bug reported, root-caused, and manually recovered by @tobyzn on his `asimov` install. Gist: https://gist.github.com/tobyzn/2e70b548e94d497b18f71b7ac6c9f407.

Refs #21.

## Test plan

- [ ] @tobyzn tests on `asimov`: revert the manual `~/.claude.json` edit, re-run `bash chassis/scripts/bootstrap-customer-scripts.sh`, confirm `~/.claude.json` is repopulated and the next `bash scripts/restart-asimov-discord.sh` boots straight to "Listening for channel messages" with no prompt.
- [ ] Jax re-runs bootstrap on his own box, confirms idempotent no-op and no corruption.
- [ ] Verify `--dry-run` does not touch `~/.claude.json`.
