### PR TITLE
fix(watchdog): detect folder-trust prompt + generic TUI menu parking (#21)

### DIFF
--- a/chassis/scripts/templates/watchdog-discord.sh.template
+++ b/chassis/scripts/templates/watchdog-discord.sh.template
@@ -53,11 +53,36 @@ if ! tmux has-session -t "${TMUX_SESSION_NAME}" 2>/dev/null; then
     exit 0
 fi
 
-# Capture recent pane output and check for auth failure indicators
+# Capture recent pane output for state inspection.
 PANE_OUTPUT=$(tmux capture-pane -t "${TMUX_SESSION_NAME}" -p -S -50 2>/dev/null)
 
 if echo "$PANE_OUTPUT" | grep -qiE "Not logged in|Please run /login|authentication.*failed|token.*expired"; then
     echo "[$(timestamp)] Auth failure detected - restarting" >> "$LOG_FILE"
+    bash "$RESTART_SCRIPT"
+    exit 0
+fi
+
+# Folder-trust prompt detection (chassis#21). Claude Code's per-directory
+# trust gate runs before --dangerously-skip-permissions can apply, so a
+# claude process launched into an untrusted directory parks on this prompt
+# forever - tmux session looks alive, bot is dead. Bootstrap pre-seed
+# (chassis#22) makes this unreachable on new installs, but the watchdog
+# detection is the belt-and-suspenders catch for any future variant of
+# "tmux alive but bot parked on a prompt".
+if echo "$PANE_OUTPUT" | grep -qiE "Is this a project you trust|Accessing workspace:.*trust"; then
+    echo "[$(timestamp)] Folder-trust prompt detected - restarting" >> "$LOG_FILE"
+    echo "[$(timestamp)]   (run bootstrap-customer-scripts.sh to pre-seed trust for CUSTOMER_HOME)" >> "$LOG_FILE"
+    bash "$RESTART_SCRIPT"
+    exit 0
+fi
+
+# Generic interactive-prompt detection. Any TUI menu pattern ("> 1." style
+# selectable list) in the pane means the process is parked waiting for input
+# nothing will provide. Conservative regex: requires a current-selection
+# arrow at the start of a line followed by a numbered option, which Claude's
+# prompts produce and steady-state log output does not.
+if echo "$PANE_OUTPUT" | grep -qE '^[[:space:]]*[>❯][[:space:]]+[0-9]+\.'; then
+    echo "[$(timestamp)] Interactive prompt detected (unknown menu) - restarting" >> "$LOG_FILE"
     bash "$RESTART_SCRIPT"
     exit 0
 fi


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to #22: extends the Discord watchdog's existing pane-content inspection to recover from "tmux alive but bot parked on a prompt" - not just the specific trust-dialog case from #21, but any future Claude TUI prompt that could block startup.

The current watchdog already runs `tmux capture-pane` and greps for auth failures. It just didn't grep for the trust dialog. After this PR it grepped for both, plus a conservative generic-TUI-menu pattern.

## Two new rules

### 1. Folder-trust prompt (specific)

Regex: `Is this a project you trust|Accessing workspace:.*trust`. Matches the exact pattern Claude Code shows on first-run into an untrusted directory:

```
Accessing workspace: /Users/.../.behalfbot
Is this a project you trust?
 > 1. Yes, I trust this folder
   2. No, exit
```

On match: restart the session and log a pointer to `bootstrap-customer-scripts.sh`'s pre-seed step (the actual fix from #22). The watchdog rule alone would loop the prompt forever - it's a "get back online now" lever, not the cure.

### 2. Generic TUI menu (catch-all)

Regex: `^[[:space:]]*[>❯][[:space:]]+[0-9]+\.` matches Claude's TUI menu selection pattern (the current-selection arrow at the start of a line followed by a numbered option). Anchored tightly enough that normal log lines do not match.

Tested against:

```
✓ "Is this a project you trust?..." → DETECTED
✓ Generic " > 1. Yes, ..." pane → DETECTED
✗ "[2026-06-09 10:00] Listening for channel messages..." → no false positive
✗ "exit code > 1 means error" → no false positive
```

This is the "catches the next bug we haven't seen yet" rule. If Claude Code ever adds another startup prompt the bot can't answer, the watchdog will pull it back into a clean restart instead of leaving it parked silently.

## Why both rules

The specific rule wins when the diagnostic detail in the log matters - operator sees "Folder-trust prompt detected" and knows exactly what happened and what to do. The generic rule wins on future-unknown prompts where we wouldn't have a specific signature yet.

If they ever fire at the same time (specific match implies generic match), the specific rule runs first and short-circuits, so the log message is the more informative one.

## Scope notes

- Does not change positive-liveness behavior. The watchdog still treats "no prompt detected, no auth failure, tmux alive" as healthy. A separate enhancement could add positive assertion of `Listening for channel messages from:` presence, but that's a behavior change with rollout risk (false negatives on slow-start installs) and belongs in its own PR.
- Existing customer-rendered watchdog scripts will not pick this up until the operator re-runs `bash chassis/scripts/bootstrap-customer-scripts.sh` (or the chassis container rebuilds, which re-renders).

## Test plan

- [ ] @tobyzn deploys this on `asimov` (alongside #22 if already merged) and confirms the watchdog logs show "Session healthy" on normal runs.
- [ ] Simulated test: kill `asimov-discord` tmux session, delete the trust entry from `~/.claude.json` to force the prompt, wait for next watchdog tick, confirm the watchdog catches the prompt and triggers a restart.
- [ ] Jax: re-render watchdog script via `bootstrap-customer-scripts.sh`, run watchdog manually with `--healthy` session, confirm "Session healthy" still logs.

## Credit

Same bug-report chain as #22 - reported and root-caused by @tobyzn at https://gist.github.com/tobyzn/2e70b548e94d497b18f71b7ac6c9f407. This PR addresses the "why didn't the watchdog catch it?" half of his writeup; #22 addresses the "why did the bug exist?" half.

Refs #21.
