### PR TITLE
fix(chassis#21): trust-recovery loop + watchdog regex correctness

### DIFF
--- a/chassis/scripts/bootstrap-customer-scripts.sh
+++ b/chassis/scripts/bootstrap-customer-scripts.sh
@@ -149,93 +149,14 @@ render_template "$TEMPLATES_DIR/watchdog-discord.sh.template" \
     "$OUT_SCRIPTS/watchdog-${BOT_NAME}-discord.sh"
 
 # Pre-seed Claude Code's per-directory folder-trust state for CUSTOMER_HOME.
-#
-# Claude Code stores folder-trust per absolute path in ~/.claude.json under
-# projects["<abs path>"].hasTrustDialogAccepted. --dangerously-skip-permissions
-# does NOT bypass this gate; it controls the per-tool permission classifier,
-# which only runs after trust is established. If CUSTOMER_HOME is not already
-# trusted, claude boots into an interactive trust prompt and parks forever -
-# the Discord tmux session stays alive (so the watchdog session-existence check
-# passes) but the bot never connects. Reported by Toby on asimov via #21.
-#
-# This step is idempotent: re-running merges fields rather than clobbering
-# unrelated state.
-preseed_claude_trust() {
-    local target_dir="$1"
-    local claude_config="$HOME/.claude.json"
-
-    if [[ "$DRY_RUN" == "true" ]]; then
-        echo "[dry-run] would pre-seed claude folder-trust for $target_dir in $claude_config"
-        return 0
-    fi
-
-    if ! command -v python3 >/dev/null 2>&1; then
-        echo "  WARN: python3 not on PATH; skipping claude-trust pre-seed for $target_dir" >&2
-        echo "        First Discord launch will hit the trust prompt and park." >&2
-        return 0
-    fi
-
-    if ! python3 - "$claude_config" "$target_dir" <<'PYEOF'
-import json
-import os
-import sys
-import tempfile
-
-config_path, target_dir = sys.argv[1], sys.argv[2]
-
-if os.path.exists(config_path):
-    try:
-        with open(config_path) as f:
-            data = json.load(f)
-    except json.JSONDecodeError as e:
-        print(f"  ERROR: {config_path} is not valid JSON: {e}", file=sys.stderr)
-        print(f"         Refusing to overwrite. Fix or delete the file and re-run.", file=sys.stderr)
-        sys.exit(1)
-    if not isinstance(data, dict):
-        print(f"  ERROR: {config_path} top-level is not a JSON object; refusing to edit.", file=sys.stderr)
-        sys.exit(1)
-else:
-    data = {}
-
-projects = data.setdefault("projects", {})
-if not isinstance(projects, dict):
-    print(f"  ERROR: {config_path} 'projects' is not an object; refusing to edit.", file=sys.stderr)
-    sys.exit(1)
-
-entry = projects.setdefault(target_dir, {})
-if not isinstance(entry, dict):
-    print(f"  ERROR: {config_path} projects['{target_dir}'] is not an object; refusing to edit.", file=sys.stderr)
-    sys.exit(1)
-
-already_trusted = entry.get("hasTrustDialogAccepted") is True and entry.get("hasCompletedProjectOnboarding") is True
-entry["hasTrustDialogAccepted"] = True
-entry["hasCompletedProjectOnboarding"] = True
-
-tmp_fd, tmp_path = tempfile.mkstemp(prefix=".claude.json.", dir=os.path.dirname(config_path) or ".")
-try:
-    with os.fdopen(tmp_fd, "w") as f:
-        json.dump(data, f, indent=2)
-        f.write("\n")
-    os.replace(tmp_path, config_path)
-except Exception:
-    try:
-        os.unlink(tmp_path)
-    except OSError:
-        pass
-    raise
-
-if already_trusted:
-    print(f"  claude folder-trust for {target_dir}: already set (no-op)")
-else:
-    print(f"  claude folder-trust for {target_dir}: pre-seeded in {config_path}")
-PYEOF
-    then
-        echo "  ERROR: claude-trust pre-seed for $target_dir failed; aborting bootstrap." >&2
-        return 1
-    fi
-}
-
-preseed_claude_trust "$CUSTOMER_HOME"
+# Logic lives in preseed-claude-trust.sh so the restart template can call
+# the same helper (chassis#21 follow-up: trust-wipe recovery requires the
+# restart path to re-seed too, not just bootstrap).
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo "[dry-run] would pre-seed claude folder-trust for $CUSTOMER_HOME via preseed-claude-trust.sh"
+else
+    bash "$SCRIPT_DIR/preseed-claude-trust.sh" "$CUSTOMER_HOME"
+fi
 
 if [[ "$RENDER_PLISTS" == "true" ]]; then
     render_template "$LAUNCHD_DIR/com.behalfbot.discord-restart.plist.template" \

--- a/chassis/scripts/preseed-claude-trust.sh
+++ b/chassis/scripts/preseed-claude-trust.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# preseed-claude-trust.sh - ensure Claude Code has CUSTOMER_HOME marked as
+# trusted in ~/.claude.json, so claude launches into that directory don't
+# park on the first-run folder-trust prompt.
+#
+# Background (chassis#21):
+#   Claude Code stores folder-trust per absolute path in ~/.claude.json
+#   under projects["<abs path>"].hasTrustDialogAccepted. The flag
+#   --dangerously-skip-permissions does NOT bypass this gate; it controls
+#   the per-tool permission classifier, which only runs after trust is
+#   established. The #6 CUSTOMER_HOME migration moved the Discord launch
+#   cwd to ${CUSTOMER_HOME} (typically ~/.behalfbot), a path no install
+#   had ever trusted - so every restart parked on the trust prompt,
+#   waiting on keyboard input that nothing was around to answer.
+#
+# Why this is its own script:
+#   chassis#23 follow-up - the original PR put this logic only inside
+#   bootstrap-customer-scripts.sh, so the recovery path (watchdog → restart
+#   script → claude) didn't re-seed trust after a wipe. The watchdog would
+#   detect the parked prompt, run restart, claude would park again, and
+#   the bot would infinite-loop with no actual recovery. Extracting into
+#   a standalone idempotent script lets BOTH bootstrap and the restart
+#   template call the same pre-seed before launching claude.
+#
+# Usage:
+#   bash chassis/scripts/preseed-claude-trust.sh <CUSTOMER_HOME>
+#
+# Idempotent. Safe to call from restart templates on every restart.
+#
+# Exit codes:
+#   0 - trust entry present (either pre-existing or freshly seeded)
+#   0 - python3 missing, warning printed, caller should treat as soft-fail
+#       (restart can still proceed; first claude launch will hit the prompt)
+#   1 - ~/.claude.json is invalid JSON or has unexpected shape;
+#       refuses to clobber. Caller must investigate manually.
+
+set -euo pipefail
+
+TARGET_DIR="${1:-}"
+if [[ -z "$TARGET_DIR" ]]; then
+    echo "Usage: preseed-claude-trust.sh <abs-path-to-trust>" >&2
+    exit 2
+fi
+
+CLAUDE_CONFIG="${CLAUDE_CONFIG:-$HOME/.claude.json}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  WARN: python3 not on PATH; skipping claude-trust pre-seed for $TARGET_DIR" >&2
+    echo "        Next claude launch into $TARGET_DIR will hit the trust prompt." >&2
+    exit 0
+fi
+
+if ! python3 - "$CLAUDE_CONFIG" "$TARGET_DIR" <<'PYEOF'
+import json
+import os
+import sys
+import tempfile
+
+config_path, target_dir = sys.argv[1], sys.argv[2]
+
+if os.path.exists(config_path):
+    try:
+        with open(config_path) as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"  ERROR: {config_path} is not valid JSON: {e}", file=sys.stderr)
+        print(f"         Refusing to overwrite. Fix or delete the file and re-run.", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(data, dict):
+        print(f"  ERROR: {config_path} top-level is not a JSON object; refusing to edit.", file=sys.stderr)
+        sys.exit(1)
+else:
+    data = {}
+
+projects = data.setdefault("projects", {})
+if not isinstance(projects, dict):
+    print(f"  ERROR: {config_path} 'projects' is not an object; refusing to edit.", file=sys.stderr)
+    sys.exit(1)
+
+entry = projects.setdefault(target_dir, {})
+if not isinstance(entry, dict):
+    print(f"  ERROR: {config_path} projects['{target_dir}'] is not an object; refusing to edit.", file=sys.stderr)
+    sys.exit(1)
+
+already_trusted = entry.get("hasTrustDialogAccepted") is True and entry.get("hasCompletedProjectOnboarding") is True
+entry["hasTrustDialogAccepted"] = True
+entry["hasCompletedProjectOnboarding"] = True
+
+tmp_fd, tmp_path = tempfile.mkstemp(prefix=".claude.json.", dir=os.path.dirname(config_path) or ".")
+try:
+    with os.fdopen(tmp_fd, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+    os.replace(tmp_path, config_path)
+except Exception:
+    try:
+        os.unlink(tmp_path)
+    except OSError:
+        pass
+    raise
+
+if already_trusted:
+    print(f"  claude folder-trust for {target_dir}: already set (no-op)")
+else:
+    print(f"  claude folder-trust for {target_dir}: pre-seeded in {config_path}")
+PYEOF
+then
+    echo "  ERROR: claude-trust pre-seed for $TARGET_DIR failed." >&2
+    exit 1
+fi

--- a/chassis/scripts/templates/restart-discord.sh.template
+++ b/chassis/scripts/templates/restart-discord.sh.template
@@ -53,6 +53,23 @@ else
     echo "[$(timestamp)] No existing ${TMUX_SESSION_NAME} session found" >> "$LOG_FILE"
 fi
 
+# Re-seed Claude Code's folder-trust state for CUSTOMER_HOME before launch.
+# Idempotent - cheap no-op when the trust entry is already present, which
+# is the normal case. The reason this lives in the restart path (and not
+# just bootstrap) is the chassis#21 follow-up: if the trust entry is
+# wiped between runs (manual cleanup, ~/.claude.json corruption, restored
+# backup, etc.) the watchdog would otherwise loop forever - it'd detect
+# the trust prompt and restart claude, which would re-park because trust
+# is still missing. Calling the pre-seed helper here means the restart
+# path is self-healing for trust state. See chassis#23 follow-up PR for
+# the full post-mortem.
+if [[ -x "${CHASSIS_HOME}/chassis/scripts/preseed-claude-trust.sh" ]]; then
+    bash "${CHASSIS_HOME}/chassis/scripts/preseed-claude-trust.sh" "${CUSTOMER_HOME}" >> "$LOG_FILE" 2>&1 || \
+        echo "[$(timestamp)] WARN: preseed-claude-trust.sh failed; claude may park on trust prompt" >> "$LOG_FILE"
+else
+    echo "[$(timestamp)] WARN: preseed-claude-trust.sh not found at ${CHASSIS_HOME}/chassis/scripts/; skipping trust pre-seed" >> "$LOG_FILE"
+fi
+
 # Start new session.
 #
 # Working dir is CUSTOMER_HOME so claude resolves the install's CLAUDE.md, .env,

--- a/chassis/scripts/templates/watchdog-discord.sh.template
+++ b/chassis/scripts/templates/watchdog-discord.sh.template
@@ -66,12 +66,18 @@ fi
 # trust gate runs before --dangerously-skip-permissions can apply, so a
 # claude process launched into an untrusted directory parks on this prompt
 # forever - tmux session looks alive, bot is dead. Bootstrap pre-seed
-# (chassis#22) makes this unreachable on new installs, but the watchdog
-# detection is the belt-and-suspenders catch for any future variant of
-# "tmux alive but bot parked on a prompt".
-if echo "$PANE_OUTPUT" | grep -qiE "Is this a project you trust|Accessing workspace:.*trust"; then
-    echo "[$(timestamp)] Folder-trust prompt detected - restarting" >> "$LOG_FILE"
-    echo "[$(timestamp)]   (run bootstrap-customer-scripts.sh to pre-seed trust for CUSTOMER_HOME)" >> "$LOG_FILE"
+# (chassis#22) makes this unreachable on new installs; the restart
+# template also calls preseed-claude-trust.sh on every restart (chassis#23
+# follow-up) so this detection rule has a real recovery path - the restart
+# now re-seeds trust before re-launching claude, breaking the previous
+# infinite restart loop on trust-wipe.
+#
+# Regex matches the actual current Claude Code wording: "Quick safety
+# check: Is this a project you created or one you trust?" The earlier
+# tighter regex matched neither alternative on the real prompt and was
+# only saved by the generic-menu fallback below (chassis#23 review by Toby).
+if echo "$PANE_OUTPUT" | grep -qiE "Quick safety check|trust this folder|Is this a project you"; then
+    echo "[$(timestamp)] Folder-trust prompt detected - restarting (restart will re-seed trust via preseed-claude-trust.sh)" >> "$LOG_FILE"
     bash "$RESTART_SCRIPT"
     exit 0
 fi


### PR DESCRIPTION
## Summary

Post-mortem follow-up to #22 + #23, prompted by @tobyzn's PR #23 review (https://github.com/scrollinondubs/behalfbot/issues/23#issuecomment-4658847660).

Two real defects shipped in the original pair of PRs. This PR fixes both in one combined change.

## What was broken

### Issue A: watchdog regex never matched the real Claude prompt

Current Claude Code wording is:

> `Quick safety check: Is this a project you created or one you trust?`

The previous regex `Is this a project you trust|Accessing workspace:.*trust` failed on both alternatives:

- First alternative fails because the words "created or one you" sit between "you" and "trust"
- Second alternative fails because `grep` is line-based and the two anchor phrases land on separate lines

Detection was silently saved by the generic-TUI-menu fallback rule, but the trust-specific diagnostic log line was dead code. The "run bootstrap-customer-scripts.sh to pre-seed trust" hint never printed.

### Issue B: recovery path infinite-looped on trust-wipe

I claimed in the PR #23 description that "the restart re-pre-seeds the trust entry (with #22)." Wrong. The pre-seed lived only inside `bootstrap-customer-scripts.sh`. The watchdog calls the restart script, NOT bootstrap. So on trust-wipe:

```
watchdog detects parked prompt
  → runs restart script
  → claude re-parks (trust entry still missing)
  → next watchdog tick: detect → restart → re-park
  → ~30-min infinite loop with no actual recovery
```

This is the worse of the two bugs - the watchdog rule was created specifically to recover this scenario and it couldn't.

## What this PR changes

1. **New helper:** `chassis/scripts/preseed-claude-trust.sh`. Extracted from the inline implementation in `bootstrap-customer-scripts.sh`. Idempotent, takes the target dir as arg. Handles missing / invalid-JSON / pre-existing `~/.claude.json` cases (same edge-case surface as the inline version it replaces).
2. **bootstrap calls the helper** instead of carrying inline logic. Behaviorally identical for new installs; ~85 fewer lines in the bootstrap script.
3. **`restart-discord.sh.template` calls the helper** before launching claude. Every restart is now self-healing for trust state - trust-wipe no longer infinite-loops.
4. **Watchdog regex broadened** to `Quick safety check|trust this folder|Is this a project you`. Matches the current prompt + plausible Anthropic rewordings, no false positives on normal log lines.

## Verification

```
--- helper script syntax + all edge cases (no file, valid JSON, invalid JSON, idempotent rerun) ---
all pass ✓

--- regex against real Claude prompt text ---
"Quick safety check: Is this a project you created or one you trust?"
→ DETECTED ✓

--- regex against old shorter prompt text (regression check) ---
"Is this a project you trust?"
→ DETECTED ✓

--- false-positive check: normal log line ---
"[2026-06-09 11:00] Listening for channel messages from: plugin:discord"
→ NO MATCH ✓

--- rendered restart script ---
Bootstrap renders the helper call into restart-${BOT_NAME}-discord.sh
with correct absolute paths.
```

## Operator action after merge

Re-run `bash chassis/scripts/bootstrap-customer-scripts.sh` on existing installs to re-render `restart-${BOT_NAME}-discord.sh` with the new pre-seed call. Without this, existing rendered scripts will still skip the pre-seed and remain vulnerable to trust-wipe infinite-loops (though new installs get the fix automatically via fresh render).

## Test plan

- [ ] @tobyzn re-runs the same trust-wipe test on `asimov` that exposed Issue B in #23. Expect: watchdog detects, runs restart, restart re-seeds trust, claude launches successfully, no infinite loop.
- [ ] Jax re-renders on his install (`cd ~/behalfbot && git pull && bash chassis/scripts/bootstrap-customer-scripts.sh`) and verifies watchdog log shows "Folder-trust prompt detected" message (not the generic-menu one) if the prompt ever fires.
- [ ] Verify the helper exits non-zero on invalid JSON (refuses to clobber) - already covered by syntax test above but worth a real test on a corrupted prod-shape config.

## Credit

@tobyzn caught both bugs in a single test pass on his `asimov` install - the kind of review that saves prod outages. Thank you.

Refs #21, #22, #23.
