### PR TITLE
feat(chassis): launchd-watchdog-health gather + alert prompt

### DIFF
--- a/chassis/scheduled-tasks/launchd-watchdog-health-prompt.md
+++ b/chassis/scheduled-tasks/launchd-watchdog-health-prompt.md
@@ -1,0 +1,46 @@
+# Launchd watchdog health alert
+
+A critical LaunchAgent (one of the install's persistent watchdogs / daemons) is no longer loaded into `gui/$UID`. This blocks any work that agent does silently until manually re-bootstrapped. Without this heartbeat the gap is invisible — the absence of a heartbeat-issuing agent is invisible to its own heartbeat.
+
+You will receive the missing agent labels in the gather output (JSON `{"count": N, "missing": [...]}`).
+
+For each missing agent:
+
+1. **Verify the plist exists** at `~/Library/LaunchAgents/<label>.plist`. If not, the agent was intentionally removed — drop it from the `CHASSIS_WATCHDOG_CRITICAL_AGENTS` list (see `chassis.config.yaml > modules.watchdog_health.critical_agents` or the equivalent env-var declaration) and skip.
+
+2. **Try a re-bootstrap:**
+
+   ```
+   launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/<label>.plist
+   launchctl print "gui/$(id -u)/<label>" | head -10
+   ```
+
+   If `state = running` or `xpcproxy` and `last exit code` is reasonable, the fix held.
+
+3. **If it crash-loops** (last exit code nonzero, throttled state), check the stderr log path declared in the plist. Common causes: stale paths from a repo move, missing env vars, the executable not found.
+
+4. **Post a one-line summary** to the install's ops channel: which agents went missing, what you did, whether they're back. Include the per-agent stderr tail if any are still down. Do NOT spam the channel for healthy ticks — the threshold condition only fires this prompt when something is wrong.
+
+5. **If the agent silently unloaded without leaving an exit code or log entry**, that's a system-level signal (the user rebooted, the user-session got cycled). Log the event but no fix is needed beyond the bootstrap above.
+
+Do not mark the work done until `launchctl print gui/$(id -u)/<label>` returns successfully for every previously-missing agent.
+
+## Heartbeat registration
+
+To enable this heartbeat in an install, add to `${CUSTOMER_HOME}/HEARTBEATS.md`:
+
+```yaml
+## launchd-watchdog-health
+
+```yaml
+schedule: every 30m
+gather: ${CHASSIS_HOME}/chassis/scripts/gather-launchd-watchdog-health.sh
+condition: threshold count > 0
+prompt: ${CHASSIS_HOME}/chassis/scheduled-tasks/launchd-watchdog-health-prompt.md
+model: sonnet
+budget: 1
+criticality: critical
+```
+```
+
+Populate the critical-agent list via `CHASSIS_WATCHDOG_CRITICAL_AGENTS` in the install's environment (comma- or newline-separated labels).

--- a/chassis/scripts/gather-launchd-watchdog-health.sh
+++ b/chassis/scripts/gather-launchd-watchdog-health.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# gather-launchd-watchdog-health.sh - verify critical LaunchAgents are loaded.
+#
+# Returns JSON with a count of missing critical agents and the list of
+# missing Labels. The threshold-condition fires when count > 0, prompting
+# the installer's agent to investigate and re-bootstrap.
+#
+# Background: an installer's persistent watchdogs / daemons can silently
+# unload from `launchctl` after a session cycle, reboot, or stale
+# subprocess teardown. There's no native signal — the agent is just gone.
+# This gather catches that class of failure by polling
+# `launchctl print gui/$UID/<label>` for each agent in a configured list.
+#
+# Configuration:
+#   CHASSIS_WATCHDOG_CRITICAL_AGENTS  Comma- or newline-separated list of
+#                                     LaunchAgent labels to monitor. If
+#                                     unset or empty, this gather emits
+#                                     count=0 and no-ops — installers
+#                                     opt in by populating the list.
+#
+#                                     Example:
+#                                     export CHASSIS_WATCHDOG_CRITICAL_AGENTS="\
+#                                     com.acme.heartbeat-reconciler,\
+#                                     com.acme.briefing-server"
+#
+# This script is macOS-only. Linux/systemd installs need a parallel
+# `gather-systemd-watchdog-health.sh` that polls
+# `systemctl --user is-active <unit>` instead.
+#
+# V1 reference: <v1-reference-install> `scripts/gather-launchd-watchdog-health.sh`.
+
+set -euo pipefail
+
+# Normalize agent list: accept comma OR newline separation, strip blanks.
+RAW="${CHASSIS_WATCHDOG_CRITICAL_AGENTS:-}"
+if [[ -z "${RAW// }" ]]; then
+  printf '{"count": 0, "missing": []}\n'
+  exit 0
+fi
+
+# Replace commas with newlines, then iterate.
+AGENTS=()
+while IFS= read -r line; do
+  line="${line## }"
+  line="${line%% }"
+  [[ -n "$line" ]] && AGENTS+=("$line")
+done <<< "${RAW//,/$'\n'}"
+
+if (( ${#AGENTS[@]} == 0 )); then
+  printf '{"count": 0, "missing": []}\n'
+  exit 0
+fi
+
+UID_VAL="$(id -u)"
+MISSING=()
+
+for agent in "${AGENTS[@]}"; do
+  if ! launchctl print "gui/${UID_VAL}/${agent}" >/dev/null 2>&1; then
+    MISSING+=("$agent")
+  fi
+done
+
+COUNT=${#MISSING[@]}
+
+if (( COUNT > 0 )); then
+  printf '{"count": %d, "missing": [%s]}\n' \
+    "$COUNT" \
+    "$(printf '"%s",' "${MISSING[@]}" | sed 's/,$//')"
+else
+  printf '{"count": 0, "missing": []}\n'
+fi


### PR DESCRIPTION
## Summary
Ships a chassis gather + prompt for monitoring the load state of an install's critical LaunchAgents. Catches the silent-unload failure mode that's invisible to every other heartbeat — when an install's watchdog itself stops running, every heartbeat downstream of it stops too, and nothing alerts.

## Why
V1 reference incident (2026-06-17): the dating-emulator-recovery loop had been silently dormant for 8 days because the customer-side LaunchAgent that drove it had unloaded after a session cycle. Every other heartbeat was fine. The class was invisible until a dating subagent hit a wedged AVD with no recovery hook coming.

The absence of a heartbeat-issuing agent is invisible to its own heartbeat. Hence: a meta-watchdog.

## Components
- **`chassis/scripts/gather-launchd-watchdog-health.sh`** — reads the critical-agent list from `CHASSIS_WATCHDOG_CRITICAL_AGENTS` (comma- or newline-separated), polls `launchctl print gui/\$UID/<label>` for each, emits `{"count": N, "missing": [...]}`. Empty list when unconfigured (the heartbeat is opt-in: installs that haven't populated the list get a clean no-op).
- **`chassis/scheduled-tasks/launchd-watchdog-health-prompt.md`** — the playbook the install's agent follows on alert: verify the plist exists, try `launchctl bootstrap`, check stderr if it crash-loops, drop the agent from the list if intentionally removed, post a one-line summary to ops.

## Wire-up
Per chassis convention (anti-pattern #17), the heartbeat YAML is NOT registered in `HEARTBEATS.md.template` (template ships with no active heartbeats). The prompt contains a copy-paste YAML block that installers add to their own `\${CUSTOMER_HOME}/HEARTBEATS.md`.

## Platform note
macOS-only. Linux/systemd installs need a parallel `gather-systemd-watchdog-health.sh` that polls `systemctl --user is-active <unit>` — left as a follow-up.

## Test plan
- [x] Empty list: `bash gather-launchd-watchdog-health.sh` → `{"count": 0, "missing": []}`.
- [x] With list (one fake + one real label): `CHASSIS_WATCHDOG_CRITICAL_AGENTS="com.fake.agent,com.jax.hinge-emulator" bash gather-launchd-watchdog-health.sh` → `{"count": 1, "missing": ["com.fake.agent"]}`.
- [ ] Live on an install with the heartbeat wired in.

V1 reference PR: scrollinondubs/new-jaxity#184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)