### PR TITLE
fix(chassis#28): implement hydrate_mcp_json, drop TODO stub

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -310,30 +310,58 @@ validate_install_artifacts() {
 hydrate_mcp_json() {
     step "5/14" "Hydrate .mcp.json from template"
 
-    log "TODO: jq-based template-substitution from .mcp.json.template"
-    log "  - Read chassis.config.yaml.modules.* flags"
-    log "  - Filter .mcp.json.template entries by _enable_when matching active modules"
-    log "  - Substitute <PLACEHOLDER> values from .env"
-    log "  - Write hydrated .mcp.json (gitignored)"
-    log ""
-    log "Reference: docs/mcp-setup.md"
-
-    # chassis#5 item 6: until the full hydration step lands, guarantee that
-    # ${CUSTOMER_HOME}/.mcp.json exists with an empty mcpServers object so the
-    # heartbeat dispatcher's `claude -p --mcp-config ...` invocation does not
-    # crash on a fresh or post-migration install. The dispatcher has a defense-
-    # in-depth absence guard too; this ensures the canonical path always exists.
+    local template="$CHASSIS_HOME/chassis/.mcp.json.template"
+    local hydrator="$CHASSIS_HOME/chassis/scripts/hydrate-mcp-json.py"
+    local config="$CUSTOMER_HOME/chassis.config.yaml"
+    local env_file="$CUSTOMER_HOME/.env"
     local mcp_file="$CUSTOMER_HOME/.mcp.json"
-    if [[ ! -f "$mcp_file" ]]; then
-        if [[ "$DRY_RUN" == "true" ]]; then
-            log "  [dry-run] would create $mcp_file with empty mcpServers"
-        else
-            printf '%s\n' '{"mcpServers": {}}' > "$mcp_file"
-            log "  ✓ wrote empty $mcp_file (placeholder until hydration TODO lands)"
-        fi
-    else
-        log "  $mcp_file exists, leaving untouched"
+
+    if [[ ! -f "$template" ]]; then
+        log "  ERROR: $template missing - chassis install incomplete"
+        return 1
     fi
+    if [[ ! -x "$hydrator" ]]; then
+        log "  ERROR: $hydrator missing or not executable"
+        return 1
+    fi
+    if [[ ! -f "$config" ]]; then
+        log "  WARN: $config missing - falling back to empty mcpServers"
+        log "        Bootstrap should have produced chassis.config.yaml in an"
+        log "        earlier step. Investigate before depending on MCP servers."
+        if [[ "$DRY_RUN" != "true" ]] && [[ ! -f "$mcp_file" ]]; then
+            printf '%s\n' '{"mcpServers": {}}' > "$mcp_file"
+        fi
+        return 0
+    fi
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log "  [dry-run] would run: $hydrator --config $config --template $template --env $env_file --output $mcp_file"
+        return 0
+    fi
+
+    # Hydrate. The script exits 2 when placeholders are unresolved; that's a
+    # warn-but-not-fatal condition (the .mcp.json is still written, with the
+    # offending <TOKEN> values left in place for the installer to fill).
+    local hydrate_rc=0
+    local env_arg=()
+    [[ -f "$env_file" ]] && env_arg=(--env "$env_file")
+    python3 "$hydrator" --config "$config" --template "$template" \
+        "${env_arg[@]}" --output "$mcp_file" 2>&1 | tee -a "$TRANSCRIPT" || hydrate_rc=$?
+
+    case "$hydrate_rc" in
+        0)
+            log "  ✓ hydrated $mcp_file"
+            ;;
+        2)
+            log "  ⚠ hydrated $mcp_file with unresolved <PLACEHOLDER> tokens"
+            log "    Inspect the warnings above and update .env. Re-run bootstrap"
+            log "    (or this step) to finalize."
+            ;;
+        *)
+            log "  ERROR: hydrate-mcp-json.py exited $hydrate_rc - $mcp_file may be incomplete"
+            return 1
+            ;;
+    esac
 }
 
 hydrate_claude_md() {

--- a/chassis/scripts/hydrate-mcp-json.py
+++ b/chassis/scripts/hydrate-mcp-json.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""hydrate-mcp-json.py - Build customer .mcp.json from template + chassis config + .env.
+
+Replaces the bootstrap.sh `hydrate_mcp_json()` TODO stub.
+
+Algorithm:
+1. Load chassis.config.yaml (resolved customer-side path passed in).
+2. Load .mcp.json.template (chassis-side path passed in).
+3. Load .env (customer-side, optional) for placeholder substitution.
+4. For each mcpServers entry:
+   - Skip entries whose key starts with '_' (template-only dividers).
+   - If entry has `_enable_when`, evaluate the predicate against the config;
+     drop the entry if false.
+   - Strip all keys starting with '_' from the kept entry.
+   - Substitute <PLACEHOLDER> tokens in string values from .env (or env vars).
+     Tokens whose substitution value is missing are LEFT IN PLACE - bootstrap
+     should warn loud but not silently emit a broken config.
+5. Write hydrated JSON to the output path.
+
+Usage:
+    python3 hydrate-mcp-json.py \\
+        --config /path/to/chassis.config.yaml \\
+        --template /path/to/.mcp.json.template \\
+        --env /path/to/.env \\
+        --output /path/to/.mcp.json [--dry-run]
+
+Exit codes:
+    0 - hydrated successfully
+    1 - bad input (file missing, malformed YAML/JSON)
+    2 - unresolved placeholders detected (file still written; bootstrap should warn)
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+
+def load_yaml(path):
+    try:
+        import yaml
+    except ImportError:
+        print(f'ERROR: PyYAML not installed. apt-get install python3-yaml '
+              f'OR pip install pyyaml', file=sys.stderr)
+        sys.exit(1)
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+def load_json(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def load_env(path):
+    """Parse a .env file into a dict. Tolerates `export FOO=bar`, comments,
+    quoted values. Empty values become ''."""
+    env = {}
+    if not path or not os.path.exists(path):
+        return env
+    with open(path) as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith('#'):
+                continue
+            if line.startswith('export '):
+                line = line[len('export '):]
+            if '=' not in line:
+                continue
+            key, _, value = line.partition('=')
+            key = key.strip()
+            value = value.strip()
+            if (value.startswith('"') and value.endswith('"')) or \
+               (value.startswith("'") and value.endswith("'")):
+                value = value[1:-1]
+            env[key] = value
+    return env
+
+
+def resolve_path(config, dotted):
+    """Resolve a dotted path like 'chassis.config.yaml.modules.research.brave'
+    against the loaded config. Strips the `chassis.config.yaml.` prefix.
+
+    Returns None if any segment is missing. Returns the leaf value otherwise.
+    """
+    if dotted.startswith('chassis.config.yaml.'):
+        dotted = dotted[len('chassis.config.yaml.'):]
+    cur = config
+    for segment in dotted.split('.'):
+        if isinstance(cur, dict) and segment in cur:
+            cur = cur[segment]
+        else:
+            return None
+    return cur
+
+
+_LITERAL_PAT = re.compile(r"""
+    ^                                # start
+    (?:
+        (?P<bool>true|false)         # boolean literal
+        | '(?P<sq>[^']*)'            # single-quoted string
+        | "(?P<dq>[^"]*)"            # double-quoted string
+        | (?P<bare>[\w\-]+)          # bareword (number-ish, identifier)
+    )
+    $                                # end
+""", re.VERBOSE)
+
+
+def parse_literal(token):
+    """Parse a literal token from an `_enable_when` RHS.
+
+    Returns (kind, value):
+        kind ∈ {'bool', 'str', 'bare'}
+        value is the parsed Python value.
+    """
+    m = _LITERAL_PAT.match(token.strip())
+    if not m:
+        return None
+    if m.group('bool'):
+        return ('bool', m.group('bool') == 'true')
+    if m.group('sq') is not None:
+        return ('str', m.group('sq'))
+    if m.group('dq') is not None:
+        return ('str', m.group('dq'))
+    if m.group('bare'):
+        return ('bare', m.group('bare'))
+    return None
+
+
+def evaluate_enable_when(predicate, config):
+    """Evaluate a simple `<dotted.path> == <literal>` predicate.
+
+    Returns True if the LHS resolves and equals the literal, False otherwise.
+    Conservatively returns False on any unrecognized predicate shape - we
+    prefer dropping an entry over emitting a broken one when the predicate
+    cannot be parsed.
+    """
+    if '==' not in predicate:
+        return False
+    lhs, _, rhs = predicate.partition('==')
+    actual = resolve_path(config, lhs.strip())
+    parsed = parse_literal(rhs)
+    if parsed is None:
+        return False
+    _, expected = parsed
+    return actual == expected
+
+
+_PLACEHOLDER_PAT = re.compile(r'<([A-Z_][A-Z0-9_]*)>')
+
+
+def substitute_placeholders(value, env, unresolved):
+    """Replace <PLACEHOLDER> tokens with env values. Records unresolved tokens."""
+    if isinstance(value, str):
+        def repl(match):
+            key = match.group(1)
+            if key in env:
+                return env[key]
+            if key in os.environ:
+                return os.environ[key]
+            unresolved.add(key)
+            return match.group(0)  # leave as-is
+        return _PLACEHOLDER_PAT.sub(repl, value)
+    if isinstance(value, list):
+        return [substitute_placeholders(v, env, unresolved) for v in value]
+    if isinstance(value, dict):
+        return {k: substitute_placeholders(v, env, unresolved)
+                for k, v in value.items()}
+    return value
+
+
+def strip_meta_keys(entry):
+    """Drop keys starting with `_` from a dict (template-only metadata)."""
+    return {k: v for k, v in entry.items() if not k.startswith('_')}
+
+
+def hydrate(config, template, env):
+    """Build the hydrated mcpServers dict and return (output, unresolved)."""
+    unresolved = set()
+    out = {}
+    servers = template.get('mcpServers', {})
+    for name, entry in servers.items():
+        if name.startswith('_'):
+            continue  # divider/placeholder entry
+        if not isinstance(entry, dict):
+            continue
+        predicate = entry.get('_enable_when')
+        if predicate is not None:
+            if not evaluate_enable_when(predicate, config):
+                continue
+        stripped = strip_meta_keys(entry)
+        substituted = substitute_placeholders(stripped, env, unresolved)
+        out[name] = substituted
+    return {'mcpServers': out}, unresolved
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument('--config', required=True, help='chassis.config.yaml path')
+    p.add_argument('--template', required=True, help='.mcp.json.template path')
+    p.add_argument('--env', default=None, help='.env path (optional)')
+    p.add_argument('--output', required=True, help='target .mcp.json path')
+    p.add_argument('--dry-run', action='store_true',
+                   help='print hydrated JSON to stdout, do not write')
+    args = p.parse_args()
+
+    for path, label in [(args.config, 'config'), (args.template, 'template')]:
+        if not os.path.exists(path):
+            print(f'ERROR: {label} not found: {path}', file=sys.stderr)
+            sys.exit(1)
+
+    config = load_yaml(args.config)
+    template = load_json(args.template)
+    env = load_env(args.env)
+
+    hydrated, unresolved = hydrate(config, template, env)
+    output_text = json.dumps(hydrated, indent=2)
+
+    if args.dry_run:
+        print(output_text)
+    else:
+        with open(args.output, 'w') as f:
+            f.write(output_text)
+            f.write('\n')
+        print(f'wrote {args.output} '
+              f'({len(hydrated["mcpServers"])} mcpServers)')
+
+    if unresolved:
+        print(f'WARN: unresolved placeholders left in output: '
+              f'{sorted(unresolved)}', file=sys.stderr)
+        print(f'      these are <TOKEN> values not found in --env or os.environ. '
+              f'Fix .env and re-run.', file=sys.stderr)
+        sys.exit(2)
+
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Closes #28.

## Summary
`bootstrap.sh` step 5/14 was a TODO that wrote an empty `{"mcpServers": {}}` to every install. The template at `chassis/.mcp.json.template` is present and well-formed but was never consumed. Effect: every chassis install since this stub landed shipped without MCPs - no memory, no GitHub, no second-brain, nothing.

Surfaced via William Holdeman's amnesiac behalf.bot on 2026-06-20.

## What's in this PR
- `chassis/scripts/hydrate-mcp-json.py` - new hydrator that handles `_enable_when` filters, `_role` / `_install_note` metadata stripping, and `<PLACEHOLDER>` token substitution from `.env`.
- `bootstrap.sh` `hydrate_mcp_json()` rewritten to call the hydrator with proper paths, honour `--dry-run`, and distinguish exit codes (`0` = clean, `2` = unresolved placeholders left in output as warn-not-fatal, other = fatal).

## Smoke test
Against a representative config (`research.brave=true`, `research.tavily=false`, `turso=false`, `amplitude=true`, `remarkable=false`, `bfl.strava_oura_reconcile=false`, `second_brain.backend=siyuan`):

Output contains exactly 7 mcpServers:
- All four default-on (memory, playwright, context7, github) ✓
- siyuan included (matches second_brain.backend) ✓
- notion dropped (predicate fails) ✓
- brave-search + amplitude included (module flags true) ✓
- tavily + turso + remarkable + oura correctly excluded ✓

Token substitution: `<GITHUB_PAT>` → from `.env` ✓ . Missing env values surface as a warning and leave `<TOKEN>` in place for the installer to fill (not silently empty).

## Verification (post-merge)
Bootstrap a fresh install with `chassis.config.yaml` + `.env` populated. Confirm `.mcp.json.mcpServers.memory` exists with a writable `MEMORY_FILE_PATH`. Confirm the `claude` process picks up the memory MCP at startup.

## What this does NOT fix (deferred follow-ups, all under chassis#28 umbrella)
- **Gap 4** (no tmux): `launchctl bootstrap gui/$(id -u) ...` is still a manual final step. Adding it to bootstrap.sh is a separate PR.
- **bootstrap-audit.sh**: post-install verification routine for all 5 gaps - separate PR.
- **chassis.config.yaml schema validation**: still flagged TODO at step 4/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)