### PR TITLE
fix(chassis#28): auto-load LaunchDaemons + bootstrap-audit.sh post-install verification

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -600,39 +600,110 @@ install_os_deps() {
 setup_dispatcher_unit() {
     step "12/14" "Set up dispatcher launchd / systemd unit"
 
-    log "TODO: detect OS (macOS vs Linux) + emit appropriate unit:"
-    log ""
-    log "macOS — chassis ships a plist template at chassis/launchd/"
-    log "  com.behalfbot.heartbeat-dispatcher.plist.template. The earlier"
-    log "  render_customer_scripts step (with --plists) writes the rendered"
-    log "  copy into \$CUSTOMER_HOME/launchd/. From there:"
-    log "    ln -sf \$CUSTOMER_HOME/launchd/com.behalfbot.heartbeat-dispatcher.plist \\"
-    log "         ~/Library/LaunchAgents/"
-    log "    launchctl bootstrap gui/\$(id -u) ~/Library/LaunchAgents/com.behalfbot.heartbeat-dispatcher.plist"
-    log "  Containerized installs do NOT need this plist - docker compose handles cadence."
-    log ""
-    log "Linux — write /etc/systemd/system/behalfbot-heartbeat-dispatcher.{service,timer}"
-    log "  (system-scope, NOT --user, per lesson #26)"
-    log "  service ExecStart sources chassis-env.sh + invokes dispatcher.sh"
-    # installer-1 install lesson (#35): systemd strips PATH — uv and user-local binaries won't resolve
-    # without an explicit Environment= line. Embed:
-    #   Environment=PATH=/home/<user>/.local/bin:/usr/local/bin:/usr/bin:/bin
-    # in the .service file. Without it every heartbeat invoking "uv run" silently fails.
-    log "  IMPORTANT: embed Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin"
-    log "    in the .service file — systemd strips PATH, uv run silently fails without it (#35)"
-    log "  timer OnCalendar=*:0/15 (every 15 min)"
-    log "  Restart=on-failure; ConditionPathExists=\$CUSTOMER_HOME"
-    log ""
-    log "Both: load + enable + start; verify with first-tick log entry"
+    local os
+    os="$(uname -s)"
+
+    if [[ "$os" == "Darwin" ]]; then
+        # On macOS the chassis ships discord-restart + discord-watchdog as
+        # LaunchDaemons (promoted from LaunchAgents in chassis#14). They're
+        # rendered into $CUSTOMER_HOME/launchd/ during step 8 by
+        # bootstrap-customer-scripts.sh. This step copies them into
+        # /Library/LaunchDaemons/ and bootstraps the system domain.
+        #
+        # heartbeat-dispatcher is DEPRECATED in containerized installs
+        # (docker-compose handles cadence) so we skip it by default. Set
+        # BOOTSTRAP_DISPATCHER_LEGACY_PLIST=1 to opt in for bare-metal layouts.
+
+        local daemons=(
+            "com.behalfbot.${BOT_NAME:-bot}-discord-restart"
+            "com.behalfbot.${BOT_NAME:-bot}-discord-watchdog"
+        )
+        if [[ "${BOOTSTRAP_DISPATCHER_LEGACY_PLIST:-0}" == "1" ]]; then
+            daemons+=("com.behalfbot.heartbeat-dispatcher")
+        fi
+
+        local need_sudo=0
+        for label in "${daemons[@]}"; do
+            local src="$CUSTOMER_HOME/launchd/${label}.plist"
+            local dst="/Library/LaunchDaemons/${label}.plist"
+            if [[ ! -f "$src" ]]; then
+                log "  WARN: $src not rendered - skip $label (step 8 may have failed)"
+                continue
+            fi
+            if [[ "$DRY_RUN" == "true" ]]; then
+                log "  [dry-run] would: sudo cp $src $dst"
+                log "  [dry-run] would: sudo launchctl bootout system/$label (if loaded)"
+                log "  [dry-run] would: sudo launchctl bootstrap system $dst"
+                continue
+            fi
+            need_sudo=1
+            log "  Installing LaunchDaemon: $label"
+            sudo cp "$src" "$dst"
+            sudo chown root:wheel "$dst"
+            sudo chmod 644 "$dst"
+            # Bootout first so re-runs replace cleanly; ignore stderr when not loaded.
+            sudo launchctl bootout "system/$label" >/dev/null 2>&1 || true
+            if sudo launchctl bootstrap system "$dst"; then
+                log "    ✓ $label loaded into system domain"
+            else
+                log "    ERROR: bootstrap failed for $label (see launchctl output above)"
+                return 1
+            fi
+        done
+
+        if [[ "$need_sudo" == "0" && "$DRY_RUN" != "true" ]]; then
+            log "  no daemons to install (nothing rendered in $CUSTOMER_HOME/launchd/)"
+        fi
+        return 0
+    fi
+
+    if [[ "$os" == "Linux" ]]; then
+        log "TODO: Linux systemd unit emission not yet implemented"
+        log "  - write /etc/systemd/system/behalfbot-heartbeat-dispatcher.{service,timer}"
+        log "    (system-scope, NOT --user, per lesson #26)"
+        log "  - service ExecStart sources chassis-env.sh + invokes dispatcher.sh"
+        # installer-1 install lesson (#35): systemd strips PATH — uv and user-local binaries won't resolve
+        # without an explicit Environment= line. Embed:
+        #   Environment=PATH=/home/<user>/.local/bin:/usr/local/bin:/usr/bin:/bin
+        # in the .service file. Without it every heartbeat invoking "uv run" silently fails.
+        log "  - embed Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin"
+        log "    in the .service file - systemd strips PATH, uv run silently fails without it (#35)"
+        log "  - timer OnCalendar=*:0/15 (every 15 min)"
+        log "  - Restart=on-failure; ConditionPathExists=\$CUSTOMER_HOME"
+        return 0
+    fi
+
+    log "  WARN: unsupported OS '$os' - skip unit setup"
 }
 
 # ============================================================
 # 12. Smoke tests
 # ============================================================
 
-run_smoke_tests() {
-    step "13/14" "Run smoke tests"
+run_bootstrap_audit() {
+    # Post-install audit. Runs the 5-gap verification routine and surfaces
+    # any silent regression before declaring the install complete.
+    local auditor="$CHASSIS_HOME/chassis/scripts/bootstrap-audit.sh"
+    if [[ ! -x "$auditor" ]]; then
+        log "  WARN: $auditor missing - skipping post-install audit"
+        return 0
+    fi
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log "  [dry-run] would run: CUSTOMER_HOME=$CUSTOMER_HOME BOT_NAME=${BOT_NAME:-bot} bash $auditor"
+        return 0
+    fi
+    # Audit script exits non-zero on failures; surface but don't abort the
+    # bootstrap (the installer should see the report and fix, then re-run).
+    CUSTOMER_HOME="$CUSTOMER_HOME" BOT_NAME="${BOT_NAME:-bot}" \
+        bash "$auditor" 2>&1 | tee -a "$TRANSCRIPT" || true
+}
 
+run_smoke_tests() {
+    step "13/14" "Run smoke tests + post-install audit"
+
+    run_bootstrap_audit
+
+    log ""
     log "TODO: per-plugin smoke checks:"
     log "  - chassis-core: dispatcher fires once + dry-runs every registered heartbeat"
     log "  - github MCP: gh auth status returns agent-side identity"

--- a/chassis/scripts/bootstrap-audit.sh
+++ b/chassis/scripts/bootstrap-audit.sh
@@ -1,0 +1,267 @@
+#!/bin/bash
+# bootstrap-audit.sh - Post-install verification routine.
+#
+# Walks the 5 known install gaps (chassis#28) and reports clean / warn / fail
+# for each. Designed to run at the END of bootstrap.sh AND on a recurring
+# day-7 heartbeat so silent regressions surface.
+#
+# Gap coverage (cross-ref: project_behalfbot_install_gaps_william_2026_06_20.md,
+# project_behalfbot_install_checklist_gaps_2026_06_11.md):
+#
+#   Gap 1 - HEARTBEATS.md is missing an `s3-backup` row.
+#           Discovered on Ben Lakoff's install 2026-06-11. S3 backup runs
+#           once at bootstrap then never again, no alert.
+#   Gap 2 - `git remote -v` returns no customer-owned URL.
+#           Same install. Means customizations only exist on the install
+#           machine - no off-machine push target.
+#   Gap 3 - `.mcp.json.mcpServers.memory` block is missing OR points at a
+#           non-writable MEMORY_FILE_PATH. Surfaced via William Holdeman
+#           2026-06-20 amnesiac-bot incident.
+#   Gap 4 - macOS LaunchDaemons not loaded. discord-restart + discord-watchdog
+#           must be `launchctl print system/com.behalfbot.<name>` OK. Without
+#           the Daemons loaded, the tmux session that backs Discord routing
+#           is never created.
+#   Gap 5 - signup interview depth - NOT covered here (lives in the
+#           behalf.bot website signup flow; this audit is install-side).
+#
+# Exit code: 0 if all checks pass, 1 if any fail. Stdout is human-readable;
+# stderr carries fix-suggestion hints. Designed to be re-run after fixes
+# without state cleanup.
+#
+# Usage:
+#   bash chassis/scripts/bootstrap-audit.sh [--customer-home PATH] [--bot-name NAME]
+#
+# Defaults: CUSTOMER_HOME=~/.behalfbot, BOT_NAME from chassis.config.yaml or 'bot'.
+
+set -uo pipefail  # NOT -e: we want to continue auditing after a failed check
+
+CUSTOMER_HOME="${CUSTOMER_HOME:-${HOME}/.behalfbot}"
+BOT_NAME="${BOT_NAME:-}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --customer-home) CUSTOMER_HOME="$2"; shift 2 ;;
+        --bot-name) BOT_NAME="$2"; shift 2 ;;
+        --help|-h)
+            sed -n '1,40p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "Unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+# Bot name fallback: read from chassis.config.yaml, then bot identity, then 'bot'.
+if [[ -z "$BOT_NAME" ]] && command -v python3 >/dev/null 2>&1; then
+    if [[ -f "$CUSTOMER_HOME/chassis.config.yaml" ]]; then
+        BOT_NAME="$(python3 -c "
+import sys
+try:
+    import yaml
+    with open('$CUSTOMER_HOME/chassis.config.yaml') as f:
+        c = yaml.safe_load(f) or {}
+    n = (c.get('identity', {}).get('assistant', {}).get('name') or '')
+    sys.stdout.write(str(n).lower())
+except Exception:
+    pass
+" 2>/dev/null)"
+    fi
+fi
+[[ -z "$BOT_NAME" ]] && BOT_NAME="bot"
+
+OS="$(uname -s)"
+PASS=0
+WARN=0
+FAIL=0
+
+ok()    { printf '\033[32m  ✓\033[0m %s\n' "$1"; PASS=$((PASS + 1)); }
+warn()  { printf '\033[33m  ⚠\033[0m %s\n' "$1"; WARN=$((WARN + 1)); }
+fail()  { printf '\033[31m  ✗\033[0m %s\n' "$1"; FAIL=$((FAIL + 1)); }
+hint()  { printf '    %s\n' "$1" >&2; }
+group() { printf '\n\033[1m%s\033[0m\n' "$1"; }
+
+# ============================================================
+# Gap 1 - HEARTBEATS.md contains s3-backup row
+# ============================================================
+
+audit_gap_1_backup_heartbeat() {
+    group "Gap 1: HEARTBEATS.md backup row"
+    local hb="$CUSTOMER_HOME/HEARTBEATS.md"
+    if [[ ! -f "$hb" ]]; then
+        fail "HEARTBEATS.md not found at $hb"
+        hint "Bootstrap step 7/14 (initialize_heartbeats) appears to have skipped."
+        hint "Re-run: CUSTOMER_HOME=$CUSTOMER_HOME bash bootstrap.sh"
+        return
+    fi
+    # Accept any heartbeat whose section header or table row contains "backup"
+    # (Sean's install uses siyuan-backup, turso-backup, n8n-backup; Lakoff's
+    # was s3-backup; future installs may use restic-backup, b2-backup, etc.)
+    if grep -qiE '^(## |\| *)[a-z0-9_-]*backup' "$hb"; then
+        local found
+        found="$(grep -ioE '^(## |\| *)[a-z0-9_-]*backup[a-z0-9_-]*' "$hb" | sed -E 's/^(## |\| *)//' | sort -u | tr '\n' ' ')"
+        ok "backup heartbeat(s) present in HEARTBEATS.md: $found"
+    else
+        fail "no backup heartbeat in HEARTBEATS.md"
+        hint "Append a backup row to $hb. Reference row format:"
+        hint "  | s3-backup | daily 04:00 | always | scripts/run-backup.sh | normal |"
+    fi
+}
+
+# ============================================================
+# Gap 2 - git remote points at customer-owned URL
+# ============================================================
+
+audit_gap_2_customer_remote() {
+    group "Gap 2: customer GitHub remote wired"
+    if [[ ! -d "$CUSTOMER_HOME/.git" ]]; then
+        warn "$CUSTOMER_HOME is not a git repo - skip (chassis install may use a different layout)"
+        return
+    fi
+    local origin
+    origin="$(cd "$CUSTOMER_HOME" && git remote get-url origin 2>/dev/null)"
+    if [[ -z "$origin" ]]; then
+        fail "no 'origin' remote configured"
+        hint "Create a private customer repo and wire it as origin. From $CUSTOMER_HOME:"
+        hint "  gh repo create \$USER/behalfbot-\$INSTALLER --private --source=. --remote=origin --push"
+        return
+    fi
+    # 'origin' should be the customer repo, not the chassis upstream. A
+    # separate 'chassis' or 'upstream' remote pointing at scrollinondubs/behalfbot
+    # is fine and expected (used for subtree pulls).
+    if [[ "$origin" == *scrollinondubs/behalfbot.git* ]] || \
+       [[ "$origin" == *scrollinondubs/behalfbot* && "$origin" != *new-jaxity* ]]; then
+        fail "origin points at the chassis template repo (scrollinondubs/behalfbot)"
+        hint "Customer state should NOT push back to chassis. Re-wire origin:"
+        hint "  cd $CUSTOMER_HOME && git remote set-url origin <customer-repo-url>"
+        return
+    fi
+    # Strip embedded auth tokens before printing
+    local clean
+    clean="$(echo "$origin" | sed -E 's|https://[^@]*@|https://|')"
+    ok "origin: $clean"
+}
+
+# ============================================================
+# Gap 3 - .mcp.json has memory server with writable path
+# ============================================================
+
+audit_gap_3_memory_mcp() {
+    group "Gap 3: memory MCP wired with writable path"
+    local mcp="$CUSTOMER_HOME/.mcp.json"
+    if [[ ! -f "$mcp" ]]; then
+        fail ".mcp.json not found at $mcp"
+        hint "Re-run bootstrap step 5/14 (hydrate_mcp_json)."
+        return
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        warn "jq not installed - skipping deep mcp.json check"
+        hint "  brew install jq  (macOS) / apt-get install jq (Linux)"
+        return
+    fi
+    local mem_block
+    mem_block="$(jq -e '.mcpServers.memory' "$mcp" 2>/dev/null)"
+    if [[ -z "$mem_block" || "$mem_block" == "null" ]]; then
+        fail "mcpServers.memory missing from .mcp.json"
+        hint "Hydrator should have written this. Re-run:"
+        hint "  python3 chassis/scripts/hydrate-mcp-json.py --config $CUSTOMER_HOME/chassis.config.yaml \\"
+        hint "    --template chassis/.mcp.json.template --env $CUSTOMER_HOME/.env \\"
+        hint "    --output $mcp"
+        return
+    fi
+    local mem_path
+    mem_path="$(jq -r '.mcpServers.memory.env.MEMORY_FILE_PATH // empty' "$mcp" 2>/dev/null)"
+    if [[ -z "$mem_path" ]]; then
+        fail "mcpServers.memory.env.MEMORY_FILE_PATH not set"
+        return
+    fi
+    # Expand ${CHASSIS_HOME} / ${CUSTOMER_HOME} for the writability check
+    local expanded="$mem_path"
+    expanded="${expanded//\$\{CHASSIS_HOME\}/${CHASSIS_HOME:-${HOME}/behalfbot}}"
+    expanded="${expanded//\$\{CUSTOMER_HOME\}/$CUSTOMER_HOME}"
+    local parent
+    parent="$(dirname "$expanded")"
+    if [[ ! -d "$parent" ]]; then
+        warn "parent dir does not exist: $parent"
+        hint "  mkdir -p \"$parent\""
+        return
+    fi
+    if touch "$expanded" 2>/dev/null; then
+        ok "memory MCP wired; MEMORY_FILE_PATH writable: $expanded"
+    else
+        fail "MEMORY_FILE_PATH not writable: $expanded"
+        hint "  chown \$(whoami) \"$expanded\" (or fix parent permissions)"
+    fi
+}
+
+# ============================================================
+# Gap 4 - LaunchDaemons loaded (macOS) / units loaded (Linux)
+# ============================================================
+
+audit_gap_4_launchd() {
+    group "Gap 4: LaunchDaemon / systemd unit loaded"
+    if [[ "$OS" == "Darwin" ]]; then
+        local labels=(
+            "com.behalfbot.${BOT_NAME}-discord-restart"
+            "com.behalfbot.${BOT_NAME}-discord-watchdog"
+        )
+        for label in "${labels[@]}"; do
+            if launchctl print "system/${label}" >/dev/null 2>&1; then
+                ok "$label loaded (system domain)"
+            elif launchctl print "gui/$(id -u)/${label}" >/dev/null 2>&1; then
+                warn "$label loaded in gui/\$UID instead of system domain"
+                hint "Older install. Promote per chassis#14:"
+                hint "  sudo launchctl bootstrap system /Library/LaunchDaemons/${label}.plist"
+                hint "  launchctl bootout gui/\$(id -u)/${label}"
+            else
+                fail "$label NOT loaded"
+                hint "From $CUSTOMER_HOME:"
+                hint "  sudo cp launchd/${label}.plist /Library/LaunchDaemons/"
+                hint "  sudo launchctl bootstrap system /Library/LaunchDaemons/${label}.plist"
+            fi
+        done
+    elif [[ "$OS" == "Linux" ]]; then
+        # systemd path - not yet implemented in bootstrap; flag as warn
+        warn "Linux systemd audit not implemented yet"
+        hint "Verify manually: systemctl --user status behalfbot-discord-restart.service"
+    else
+        warn "unrecognized OS: $OS - skip"
+    fi
+}
+
+# ============================================================
+# Bonus - tmux session for the bot exists
+# ============================================================
+
+audit_tmux_session() {
+    group "Bonus: tmux session for the bot"
+    if ! command -v tmux >/dev/null 2>&1; then
+        warn "tmux not installed - install with 'brew install tmux' (macOS) or 'apt-get install tmux'"
+        return
+    fi
+    local label="${BOT_NAME}-discord"
+    if tmux has-session -t "$label" 2>/dev/null; then
+        ok "tmux session '$label' is running"
+    else
+        warn "tmux session '$label' not running"
+        hint "Will be created at next discord-restart fire (daily 05:00 + RunAtLoad)."
+        hint "To create now: bash $CUSTOMER_HOME/scripts/restart-${BOT_NAME}-discord.sh"
+    fi
+}
+
+# ============================================================
+# Main
+# ============================================================
+
+main() {
+    printf '\033[1mBootstrap audit\033[0m for %s (bot: %s)\n' "$CUSTOMER_HOME" "$BOT_NAME"
+
+    audit_gap_1_backup_heartbeat
+    audit_gap_2_customer_remote
+    audit_gap_3_memory_mcp
+    audit_gap_4_launchd
+    audit_tmux_session
+
+    printf '\n\033[1mSummary:\033[0m %d passed, %d warned, %d failed\n' "$PASS" "$WARN" "$FAIL"
+    [[ $FAIL -gt 0 ]] && exit 1 || exit 0
+}
+
+main


### PR DESCRIPTION
Second of three PRs covering chassis#28. First was #29 (hydrate_mcp_json).

## What this PR fixes

### Gap 4: LaunchDaemons not auto-loaded
`setup_dispatcher_unit()` previously just PRINTED `launchctl bootstrap ...` for the installer to run manually. Easy to skip - when skipped, discord-restart never fires, the tmux session that backs Discord routing is never created, and the bot is silent. This is what burned William Holdeman.

Now: detect macOS, copy rendered plists from `$CUSTOMER_HOME/launchd/` to `/Library/LaunchDaemons/`, set root:wheel ownership, `sudo launchctl bootstrap system` each plist. Bootout-first pattern makes re-runs replace cleanly.

Daemons handled:
- `com.behalfbot.${BOT_NAME}-discord-restart` (daily 05:00 + RunAtLoad)
- `com.behalfbot.${BOT_NAME}-discord-watchdog` (continuous keepalive)
- `com.behalfbot.heartbeat-dispatcher` (legacy, opt-in via `BOOTSTRAP_DISPATCHER_LEGACY_PLIST=1`; default off because containerized installs use docker-compose for cadence)

Linux still TODO - flagged with existing systemd notes preserved.

Outdated `launchctl bootstrap gui/$(id -u)` instruction removed (stale post-chassis#14 LaunchAgent→LaunchDaemon promotion).

### bootstrap-audit.sh: post-install verification routine
New `chassis/scripts/bootstrap-audit.sh` runs the 5 known install gaps as a single report. Designed to run at the END of bootstrap.sh AND on a recurring day-7 heartbeat (heartbeat registration is a separate PR). Continues after any single check failure so the installer sees the full picture, not just the first thing wrong.

Coverage:
- **Gap 1**: HEARTBEATS.md has a backup heartbeat (broad regex tolerates s3-backup, siyuan-backup, turso-backup, restic-backup, etc.)
- **Gap 2**: `git remote get-url origin` returns a customer URL, not the chassis template. Extra `chassis`/`upstream` remotes tolerated.
- **Gap 3**: `.mcp.json.mcpServers.memory` exists with writable `MEMORY_FILE_PATH`. Expands `${CHASSIS_HOME}`/`${CUSTOMER_HOME}`.
- **Gap 4**: discord-restart + discord-watchdog LaunchDaemons loaded in system domain. Warns and provides migration command if found in the older `gui/$UID` layout.
- **Bonus**: tmux session `${BOT_NAME}-discord` running.

Exit 0 if all pass, 1 if any fail.

`bootstrap.sh` step 13/14 now calls the auditor first. Audit failures surface in the transcript but don't abort the bootstrap - the installer sees the report, fixes, re-runs.

## Smoke test
Against Sean's install (`CUSTOMER_HOME=/Users/jax/.behalfbot BOT_NAME=jax`): 6/6 pass.
- 8 backup heartbeats found
- origin = customer repo
- memory MCP wired + path writable
- both LaunchDaemons loaded
- tmux session `jax-discord` running

## What's still in chassis#28 scope (separate PRs)
- Linux systemd unit emission
- Register `bootstrap-audit` as a recurring heartbeat (day-7 cadence)
- chassis.config.yaml schema validation (still TODO at step 4/14)

## Notes for review
- `sudo` prompts during `setup_dispatcher_unit` - installer interactivity assumed. Non-interactive installs need a separate path (out of scope here).
- Auditor uses ANSI color escapes. If you run it via a hook into a non-color sink, the output is still readable but cluttered with escape sequences. Could add `--no-color` flag in a follow-up if it becomes annoying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)