### PR TITLE
feat(chassis#28): register bootstrap-audit as a weekly heartbeat + BOT_NAME hardening

### DIFF
--- a/chassis/HEARTBEATS.md.template
+++ b/chassis/HEARTBEATS.md.template
@@ -79,6 +79,26 @@ criticality: normal
 
 ---
 
+## bootstrap-audit (chassis-shipped, default-on)
+
+Weekly verification of the five known install gaps (see
+`chassis/scripts/bootstrap-audit.sh`). Silent on a clean install; fires
+Claude only when one or more checks fail. Catches silent regressions -
+e.g. an OS update bootouts a LaunchDaemon, a `.mcp.json` edit drops the
+memory block, the customer remote gets re-pointed.
+
+```yaml
+schedule: weekly sunday 09:00
+gather: ${CHASSIS_HOME}/chassis/scripts/gather-bootstrap-audit.sh
+condition: threshold count > 0
+prompt: ${CHASSIS_HOME}/chassis/scheduled-tasks/bootstrap-audit-prompt.md
+model: sonnet
+budget: 1
+criticality: background
+```
+
+---
+
 ## Active heartbeats
 
 <!--

--- a/chassis/scheduled-tasks/bootstrap-audit-prompt.md
+++ b/chassis/scheduled-tasks/bootstrap-audit-prompt.md
@@ -1,0 +1,35 @@
+# Bootstrap audit triage
+
+The chassis `bootstrap-audit.sh` routine has flagged one or more failing checks on this install. Each failure represents a silent install gap that, left unfixed, will surface later as a behavior bug the installer notices and Jax has to chase down.
+
+## What you have
+
+Read the audit transcript at the path passed in via the gather output (`transcript_path` field). It is the full output of the audit including which gaps failed and the concrete fix commands suggested.
+
+The transcript walks five known install gaps:
+
+1. **HEARTBEATS.md backup row** - a regular backup heartbeat is registered. Failure means scheduled backups aren't firing.
+2. **Customer GitHub remote** - `origin` points at the customer's own private repo, not the chassis template. Failure means changes here only exist on this machine.
+3. **Memory MCP** - the knowledge graph MCP is wired into `.mcp.json` and its `MEMORY_FILE_PATH` is writable. Failure means narrative memory across sessions is broken.
+4. **LaunchDaemons** - `com.behalfbot.<bot>-discord-restart` and `-discord-watchdog` are loaded in the system domain. Failure means the Discord bridge has no persistent `claude` process to route into.
+5. **Tmux session** - the bot's tmux session exists. A failure here is a warning unless paired with a failing LaunchDaemon check (the daemon creates the session at 05:00 + RunAtLoad).
+
+## What to do
+
+1. **Read the transcript file** to see exactly which checks failed and what fix commands the audit suggested.
+2. **Triage by severity.** A missing `origin` or missing backup row is recoverable any time. A non-loaded LaunchDaemon means the bot has been silent on Discord since the failure started - higher priority.
+3. **Propose a fix plan** in a Discord message to `#jax-ops`. Include:
+   - Which gap failed
+   - The fix command from the transcript
+   - Whether you need Sean's `sudo` (LaunchDaemon installs do; backup row does not)
+   - An estimate of any ongoing impact (e.g. "Discord has been routing to a dead session for N days")
+4. **Do not auto-execute** a `sudo` command. Surface for Sean's approval first. Non-sudo fixes (HEARTBEATS.md append, `git remote set-url`) can be done via PR following the normal workflow.
+
+## Important
+
+- The audit ran on a recurring weekly schedule. Same failure two weeks in a row means the first triage didn't stick. Read the prior week's discord message (search `#jax-ops` for `bootstrap-audit`) before suggesting the same fix again.
+- If you can't make sense of a failure, ask Sean in `#jax-ops` rather than guessing. Better to escalate than auto-fix the wrong thing.
+
+## Out of scope
+
+- Implementing missing features the audit doesn't check (e.g. signup interview depth, schema validation). Those are separate workstreams. Stay narrow on the 5 gaps the audit covers.

--- a/chassis/scripts/bootstrap-audit.sh
+++ b/chassis/scripts/bootstrap-audit.sh
@@ -50,10 +50,36 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Bot name fallback: read from chassis.config.yaml, then bot identity, then 'bot'.
-if [[ -z "$BOT_NAME" ]] && command -v python3 >/dev/null 2>&1; then
+# Bot name resolution order:
+#   1. --bot-name flag (already parsed above)
+#   2. $BOT_NAME env var
+#   3. .env file: BOT_NAME=...
+#   4. chassis.config.yaml: identity.assistant.name (lowercased)
+#   5. Loaded LaunchDaemon detection: parse the discord-restart label
+#   6. Literal 'bot' as last-ditch
+resolve_bot_name() {
+    [[ -n "$BOT_NAME" ]] && return 0
+
+    if [[ -f "$CUSTOMER_HOME/.env" ]]; then
+        local val
+        val="$(grep -E '^(export +)?BOT_NAME=' "$CUSTOMER_HOME/.env" 2>/dev/null \
+              | head -1 | sed -E 's/^(export +)?BOT_NAME=//; s/^"(.*)"$/\1/; s/^.(.*).$/\1/' \
+              | head -c 64)"
+        [[ -n "$val" ]] && { BOT_NAME="$val"; return 0; }
+    fi
+
     if [[ -f "$CUSTOMER_HOME/chassis.config.yaml" ]]; then
-        BOT_NAME="$(python3 -c "
+        # Try yq if installed (clean)
+        if command -v yq >/dev/null 2>&1; then
+            local v
+            v="$(yq '.identity.assistant.name // ""' "$CUSTOMER_HOME/chassis.config.yaml" 2>/dev/null \
+                | tr -d '"' | tr '[:upper:]' '[:lower:]')"
+            [[ -n "$v" && "$v" != "null" ]] && { BOT_NAME="$v"; return 0; }
+        fi
+        # Try python+yaml (works if pyyaml installed)
+        if command -v python3 >/dev/null 2>&1; then
+            local v
+            v="$(python3 -c "
 import sys
 try:
     import yaml
@@ -64,9 +90,35 @@ try:
 except Exception:
     pass
 " 2>/dev/null)"
+            [[ -n "$v" ]] && { BOT_NAME="$v"; return 0; }
+        fi
+        # Grep fallback: scrape `name:` line under `assistant:` block. Works for
+        # the standard chassis template indentation; gives up cleanly if not.
+        local v
+        v="$(awk '
+            /^  assistant:/ {in_block=1; next}
+            in_block && /^    name: / {print $2; exit}
+            in_block && /^  [a-z]/ {exit}
+        ' "$CUSTOMER_HOME/chassis.config.yaml" 2>/dev/null | tr -d '"' | tr '[:upper:]' '[:lower:]')"
+        [[ -n "$v" ]] && { BOT_NAME="$v"; return 0; }
     fi
-fi
-[[ -z "$BOT_NAME" ]] && BOT_NAME="bot"
+
+    # Last resort: find a loaded discord-restart daemon and parse the bot name
+    # out of its label. Fragile (only works if step 12 already ran) but useful.
+    if command -v launchctl >/dev/null 2>&1; then
+        local label
+        label="$(launchctl list 2>/dev/null \
+                | awk '$3 ~ /^com\.behalfbot\..*-discord-restart$/ {print $3; exit}')"
+        if [[ -n "$label" ]]; then
+            BOT_NAME="${label#com.behalfbot.}"
+            BOT_NAME="${BOT_NAME%-discord-restart}"
+            return 0
+        fi
+    fi
+
+    BOT_NAME="bot"
+}
+resolve_bot_name
 
 OS="$(uname -s)"
 PASS=0

--- a/chassis/scripts/gather-bootstrap-audit.sh
+++ b/chassis/scripts/gather-bootstrap-audit.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# gather-bootstrap-audit.sh - cheap weekly gate for the bootstrap-audit heartbeat.
+#
+# Runs bootstrap-audit.sh and emits {"count": N} where N is the number of
+# failing checks. Dispatcher threshold of `count > 0` fires Claude to dig in
+# and propose fixes; count == 0 is silent (per `feedback_no_nag_heartbeats`).
+#
+# The audit itself walks the 5 install gaps (HEARTBEATS.md backup row,
+# customer GH remote, memory MCP, LaunchDaemons loaded, tmux session).
+# See chassis/scripts/bootstrap-audit.sh for the full check matrix.
+
+set -uo pipefail
+
+CUSTOMER_HOME="${CUSTOMER_HOME:-${HOME}/.behalfbot}"
+AUDIT_SCRIPT="${CHASSIS_HOME:-${HOME}/behalfbot}/chassis/scripts/bootstrap-audit.sh"
+
+if [[ ! -x "$AUDIT_SCRIPT" ]]; then
+    # No audit script means we can't say anything. Emit count=0 + a note,
+    # so the heartbeat stays silent and the dispatcher doesn't loop on an
+    # error from a missing helper.
+    printf '{"count": 0, "note": "bootstrap-audit.sh not found at %s; cannot gate"}\n' "$AUDIT_SCRIPT"
+    exit 0
+fi
+
+# Strip ANSI colors from audit output (heartbeat artifact + gather output
+# should be plain text so the prompt template can quote it cleanly).
+AUDIT_OUT="$(CUSTOMER_HOME="$CUSTOMER_HOME" bash "$AUDIT_SCRIPT" 2>&1 | sed -E 's/\x1b\[[0-9;]*m//g')"
+
+# Final line is "Summary: N passed, M warned, K failed". Parse K.
+FAILED="$(printf '%s\n' "$AUDIT_OUT" | awk -F'[, ]+' '/^Summary:/ {for(i=1;i<=NF;i++) if($i=="failed") print $(i-1)}' | tail -1)"
+[[ -z "$FAILED" ]] && FAILED=0
+
+# Save the audit transcript to a state file for the prompt to reference
+# without re-running the audit (it's not expensive but consistency matters
+# - same data the threshold gate saw should be the data Claude reads).
+STATE_DIR="${CUSTOMER_HOME}/state/bootstrap-audit"
+mkdir -p "$STATE_DIR"
+printf '%s\n' "$AUDIT_OUT" > "$STATE_DIR/latest.txt"
+
+# Emit JSON for the dispatcher. count == failure count drives the threshold.
+# transcript_path lets the prompt template read the full audit for context.
+printf '{"count": %d, "transcript_path": "%s/latest.txt"}\n' "$FAILED" "$STATE_DIR"


### PR DESCRIPTION
Third PR in the chassis#28 series. With this in place the audit isn't a one-shot at install time, it's a recurring sweep that catches silent regressions between installs (OS update bootouts a daemon, hand-edit drops a `.mcp.json` block, customer remote gets re-pointed, etc).

## Summary

### gather-bootstrap-audit.sh (new)
Cheap gather for the dispatcher. Runs `bootstrap-audit.sh`, strips ANSI color, parses `Summary: ... K failed`, emits `{"count": K, "transcript_path": "..."}`. Silent on `count=0`.

### bootstrap-audit-prompt.md (new)
Triage prompt. Reads cached transcript, categorises by severity (LaunchDaemon high, GH remote low), proposes fix plan to `#jax-ops`, surfaces sudo asks, refuses auto-execute.

### HEARTBEATS.md.template (modified)
Adds bootstrap-audit as the first `default-on` chassis-shipped heartbeat. Weekly Sunday 09:00, sonnet, budget 1, `criticality: background` (skipped in conservation mode by design).

### bootstrap-audit.sh BOT_NAME resolution hardening
Previous version's auto-derive depended on `python3 + pyyaml`. macOS system python doesn't ship pyyaml, so on a fresh Mac install the derive failed silently and audit fell back to literal `bot`, false-failing both LaunchDaemon checks because the actual labels are `com.behalfbot.<botname>-discord-*`.

New resolution order: `--bot-name` flag → `$BOT_NAME` env → `.env` BOT_NAME → `chassis.config.yaml identity.assistant.name` via yq → python+pyyaml → awk grep → loaded LaunchDaemon label parse → `bot`. Each step degrades cleanly.

Verified on Sean's install: now resolves to `jax` via the awk path, audit passes 6/6 (was reporting 2/2 false-fail).

## Smoke test
```
$ CUSTOMER_HOME=/Users/jax/.behalfbot CHASSIS_HOME=/Users/jax/behalfbot \
  bash chassis/scripts/gather-bootstrap-audit.sh
{"count": 0, "transcript_path": "/Users/jax/.behalfbot/state/bootstrap-audit/latest.txt"}
```

`count: 0` → threshold gate closed → dispatcher silent. Exactly what we want.

## chassis#28 status after merge
- ✅ #29: `hydrate_mcp_json` implemented
- ✅ #30: auto-load LaunchDaemons + `bootstrap-audit.sh`
- ✅ this PR: register `bootstrap-audit` as recurring heartbeat
- Out of scope (follow-up issues): Linux systemd, chassis.config.yaml schema validation, behalf.bot website signup interview depth

🤖 Generated with [Claude Code](https://claude.com/claude-code)