### PR TITLE
fix(chassis#33): resolve VERSION relative to script (overlay-mount support)

### DIFF
--- a/chassis/scripts/chassis-update.sh
+++ b/chassis/scripts/chassis-update.sh
@@ -26,7 +26,10 @@ set -uo pipefail
 
 CHASSIS_HOME="${CHASSIS_HOME:?CHASSIS_HOME must be set}"
 CUSTOMER_HOME="${CUSTOMER_HOME:-${HOME}/.behalfbot}"
-LOCAL_VERSION_FILE="${CHASSIS_HOME}/chassis/VERSION"
+# Resolve VERSION relative to this script (works in both vendored-subtree and
+# overlay-mount install layouts; see gather-chassis-update-check.sh header).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL_VERSION_FILE="${SCRIPT_DIR}/../VERSION"
 UPSTREAM_REMOTE_URL="${CHASSIS_UPDATE_REMOTE:-https://github.com/scrollinondubs/behalfbot.git}"
 UPSTREAM_REMOTE_NAME="chassis"
 UPSTREAM_BRANCH="main"

--- a/chassis/scripts/gather-chassis-update-check.sh
+++ b/chassis/scripts/gather-chassis-update-check.sh
@@ -17,7 +17,13 @@ set -uo pipefail
 CHASSIS_HOME="${CHASSIS_HOME:?CHASSIS_HOME must be set}"
 CUSTOMER_HOME="${CUSTOMER_HOME:-${HOME}/.behalfbot}"
 
-LOCAL_VERSION_FILE="${CHASSIS_HOME}/chassis/VERSION"
+# Resolve VERSION + CHANGELOG paths RELATIVE TO THIS SCRIPT, not $CHASSIS_HOME.
+# Survives both install layouts:
+#   - vendored-subtree (chassis lives at ${CHASSIS_HOME}/chassis/)
+#   - overlay-mount (Jax-style #136, chassis lives at ${CHASSIS_HOME}/chassis/chassis/)
+# Either way, this script is at <chassis>/scripts/, so VERSION is at ../VERSION.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL_VERSION_FILE="${SCRIPT_DIR}/../VERSION"
 UPSTREAM_RAW_BASE="${CHASSIS_UPDATE_RAW_BASE:-https://raw.githubusercontent.com/scrollinondubs/behalfbot/main}"
 UPSTREAM_VERSION_URL="${UPSTREAM_RAW_BASE}/chassis/VERSION"
 UPSTREAM_CHANGELOG_URL="${UPSTREAM_RAW_BASE}/chassis/CHANGELOG.md"


### PR DESCRIPTION
Fix surfaced while wiring `chassis-update-check` into Jax's `HEARTBEATS.md` (companion PR in new-jaxity).

## Summary

- `gather-chassis-update-check.sh` and `chassis-update.sh` now read `chassis/VERSION` from a path relative to `$BASH_SOURCE[0]`, not relative to `${CHASSIS_HOME}/chassis/`.
- Survives both install layouts:
  - **vendored-subtree** (Lakoff/Marc/Toby): chassis at `${CHASSIS_HOME}/chassis/`. Both old and new resolution work.
  - **overlay-mount** (Jax #136): chassis at `${CHASSIS_HOME}/chassis/chassis/` (bind-mount of the whole clone). Old resolution silently emitted `local_version_missing`.

## Why this matters

The original gather-check would have shipped with a fail-open bug for Jax's install — every weekly fire would have logged `local_version_missing` and never notified, even when chassis was behind. Lakoff/Marc/Toby installs would have worked fine because of their layout.

## Verification

```sh
$ docker exec -e CHASSIS_HOME=/app/customer -e CUSTOMER_HOME=/app/customer behalfbot \
    bash /app/customer/chassis/chassis/scripts/gather-chassis-update-check.sh

# Before this fix:
{"count": 0, "reason": "local_version_missing"}

# After this fix:
{"count": 0, "reason": "up_to_date"}
```

## Test plan

- [x] Run gather inside Jax's container; verify `up_to_date` (both `current` and `latest` are 0.1.0)
- [ ] Next monday 09:00 fire of `chassis-update-check` heartbeat in Jax's install