### PR TITLE
feat(daily-log): multi-surface gather + prompt restructure (GH viewer + Gmail + SiYuan + Discord postmortems)

### DIFF
--- a/chassis/HEARTBEATS.md.template
+++ b/chassis/HEARTBEATS.md.template
@@ -126,6 +126,37 @@ criticality: background
 
 ---
 
+## daily-log (chassis-shipped gather + prompt template, opt-in)
+
+Nightly synthesis of the day's work across every operational surface Jax
+touched (GitHub / Gmail / SiYuan / Discord postmortems). See
+`chassis/docs/heartbeats/daily-log.md` for the full env var contract and
+setup.
+
+**Customer install steps** (one-time):
+
+1. Copy the prompt template into the customer install:
+   `cp ${CHASSIS_HOME}/chassis/scheduled-tasks/daily-log-prompt.md.template ${CUSTOMER_HOME}/scheduled-tasks/daily-log-prompt.md`
+2. Fill in the four `{{ ... }}` placeholders in the copied prompt
+3. Set env vars in `${CUSTOMER_HOME}/.env`:
+   `DAILY_LOG_GH_USER`, `DAILY_LOG_DISCORD_CHANNEL_ID` (recommended),
+   `DAILY_LOG_GMAIL_IDENTITY`, `DAILY_LOG_SIYUAN_URL`,
+   `DAILY_LOG_EXTRA_METRICS_SCRIPT` (optional)
+4. Uncomment the block below
+
+```yaml
+# schedule: daily 02:00
+# gather: ${CHASSIS_HOME}/chassis/scripts/daily-log-gather.py
+# condition: always
+# prompt: ${CUSTOMER_HOME}/scheduled-tasks/daily-log-prompt.md
+# model: sonnet
+# budget: 2
+# criticality: normal
+# output_validator: true
+```
+
+---
+
 ## Active heartbeats
 
 <!--

--- a/chassis/docs/heartbeats/daily-log.md
+++ b/chassis/docs/heartbeats/daily-log.md
@@ -1,0 +1,195 @@
+# daily-log heartbeat
+
+Nightly synthesis of every operational surface Jax touched over the past 24
+hours. Produces a structured markdown log under SiYuan that the morning
+briefing consumes for context.
+
+Ships in chassis as of PR
+`feat(daily-log): multi-surface gather + prompt restructure`.
+
+## What it does
+
+- Runs nightly at 02:00 (customer install can adjust in HEARTBEATS.md).
+- `chassis/scripts/daily-log-gather.py` pre-fetches the day's activity from
+  four surfaces: GitHub, Gmail, SiYuan, Discord postmortem mining.
+- The dispatcher passes that JSON to
+  `${CUSTOMER_HOME}/scheduled-tasks/daily-log-prompt.md`, which synthesizes
+  the log and writes it to SiYuan under a customer-configured parent block.
+
+## Surfaces scanned
+
+### GitHub (dynamic repo discovery)
+
+Uses `gh api graphql` to list every repo the `DAILY_LOG_GH_USER` viewer has
+push access to, ordered by recent push. Any repo pushed in the last 14
+days gets its PRs + open issues scanned. This is deliberately dynamic:
+on the VCL platform, customers will have students assigning tasks on
+their own repos, and the daily log needs to capture that activity without
+a hardcoded org allowlist.
+
+For each active repo:
+
+- PRs merged / opened / closed-unmerged in the 24h window by
+  `DAILY_LOG_GH_USER`
+- Open issues where Jax has commented (candidate "awaiting input")
+
+### Gmail
+
+Only invoked when `DAILY_LOG_GMAIL_IDENTITY` is set. The current chassis
+gather returns `gmail_scan_deferred: true` because Gmail-API auth is
+customer-side; the prompt performs the actual search via the Gmail MCP
+using the identity as a filter.
+
+### SiYuan
+
+Queries the blocks table via the HTTP API for any doc-type block updated
+inside the 24h window with content length > 200 chars (filters out empty
+auto-created docs). For docs created (not just updated), also pulls the
+first 300 chars of first-paragraph content as a hint for the prompt.
+
+### Discord postmortem mining
+
+Fetches the last 100 messages from `DAILY_LOG_DISCORD_CHANNEL_ID` via the
+Discord HTTP API. Regex-filters bot-authored messages against a fixed
+pattern set that captures Jax's usual postmortem shape:
+
+- `Surprises:` / `Sanity-check priorities:` / `Review priorities:`
+- `deviated from spec` / `didn't work` / `broke because`
+- `Root cause:` / `Gotcha:` / `Learned:`
+
+Each match becomes a `{source, timestamp, excerpt}` object for the prompt
+to turn into `Learnings & Tribal Knowledge` bullets.
+
+## Env var contract
+
+| Var | Required | Purpose |
+|---|---|---|
+| `CHASSIS_HOME` | yes | Customer install root (already set by dispatcher) |
+| `DAILY_LOG_GH_USER` | recommended | GitHub username Jax pushes as (e.g. `jacketyjax`). If unset, GitHub scan is skipped with a warning. |
+| `DAILY_LOG_DISCORD_CHANNEL_ID` | recommended | The `#jax` channel ID for postmortem mining. If unset, Discord scan is skipped. |
+| `DAILY_LOG_GMAIL_IDENTITY` | optional | Gmail address Jax sends from (e.g. `jax@vibecodelisboa.com`). Enables prompt-side Gmail MCP search. |
+| `DAILY_LOG_SIYUAN_URL` | optional | SiYuan HTTP API base URL. Falls back to `SIYUAN_URL`. |
+| `DAILY_LOG_SIYUAN_TOKEN` | optional | SiYuan API token. Falls back to `SIYUAN_TOKEN`. |
+| `DAILY_LOG_EXTRA_METRICS_SCRIPT` | optional | Path to a customer-side executable that emits extra metrics as JSON. Chassis calls it and merges output under `metrics.custom`. |
+| `DISCORD_TOKEN` or `DISCORD_BOT_TOKEN` | needed for Discord | Discord bot token. Either name is accepted. |
+
+Any missing env var degrades gracefully: the corresponding surface is
+skipped, a note is added to `warnings`, and the rest of the gather runs.
+The gather never crashes.
+
+## Customer-install setup
+
+1. Copy the prompt template into the customer install:
+
+   ```bash
+   cp "${CHASSIS_HOME}/chassis/scheduled-tasks/daily-log-prompt.md.template" \
+      "${CUSTOMER_HOME}/scheduled-tasks/daily-log-prompt.md"
+   ```
+
+2. Fill in the four `{{ ... }}` placeholders in the copied prompt:
+
+   - `{{ CUSTOMER_JAX_IDENTITY }}` - `"Sean Tierney's autonomous assistant"`, etc.
+   - `{{ CUSTOMER_ORG_HANDLES }}` - space-separated org/domain handles
+     for the Gmail `in:sent from:` filter
+   - `{{ CUSTOMER_DAILY_LOG_PARENT_ID }}` - SiYuan block ID of the parent
+     doc under which daily logs are written
+   - `{{ CUSTOMER_DAILY_LOG_NOTEBOOK_ID }}` - SiYuan notebook (box) ID
+     hosting that parent
+
+3. Register the heartbeat in `${CUSTOMER_HOME}/HEARTBEATS.md`:
+
+   ```yaml
+   ## daily-log
+
+   schedule: daily 02:00
+   gather: ${CHASSIS_HOME}/chassis/scripts/daily-log-gather.py
+   condition: always
+   prompt: ${CUSTOMER_HOME}/scheduled-tasks/daily-log-prompt.md
+   model: sonnet
+   budget: 2
+   criticality: normal
+   output_validator: true
+   ```
+
+4. Set the env vars in `${CUSTOMER_HOME}/.env` (or the bake step that
+   sources into the dispatcher context):
+
+   ```bash
+   DAILY_LOG_GH_USER=your-gh-username
+   DAILY_LOG_GMAIL_IDENTITY=jax@your-domain.com
+   DAILY_LOG_DISCORD_CHANNEL_ID=1234567890123456789
+   ```
+
+5. Smoke-test the gather standalone:
+
+   ```bash
+   CHASSIS_HOME=$HOME/.behalfbot \
+   DAILY_LOG_GH_USER=your-gh-username \
+     "${CHASSIS_HOME}/chassis/scripts/daily-log-gather.py" --verbose | jq .
+   ```
+
+   Expected: a valid JSON payload with populated `prs_by_repo` and
+   `metrics`, and warnings for whichever surfaces you haven't configured
+   yet.
+
+## Extending metrics per install
+
+`DAILY_LOG_EXTRA_METRICS_SCRIPT` lets you add install-specific metrics
+without touching chassis. The script should emit a single JSON object on
+stdout; chassis merges it under `metrics.custom`.
+
+Example for Sean's install (adds dating funnel + outreach counts):
+
+```bash
+#!/bin/bash
+# scripts/daily-log-extra-metrics.sh
+# Emits Sean-install-specific metrics for the daily-log gather.
+
+set -euo pipefail
+: "${CHASSIS_HOME:?CHASSIS_HOME must be set}"
+
+YESTERDAY=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d)
+
+dating_swipes=$(grep -h '"action":"swipe"' \
+    "${CHASSIS_HOME}/logs/dating/${YESTERDAY}-"*.jsonl 2>/dev/null | wc -l | tr -d ' ')
+outreach_sent=$(sqlite3 "${CHASSIS_HOME}/state/outreach.db" \
+    "SELECT COUNT(*) FROM email_outreach_log WHERE date(sent_at) = '${YESTERDAY}'" \
+    2>/dev/null || echo 0)
+
+jq -n \
+    --argjson swipes "${dating_swipes:-0}" \
+    --argjson outreach "${outreach_sent:-0}" \
+    '{dating_swipes: $swipes, outreach_sent: $outreach}'
+```
+
+Then in `.env`:
+
+```bash
+DAILY_LOG_EXTRA_METRICS_SCRIPT=/Users/jax/.behalfbot/scripts/daily-log-extra-metrics.sh
+```
+
+## Design decisions
+
+- **Dynamic repo discovery** over a static allowlist. Rationale: on the VCL
+  platform, students will start assigning tasks to Jax on their own project
+  repos. Hardcoding the customer's own org would silently drop that
+  activity.
+- **Postmortem mining from Discord** over an every-subagent-writes log
+  pipeline. Rationale: postmortems already surface in `#jax` when Jax
+  reports back on PRs and heartbeats. Adding a parallel log write in every
+  subagent is deferred until that first path proves insufficient.
+- **Reflection header stays even when empty.** Rationale: consistency
+  across daily logs makes the SiYuan tree scannable at a glance. An empty
+  body communicates "nothing to reflect on" more clearly than a missing
+  header.
+- **Gmail scan is deferred to the prompt** for now. The gather returns a
+  flag; the prompt runs the actual Gmail MCP search. Rationale: no
+  chassis-side Gmail auth path exists yet, and adding one requires per-
+  customer OAuth wiring that's out of scope for this PR.
+
+## Related files
+
+- `chassis/scripts/daily-log-gather.py`
+- `chassis/scheduled-tasks/daily-log-prompt.md.template`
+- `chassis/HEARTBEATS.md.template` (documents the recommended wiring)
+- `chassis/scripts/test-daily-log-gather.sh` (smoke test)

--- a/chassis/scheduled-tasks/daily-log-prompt.md.template
+++ b/chassis/scheduled-tasks/daily-log-prompt.md.template
@@ -1,0 +1,206 @@
+# Daily Log Prompt (chassis template)
+
+Chassis-supplied template. Customer install copies this file to
+`${CUSTOMER_HOME}/scheduled-tasks/daily-log-prompt.md` and fills in the
+`{{ ... }}` placeholders. The template variables are:
+
+- `{{ CUSTOMER_JAX_IDENTITY }}` - the customer's Jax identity (e.g.
+  "Sean Tierney's autonomous assistant", "Ben Lakoff's autonomous assistant")
+- `{{ CUSTOMER_ORG_HANDLES }}` - space-separated org handles the customer
+  operates under (e.g. "vibecodelisboa fenerum" or just "kogent")
+- `{{ CUSTOMER_DAILY_LOG_PARENT_ID }}` - SiYuan block ID of the parent doc
+  under which daily logs are written (canonical ID, NOT a name-based path)
+- `{{ CUSTOMER_DAILY_LOG_NOTEBOOK_ID }}` - SiYuan notebook (box) ID hosting
+  the parent
+
+The heartbeat dispatcher fires this nightly at 02:00 after
+`chassis/scripts/daily-log-gather.py` has already collected a full-day JSON
+payload from every operational surface Jax touched. This prompt consumes
+that payload, synthesizes it into a structured log, and writes to SiYuan.
+
+---
+
+You are Jax, {{ CUSTOMER_JAX_IDENTITY }}. Read CLAUDE.md for your full
+operating manual.
+
+Your task: read the gather payload for the day that just ended and write a
+structured daily log entry to SiYuan.
+
+## Step 1: Read the gather payload
+
+The dispatcher passes the JSON output of `chassis/scripts/daily-log-gather.py`
+as the "context" for this prompt. It has this shape:
+
+```json
+{
+  "date": "YYYY-MM-DD",
+  "window": { "since": "...", "until": "..." },
+  "prs_by_repo": {
+    "owner/repo": {
+      "merged": [{ "num": N, "title": "...", "url": "...", "body_excerpt": "..." }],
+      "opened": [ ... ],
+      "closed_unmerged": [ ... ]
+    }
+  },
+  "open_issues_awaiting_input": [
+    { "repo": "...", "num": N, "title": "...", "url": "...", "last_updated": "...", "labels": [...] }
+  ],
+  "operational_email": [
+    { "to": "...", "subject": "...", "excerpt": "...", "date": "..." }
+  ],
+  "gmail_scan_deferred": true|false,
+  "siyuan_activity": [
+    { "id": "...", "hpath": "/...", "len": N, "updated_at": "...", "excerpt": "..." }
+  ],
+  "postmortems": [
+    { "source": "discord msg <id>", "timestamp": "...", "excerpt": "..." }
+  ],
+  "metrics": {
+    "prs_merged": N, "prs_opened": N, "issues_closed": N,
+    "open_issues_awaiting_input": N,
+    "commits_customer_repo": N, "briefings_generated": N,
+    "heartbeat_failures": N, "dating_sessions": N,
+    "custom": { ... }
+  },
+  "warnings": ["strings for any surface that failed gracefully"]
+}
+```
+
+If `gmail_scan_deferred` is `true`, use the Gmail MCP to search sent mail:
+`in:sent from:{{ CUSTOMER_ORG_HANDLES }} newer_than:1d` and merge the
+results into your "Shipped" analysis under the operational bullet block.
+
+If `warnings` is non-empty, note it briefly at the bottom of the Metrics
+section so the operator can see which surfaces silently degraded. Do not
+fail the whole log because a surface was skipped.
+
+## Step 2: Synthesize
+
+From the payload, produce the log. **Groupings and priorities:**
+
+- Group `prs_by_repo` by logical feature shipped, not by repo. If two PRs
+  across two repos are part of the same feature (e.g. chassis PR + customer
+  PR wiring it up), collapse them into one bullet with both links.
+- Skip pure ops noise (heartbeat-fired, spend-rollup, chassis-update-check
+  no-op) unless a failure was material.
+- Extract 3-5 items from `postmortems`. Format each as
+  `{what happened} -> {what we learned}`. If there are zero items, keep
+  the header and leave the body empty.
+- For `siyuan_activity`, note the meaningful writing (not empty auto-created
+  docs, not template stubs). The gather has already filtered by content
+  length > 200 chars, but you should apply editorial judgment: an entity-
+  formation plan is meaningful; a dating profile stub is not.
+
+## Step 3: Write the daily log to SiYuan
+
+Write under the canonical Daily Logs parent - NOT by name match, by exact
+ID. Using a name-based hpath caused a double-parent bug on Sean's install
+2026-04-17/18 where logs landed in the wrong notebook or got a malformed
+sibling created with the parent's ID as its name.
+
+**Canonical Daily Logs parent (customer-install-specific):**
+
+- Notebook (box): `{{ CUSTOMER_DAILY_LOG_NOTEBOOK_ID }}`
+- Parent node ID: `{{ CUSTOMER_DAILY_LOG_PARENT_ID }}`
+
+**Create the doc:**
+
+```
+mcp__siyuan__create_doc(
+  notebook: "{{ CUSTOMER_DAILY_LOG_NOTEBOOK_ID }}",
+  path: "/Daily Logs/YYYY-MM-DD",
+  markdown: "...",
+)
+```
+
+**Mandatory post-create verification** (chassis hardening pattern - after
+`create_doc`, verify with SQL against the SiYuan blocks table):
+
+```sql
+SELECT id, hpath, box
+FROM blocks
+WHERE hpath = '/Daily Logs/YYYY-MM-DD'
+  AND box   = '{{ CUSTOMER_DAILY_LOG_NOTEBOOK_ID }}'
+  AND type  = 'd'
+LIMIT 3
+```
+
+- Zero rows -> the tool call silently failed. Re-attempt once. If still
+  zero, print
+  `ERROR: daily-log doc not created at /Daily Logs/YYYY-MM-DD` to stdout
+  and exit non-zero so the dispatcher raises a Discord alert. Do NOT
+  fabricate a success confirmation.
+- More than one row -> you created a duplicate (or one already existed).
+  Print `WARNING: duplicate detected: [ids]` and stop; do not write again.
+- Exactly one row with matching `box` = `{{ CUSTOMER_DAILY_LOG_NOTEBOOK_ID }}`
+  -> success. Capture the returned block ID and use it in the Step 4 stdout
+  report.
+
+Dispatcher escalates `ERROR:` / `WARNING:` lines via the alerts channel.
+
+## Structure
+
+Use this exact section order and headings. Sections marked `(skip body if
+empty)` keep their `##` header but leave the body blank.
+
+```markdown
+# Daily Log - YYYY-MM-DD
+
+## Shipped
+
+- [Grouped by feature-shipped. Each item: 1-sentence narrative + PR/issue
+  link(s). Include operational bullets: emails sent (from operational_email),
+  SiYuan writing (from siyuan_activity), and any custom-metric-worthy work.]
+
+## Learnings & Tribal Knowledge
+(skip body if empty)
+
+- [3-5 items from postmortems, format: {what happened} -> {what we learned}]
+
+## Open Threads
+(skip body if empty)
+
+- [Dedup'd open_issues_awaiting_input, grouped by repo. Parse titles for
+  T-N days / date references and flag deadlines.]
+
+## Metrics Snapshot
+
+- PRs merged: N
+- PRs opened: N
+- Issues closed: N
+- Open issues awaiting input: N
+- Commits in customer repo: N
+- Briefings generated: N
+- Heartbeat failures: N (list which if any)
+- Dating swipe sessions: N (if the install runs any)
+- [Any custom metrics from metrics.custom, one per line]
+
+_Warnings from gather:_ [only shown if warnings array non-empty; comma-joined]
+
+## Reflection
+(skip body if empty)
+
+- [Read the sections above + postmortems + open threads. Propose 1-3
+  concrete process-improvement ideas. Format:
+  {observation from today's work} -> {proposed change}]
+```
+
+Keep it factual and concise. No filler. Aim for a doc the owner could scan
+in 60 seconds.
+
+**Copy quality rules (chassis-wide):**
+
+- No em dashes. Use " - " (space-dash-space).
+- No AI-writing tells (drop "delve", "leverage", "in the realm of").
+- Direct verbs, active voice, plain nouns.
+
+## Step 4: Output
+
+Log to stdout (the dispatcher captures this):
+
+- Confirm the SiYuan doc path created + block ID
+- List section headings that had non-empty bodies
+- One-line summary of the day (for morning briefing context)
+
+Do NOT post to Discord - this is a silent background task. The morning
+briefing pulls from these logs.

--- a/chassis/scripts/daily-log-gather.py
+++ b/chassis/scripts/daily-log-gather.py
@@ -1,0 +1,658 @@
+#!/usr/bin/env python3
+"""daily-log-gather.py - Multi-surface daily activity gather for the daily-log heartbeat.
+
+Pre-fetches the day's activity across every operational surface the customer's
+Jax touches, then emits a single JSON payload on stdout for the prompt to
+consume. Runs on the host / dispatcher context (not inside Claude), so all
+API access uses env vars + shell tools, never MCP.
+
+Contract (per chassis gather-script template):
+  - stdout: exactly one line of valid parseable JSON (see OUTPUT_SHAPE below)
+  - stderr: debug logging with --verbose
+  - exit 0 on success, even when everything got skipped gracefully
+  - non-zero exit ONLY on invariant violations (e.g. can't emit JSON)
+
+Design goals:
+  1. Repo scope is DYNAMIC: query jacketyjax's viewer graph for every repo
+     with recent activity, not scrollinondubs-only. Rationale: customer
+     installs on the VCL platform will have students assigning tasks to Jax
+     on their own project repos.
+  2. Postmortem source is Discord #jax message mining (regex patterns
+     against bot-authored messages in the last 24h).
+  3. Reflection section is prompt-side; this script only supplies raw
+     material.
+  4. Operational surfaces scanned: GitHub, Gmail, SiYuan, Discord.
+
+Env var contract (chassis is generic; customer install sets these):
+  CHASSIS_HOME                     - customer install root (required)
+  DAILY_LOG_GH_USER                - GitHub username Jax pushes as
+  DAILY_LOG_GMAIL_IDENTITY         - Gmail address Jax sends from
+  DAILY_LOG_DISCORD_CHANNEL_ID     - #jax channel ID for postmortem mining
+  DAILY_LOG_SIYUAN_URL             - SiYuan HTTP API URL (default: $SIYUAN_URL)
+  DAILY_LOG_SIYUAN_TOKEN           - SiYuan API token   (default: $SIYUAN_TOKEN)
+  DAILY_LOG_EXTRA_METRICS_SCRIPT   - path to a customer-side script that emits
+                                     JSON under a `custom` metrics key
+  DISCORD_TOKEN / DISCORD_BOT_TOKEN - Discord bot token (probes both)
+
+Unset env vars degrade gracefully: the corresponding surface is skipped, a
+warning is emitted into the `warnings` array, and the rest of the gather
+proceeds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+# --- Config ---------------------------------------------------------------
+
+
+DEFAULT_LOOKBACK_HOURS = 24
+DEFAULT_REPO_ACTIVITY_DAYS = 14
+DEFAULT_SIYUAN_MIN_CONTENT_LEN = 200
+DEFAULT_SIYUAN_LIMIT = 50
+DEFAULT_DISCORD_MSG_LIMIT = 100
+
+POSTMORTEM_PATTERNS = [
+    r"[Ss]urprises\s*:",
+    r"[Ss]anity-check priorities\s*:",
+    r"[Rr]eview priorities\s*:",
+    r"deviat(ed|ion) from spec",
+    r"didn'?t work",
+    r"did not work",
+    r"broke because",
+    r"[Rr]oot cause\s*:",
+    r"root cause was",
+    r"[Gg]otcha\s*:",
+    r"[Ll]earned\s*:",
+]
+POSTMORTEM_REGEX = re.compile("|".join(POSTMORTEM_PATTERNS))
+
+
+# --- Utilities ------------------------------------------------------------
+
+
+def log(msg: str, *, verbose: bool) -> None:
+    """Debug log to stderr, no-op unless --verbose."""
+    if verbose:
+        print(f"[daily-log-gather] {msg}", file=sys.stderr)
+
+
+def today_yesterday(now: datetime | None = None) -> tuple[str, str, datetime, datetime]:
+    """Return (today_str, yesterday_str, since_dt, until_dt) for the 24h window
+    ending at the given `now` (defaults to real now).
+
+    Chassis convention: the daily log covers the calendar day that just
+    ended. When the script runs at 02:00, "today" = the day just starting,
+    "yesterday" = the day being logged.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    today = now.date()
+    yesterday = today - timedelta(days=1)
+    return (
+        today.isoformat(),
+        yesterday.isoformat(),
+        datetime.combine(yesterday, datetime.min.time(), tzinfo=timezone.utc),
+        datetime.combine(today, datetime.min.time(), tzinfo=timezone.utc),
+    )
+
+
+def have(cmd: str) -> bool:
+    return shutil.which(cmd) is not None
+
+
+def run_json(argv: list[str], *, verbose: bool, timeout: int = 60) -> Any:
+    """Run a subprocess that emits JSON on stdout. Returns parsed JSON or None."""
+    log(f"run: {' '.join(argv)}", verbose=verbose)
+    try:
+        r = subprocess.run(
+            argv, capture_output=True, text=True, timeout=timeout, check=False
+        )
+    except subprocess.TimeoutExpired:
+        log(f"timeout: {' '.join(argv)}", verbose=verbose)
+        return None
+    if r.returncode != 0:
+        log(f"non-zero exit {r.returncode}: {r.stderr.strip()[:400]}", verbose=verbose)
+        return None
+    if not r.stdout.strip():
+        return None
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError as e:
+        log(f"json parse failed: {e}; stdout head: {r.stdout[:200]}", verbose=verbose)
+        return None
+
+
+def run_text(argv: list[str], *, verbose: bool, timeout: int = 60) -> str | None:
+    log(f"run: {' '.join(argv)}", verbose=verbose)
+    try:
+        r = subprocess.run(
+            argv, capture_output=True, text=True, timeout=timeout, check=False
+        )
+    except subprocess.TimeoutExpired:
+        log(f"timeout: {' '.join(argv)}", verbose=verbose)
+        return None
+    if r.returncode != 0:
+        log(f"non-zero exit {r.returncode}: {r.stderr.strip()[:400]}", verbose=verbose)
+        return None
+    return r.stdout
+
+
+# --- GitHub surface -------------------------------------------------------
+
+
+def gather_github(gh_user: str, since: datetime, until: datetime, *, verbose: bool
+                  ) -> tuple[dict[str, dict], list[dict], list[str]]:
+    """Return (prs_by_repo, open_issues_awaiting_input, warnings)."""
+    warnings: list[str] = []
+    prs_by_repo: dict[str, dict] = {}
+    open_issues: list[dict] = []
+
+    if not have("gh"):
+        warnings.append("gh CLI not installed - skipped GitHub scan")
+        return prs_by_repo, open_issues, warnings
+
+    # Step 1: dynamic repo discovery via viewer graphql.
+    activity_cutoff = (until - timedelta(days=DEFAULT_REPO_ACTIVITY_DAYS)).isoformat()
+    query = (
+        "{ viewer { repositories("
+        "first:100, "
+        "affiliations:[OWNER,COLLABORATOR,ORGANIZATION_MEMBER], "
+        "orderBy:{field:PUSHED_AT,direction:DESC}"
+        ") { nodes { nameWithOwner pushedAt } } } }"
+    )
+    graph = run_json(
+        ["gh", "api", "graphql", "-f", f"query={query}"], verbose=verbose, timeout=45
+    )
+    if graph is None:
+        warnings.append("gh graphql viewer query failed - skipped GitHub scan")
+        return prs_by_repo, open_issues, warnings
+
+    try:
+        nodes = graph["data"]["viewer"]["repositories"]["nodes"] or []
+    except (KeyError, TypeError):
+        warnings.append("gh graphql viewer returned unexpected shape - skipped GitHub scan")
+        return prs_by_repo, open_issues, warnings
+
+    active_repos: list[str] = []
+    for node in nodes:
+        name = node.get("nameWithOwner")
+        pushed = node.get("pushedAt")
+        if not name or not pushed:
+            continue
+        if pushed >= activity_cutoff:
+            active_repos.append(name)
+    log(f"active repos found: {len(active_repos)}", verbose=verbose)
+
+    # Step 2: for each active repo, pull PRs authored by gh_user in the window.
+    since_str = since.date().isoformat()
+    until_str = until.date().isoformat()
+    for repo in active_repos:
+        pr_data = run_json(
+            [
+                "gh", "pr", "list",
+                "--repo", repo,
+                "--author", gh_user,
+                "--state", "all",
+                "--search", f"updated:{since_str}..{until_str}",
+                "--json", "number,title,url,state,body,mergedAt,closedAt,createdAt",
+            ],
+            verbose=verbose, timeout=45,
+        )
+        if pr_data is None or not isinstance(pr_data, list) or not pr_data:
+            continue
+        merged, opened, closed_unmerged = [], [], []
+        for pr in pr_data:
+            body = pr.get("body") or ""
+            item = {
+                "num": pr.get("number"),
+                "title": pr.get("title"),
+                "url": pr.get("url"),
+                "body_excerpt": body[:300].strip(),
+            }
+            state = (pr.get("state") or "").upper()
+            merged_at = pr.get("mergedAt")
+            closed_at = pr.get("closedAt")
+            created_at = pr.get("createdAt")
+            if merged_at and since_str <= merged_at[:10] <= until_str:
+                merged.append(item)
+            elif state == "OPEN" and created_at and since_str <= created_at[:10] <= until_str:
+                opened.append(item)
+            elif state == "CLOSED" and closed_at and not merged_at:
+                if since_str <= closed_at[:10] <= until_str:
+                    closed_unmerged.append(item)
+        if merged or opened or closed_unmerged:
+            prs_by_repo[repo] = {
+                "merged": merged,
+                "opened": opened,
+                "closed_unmerged": closed_unmerged,
+            }
+
+        # Step 3: open issues where Jax commented but someone else spoke last,
+        # OR Jax spoke last and is waiting. Best-effort search.
+        issue_data = run_json(
+            [
+                "gh", "issue", "list",
+                "--repo", repo,
+                "--state", "open",
+                "--search", f"commenter:{gh_user}",
+                "--json", "number,title,url,labels,updatedAt,author",
+                "--limit", "30",
+            ],
+            verbose=verbose, timeout=30,
+        )
+        if not issue_data or not isinstance(issue_data, list):
+            continue
+        for issue in issue_data:
+            open_issues.append({
+                "repo": repo,
+                "num": issue.get("number"),
+                "title": issue.get("title"),
+                "url": issue.get("url"),
+                "last_updated": issue.get("updatedAt"),
+                "labels": [lbl.get("name") for lbl in (issue.get("labels") or [])
+                           if isinstance(lbl, dict) and lbl.get("name")],
+            })
+
+    return prs_by_repo, open_issues, warnings
+
+
+# --- Gmail surface --------------------------------------------------------
+
+
+def gather_gmail(identity: str, since: datetime, until: datetime, *, verbose: bool
+                 ) -> tuple[list[dict], bool, list[str]]:
+    """Return (messages, deferred_flag, warnings).
+
+    Gmail MCP tools aren't available in the host shell; the prompt will do
+    the actual retrieval when this returns `deferred=True`. We only try a
+    local `google-api-python-client` path if that lib is installed.
+    """
+    warnings: list[str] = []
+    # Fast-path skip: not installed and no lib available -> defer.
+    try:
+        import googleapiclient.discovery  # noqa: F401
+    except ImportError:
+        return [], True, warnings
+
+    # If we get here, googleapiclient is installed. The customer would need
+    # OAuth creds wired up; that's out-of-scope for chassis. Defer to prompt.
+    log("googleapiclient available but Gmail credential wiring is customer-side; deferring",
+        verbose=verbose)
+    return [], True, warnings
+
+
+# --- SiYuan surface -------------------------------------------------------
+
+
+def siyuan_post(url: str, path: str, token: str | None, payload: dict,
+                *, verbose: bool, timeout: int = 30) -> Any:
+    endpoint = url.rstrip("/") + path
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(endpoint, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    if token:
+        req.add_header("Authorization", f"Token {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as e:
+        log(f"siyuan POST {path} failed: {e}", verbose=verbose)
+        return None
+    except json.JSONDecodeError as e:
+        log(f"siyuan POST {path} bad JSON: {e}", verbose=verbose)
+        return None
+    return data
+
+
+def gather_siyuan(url: str, token: str | None, since: datetime, until: datetime,
+                  *, verbose: bool) -> tuple[list[dict], list[str]]:
+    """Return (activity, warnings). Each activity item = {id, hpath, len, updated_at, excerpt}."""
+    warnings: list[str] = []
+    activity: list[dict] = []
+    since_stamp = since.strftime("%Y%m%d%H%M%S")
+    until_stamp = until.strftime("%Y%m%d%H%M%S")
+    sql = (
+        "SELECT id, hpath, LENGTH(content) as len, updated, created "
+        "FROM blocks "
+        "WHERE type='d' "
+        f"AND updated >= '{since_stamp}' "
+        f"AND updated < '{until_stamp}' "
+        f"AND LENGTH(content) > {DEFAULT_SIYUAN_MIN_CONTENT_LEN} "
+        "ORDER BY updated DESC "
+        f"LIMIT {DEFAULT_SIYUAN_LIMIT}"
+    )
+    resp = siyuan_post(url, "/api/query/sql", token, {"stmt": sql}, verbose=verbose)
+    if resp is None or not isinstance(resp, dict):
+        warnings.append("siyuan SQL query failed - skipped SiYuan scan")
+        return activity, warnings
+    if resp.get("code") not in (0, None):
+        warnings.append(f"siyuan returned code={resp.get('code')} msg={resp.get('msg')}")
+        return activity, warnings
+    rows = resp.get("data") or []
+    for row in rows:
+        block_id = row.get("id")
+        if not block_id:
+            continue
+        item = {
+            "id": block_id,
+            "hpath": row.get("hpath") or "",
+            "len": row.get("len") or 0,
+            "updated_at": row.get("updated") or "",
+            "excerpt": "",
+        }
+        # For docs created (not just updated) today, pull first 300 chars of
+        # content as a hint. Cheap SELECT against blocks.
+        created = row.get("created") or ""
+        if created and created >= since_stamp:
+            excerpt_sql = (
+                "SELECT content FROM blocks "
+                f"WHERE root_id = '{block_id}' AND type = 'p' "
+                "ORDER BY created ASC LIMIT 3"
+            )
+            excerpt_resp = siyuan_post(
+                url, "/api/query/sql", token, {"stmt": excerpt_sql}, verbose=verbose
+            )
+            if isinstance(excerpt_resp, dict) and excerpt_resp.get("code") in (0, None):
+                paras = excerpt_resp.get("data") or []
+                joined = " ".join((p.get("content") or "").strip() for p in paras)
+                item["excerpt"] = joined[:300].strip()
+        activity.append(item)
+    return activity, warnings
+
+
+# --- Discord postmortem mining --------------------------------------------
+
+
+def gather_discord_postmortems(channel_id: str, token: str, since: datetime,
+                               *, verbose: bool) -> tuple[list[dict], list[str]]:
+    """Fetch recent messages from `#jax` and regex-extract postmortem candidates."""
+    warnings: list[str] = []
+    postmortems: list[dict] = []
+    url = (
+        f"https://discord.com/api/v10/channels/{channel_id}/messages"
+        f"?limit={DEFAULT_DISCORD_MSG_LIMIT}"
+    )
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", f"Bot {token}")
+    req.add_header("User-Agent", "chassis-daily-log-gather/1.0")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as e:
+        warnings.append(f"discord fetch failed: {e}")
+        return postmortems, warnings
+    except json.JSONDecodeError as e:
+        warnings.append(f"discord returned bad JSON: {e}")
+        return postmortems, warnings
+
+    if not isinstance(data, list):
+        warnings.append("discord API returned non-list body - skipped postmortem mining")
+        return postmortems, warnings
+
+    since_iso = since.isoformat().replace("+00:00", "")
+    for msg in data:
+        if not isinstance(msg, dict):
+            continue
+        author = msg.get("author") or {}
+        if not author.get("bot"):
+            continue
+        ts = msg.get("timestamp") or ""
+        if ts and ts < since_iso:
+            continue
+        content = msg.get("content") or ""
+        if not content:
+            continue
+        if not POSTMORTEM_REGEX.search(content):
+            continue
+        # Extract 1-3 sentence excerpt around the match.
+        excerpt = content
+        if len(excerpt) > 500:
+            m = POSTMORTEM_REGEX.search(excerpt)
+            if m:
+                start = max(0, m.start() - 150)
+                end = min(len(excerpt), m.end() + 350)
+                excerpt = excerpt[start:end].strip()
+                if start > 0:
+                    excerpt = "..." + excerpt
+                if end < len(content):
+                    excerpt = excerpt + "..."
+        postmortems.append({
+            "source": f"discord msg {msg.get('id')}",
+            "timestamp": ts,
+            "excerpt": excerpt.strip(),
+        })
+    return postmortems, warnings
+
+
+# --- Metrics --------------------------------------------------------------
+
+
+def gather_metrics(chassis_home: Path, prs_by_repo: dict, open_issues: list,
+                   since: datetime, until: datetime, extra_script: str | None,
+                   *, verbose: bool) -> dict:
+    metrics: dict[str, Any] = {}
+
+    # PR counts (deterministic derivation from GH surface).
+    prs_merged = sum(len(v.get("merged", [])) for v in prs_by_repo.values())
+    prs_opened = sum(len(v.get("opened", [])) for v in prs_by_repo.values())
+    issues_closed = sum(len(v.get("closed_unmerged", [])) for v in prs_by_repo.values())
+    metrics["prs_merged"] = prs_merged
+    metrics["prs_opened"] = prs_opened
+    metrics["issues_closed"] = issues_closed
+    metrics["open_issues_awaiting_input"] = len(open_issues)
+
+    today_str = until.date().isoformat()
+    yesterday_str = since.date().isoformat()
+
+    # Commits in the customer install repo.
+    commits = 0
+    if (chassis_home / ".git").exists():
+        out = run_text(
+            [
+                "git", "-C", str(chassis_home), "log", "--oneline",
+                f"--since={yesterday_str} 02:00",
+                f"--until={today_str} 02:00",
+            ],
+            verbose=verbose, timeout=15,
+        )
+        if out:
+            commits = len([ln for ln in out.splitlines() if ln.strip()])
+    metrics["commits_customer_repo"] = commits
+
+    # Briefings generated today.
+    briefings_dir = chassis_home / "briefings"
+    briefings_count = 0
+    if briefings_dir.exists():
+        briefings_count = len(list(briefings_dir.glob(f"{today_str}-*.md")))
+    metrics["briefings_generated"] = briefings_count
+
+    # Heartbeat failures (unique heartbeats with any ERROR/FAIL today).
+    logs_dir = chassis_home / "logs" / "scheduled"
+    heartbeat_failures = 0
+    if logs_dir.exists():
+        failed_names: set[str] = set()
+        pattern = re.compile(r"error|fail", re.IGNORECASE)
+        for log_file in logs_dir.glob(f"{today_str}-*.log"):
+            try:
+                text = log_file.read_text(errors="replace")
+            except OSError:
+                continue
+            if pattern.search(text):
+                # Filename like YYYY-MM-DD-<heartbeat>.log -> extract heartbeat name.
+                stem = log_file.stem
+                parts = stem.split("-", 3)
+                if len(parts) >= 4:
+                    failed_names.add(parts[3])
+                else:
+                    failed_names.add(stem)
+        heartbeat_failures = len(failed_names)
+    metrics["heartbeat_failures"] = heartbeat_failures
+
+    # Dating sessions (customer-install-specific; empty when absent).
+    dating_dir = chassis_home / "logs" / "dating"
+    if dating_dir.exists():
+        metrics["dating_sessions"] = len(list(dating_dir.glob(f"{today_str}-*")))
+    else:
+        metrics["dating_sessions"] = 0
+
+    # Custom metrics from customer-side extension script.
+    if extra_script and Path(extra_script).is_file() and os.access(extra_script, os.X_OK):
+        custom = run_json([extra_script], verbose=verbose, timeout=30)
+        if isinstance(custom, dict):
+            metrics["custom"] = custom
+        else:
+            metrics["custom"] = {"_error": "extra metrics script produced no JSON"}
+    else:
+        metrics["custom"] = {}
+
+    return metrics
+
+
+# --- Main -----------------------------------------------------------------
+
+
+def build_output(now: datetime | None = None, *, verbose: bool = False) -> dict:
+    """Assemble the JSON payload. Never raises; all errors -> warnings."""
+    today, yesterday, since, until = today_yesterday(now)
+    warnings: list[str] = []
+
+    chassis_home_raw = os.environ.get("CHASSIS_HOME", "").strip()
+    if not chassis_home_raw:
+        # Fall back to $HOME/.behalfbot to avoid a hard crash in dev, but
+        # emit a loud warning.
+        chassis_home_raw = str(Path.home() / ".behalfbot")
+        warnings.append("CHASSIS_HOME unset - defaulted to ~/.behalfbot")
+    chassis_home = Path(chassis_home_raw)
+
+    prs_by_repo: dict[str, dict] = {}
+    open_issues: list[dict] = []
+    operational_email: list[dict] = []
+    email_deferred = False
+    siyuan_activity: list[dict] = []
+    postmortems: list[dict] = []
+
+    # GitHub.
+    gh_user = os.environ.get("DAILY_LOG_GH_USER", "").strip()
+    if gh_user:
+        prs_by_repo, open_issues, gh_warn = gather_github(
+            gh_user, since, until, verbose=verbose
+        )
+        warnings.extend(gh_warn)
+    else:
+        warnings.append("DAILY_LOG_GH_USER unset - skipped GitHub scan")
+
+    # Gmail.
+    gmail_identity = os.environ.get("DAILY_LOG_GMAIL_IDENTITY", "").strip()
+    if gmail_identity:
+        operational_email, email_deferred, gmail_warn = gather_gmail(
+            gmail_identity, since, until, verbose=verbose
+        )
+        warnings.extend(gmail_warn)
+    else:
+        warnings.append("DAILY_LOG_GMAIL_IDENTITY unset - skipped Gmail scan")
+
+    # SiYuan.
+    siyuan_url = (os.environ.get("DAILY_LOG_SIYUAN_URL")
+                  or os.environ.get("SIYUAN_URL") or "").strip()
+    siyuan_token = (os.environ.get("DAILY_LOG_SIYUAN_TOKEN")
+                    or os.environ.get("SIYUAN_TOKEN") or "").strip() or None
+    if siyuan_url:
+        siyuan_activity, siyuan_warn = gather_siyuan(
+            siyuan_url, siyuan_token, since, until, verbose=verbose
+        )
+        warnings.extend(siyuan_warn)
+    else:
+        warnings.append("DAILY_LOG_SIYUAN_URL / SIYUAN_URL unset - skipped SiYuan scan")
+
+    # Discord postmortems.
+    channel_id = os.environ.get("DAILY_LOG_DISCORD_CHANNEL_ID", "").strip()
+    discord_token = (os.environ.get("DISCORD_TOKEN")
+                     or os.environ.get("DISCORD_BOT_TOKEN") or "").strip()
+    if channel_id and discord_token:
+        postmortems, discord_warn = gather_discord_postmortems(
+            channel_id, discord_token, since, verbose=verbose
+        )
+        warnings.extend(discord_warn)
+    elif not channel_id:
+        warnings.append("DAILY_LOG_DISCORD_CHANNEL_ID unset - skipped Discord scan")
+    else:
+        warnings.append("DISCORD_TOKEN / DISCORD_BOT_TOKEN unset - skipped Discord scan")
+
+    # Metrics.
+    extra_script = os.environ.get("DAILY_LOG_EXTRA_METRICS_SCRIPT", "").strip() or None
+    metrics = gather_metrics(
+        chassis_home, prs_by_repo, open_issues, since, until, extra_script,
+        verbose=verbose,
+    )
+
+    return {
+        "date": yesterday,
+        "window": {
+            "since": since.isoformat(),
+            "until": until.isoformat(),
+        },
+        "prs_by_repo": prs_by_repo,
+        "open_issues_awaiting_input": open_issues,
+        "operational_email": operational_email,
+        "gmail_scan_deferred": email_deferred,
+        "siyuan_activity": siyuan_activity,
+        "postmortems": postmortems,
+        "metrics": metrics,
+        "warnings": warnings,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--verbose", action="store_true",
+                        help="Log debug info to stderr")
+    parser.add_argument("--now", type=str, default=None,
+                        help="Override current time (ISO 8601, for testing)")
+    args = parser.parse_args()
+
+    now: datetime | None = None
+    if args.now:
+        try:
+            now = datetime.fromisoformat(args.now)
+            if now.tzinfo is None:
+                now = now.replace(tzinfo=timezone.utc)
+        except ValueError as e:
+            print(f"invalid --now: {e}", file=sys.stderr)
+            return 2
+
+    try:
+        payload = build_output(now=now, verbose=args.verbose)
+    except Exception as e:  # noqa: BLE001 - JSON contract is invariant
+        # Even in catastrophic failure emit valid JSON so the dispatcher
+        # doesn't crash on parse.
+        payload = {
+            "date": datetime.now(timezone.utc).date().isoformat(),
+            "prs_by_repo": {},
+            "open_issues_awaiting_input": [],
+            "operational_email": [],
+            "gmail_scan_deferred": False,
+            "siyuan_activity": [],
+            "postmortems": [],
+            "metrics": {},
+            "warnings": [f"gather crashed: {type(e).__name__}: {e}"],
+        }
+
+    print(json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/chassis/scripts/test-daily-log-gather.sh
+++ b/chassis/scripts/test-daily-log-gather.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+# test-daily-log-gather.sh - Smoke test for daily-log-gather.py.
+#
+# Verifies:
+#   1. Runs with no configuration env vars set and emits valid JSON with
+#      all-empty buckets + populated warnings.
+#   2. Individual surfaces can be independently disabled via env var absence.
+#   3. Output is parseable JSON in every scenario.
+#   4. The `warnings` array reports each skipped surface.
+#
+# No real API calls: every scenario runs with the required auth env vars
+# unset, so each surface short-circuits into the "skipped, warning added"
+# path. Chassis test infra intentionally avoids network + credentials.
+#
+# Exit codes:
+#   0 - all scenarios passed
+#   1 - one or more scenarios failed
+#   2 - test harness itself broke (missing python3 / jq)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATHER="${SCRIPT_DIR}/daily-log-gather.py"
+
+fail=0
+pass=0
+
+need() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "test-daily-log-gather: required dep missing: $1" >&2
+        exit 2
+    fi
+}
+need python3
+need jq
+
+if [[ ! -x "$GATHER" ]]; then
+    echo "test-daily-log-gather: gather script not executable at $GATHER" >&2
+    exit 2
+fi
+
+# --- Isolate env: strip every DAILY_LOG_*, SIYUAN_*, DISCORD_* var so each
+# scenario starts from a known baseline. Set CHASSIS_HOME to a tmp dir so
+# there's no accidental customer-repo scan.
+TMPHOME="$(mktemp -d)"
+trap 'rm -rf "$TMPHOME"' EXIT
+
+# Deliberately no `.git` in TMPHOME so metrics.commits_customer_repo = 0.
+
+run_scenario() {
+    local name="$1"
+    shift
+    # env -i wipes the inherited environment, then re-establishes only the
+    # vars we pass explicitly.
+    local out
+    out=$(env -i \
+        PATH="$PATH" \
+        HOME="$HOME" \
+        CHASSIS_HOME="$TMPHOME" \
+        "$@" \
+        python3 "$GATHER" 2>/dev/null)
+    if [[ -z "$out" ]]; then
+        echo "FAIL [$name] gather produced no output"
+        fail=$((fail + 1))
+        return
+    fi
+    if ! echo "$out" | jq . >/dev/null 2>&1; then
+        echo "FAIL [$name] output is not valid JSON"
+        echo "-- output --"
+        echo "$out"
+        fail=$((fail + 1))
+        return
+    fi
+    # Save for scenario-specific assertions.
+    echo "$out" > "$TMPHOME/last-output.json"
+    pass=$((pass + 1))
+}
+
+assert_key() {
+    local name="$1"
+    local key="$2"
+    if ! jq -e "$key" "$TMPHOME/last-output.json" >/dev/null 2>&1; then
+        echo "FAIL [$name] missing key: $key"
+        fail=$((fail + 1))
+        return 1
+    fi
+    return 0
+}
+
+assert_empty_array() {
+    local name="$1"
+    local key="$2"
+    local len
+    len=$(jq -r "$key | length" "$TMPHOME/last-output.json")
+    if [[ "$len" != "0" ]]; then
+        echo "FAIL [$name] expected empty $key, got length $len"
+        fail=$((fail + 1))
+        return 1
+    fi
+    return 0
+}
+
+assert_warning_contains() {
+    local name="$1"
+    local needle="$2"
+    if ! jq -e --arg n "$needle" \
+        '.warnings | map(select(contains($n))) | length > 0' \
+        "$TMPHOME/last-output.json" >/dev/null 2>&1; then
+        echo "FAIL [$name] warnings missing '$needle'"
+        echo "-- warnings --"
+        jq -r '.warnings[]' "$TMPHOME/last-output.json"
+        fail=$((fail + 1))
+        return 1
+    fi
+    return 0
+}
+
+# ------------------------------------------------------------------------
+# Scenario 1: bare invocation, zero env config. Every surface skips with a
+# warning. All buckets empty. Metrics all zeros.
+# ------------------------------------------------------------------------
+run_scenario "bare"
+if [[ -f "$TMPHOME/last-output.json" ]]; then
+    assert_key "bare" ".date"
+    assert_key "bare" ".prs_by_repo"
+    assert_key "bare" ".open_issues_awaiting_input"
+    assert_key "bare" ".operational_email"
+    assert_key "bare" ".siyuan_activity"
+    assert_key "bare" ".postmortems"
+    assert_key "bare" ".metrics"
+    assert_key "bare" ".warnings"
+    assert_empty_array "bare" ".open_issues_awaiting_input"
+    assert_empty_array "bare" ".operational_email"
+    assert_empty_array "bare" ".siyuan_activity"
+    assert_empty_array "bare" ".postmortems"
+    # prs_by_repo is an object; assert it's empty.
+    if [[ "$(jq -r '.prs_by_repo | length' "$TMPHOME/last-output.json")" != "0" ]]; then
+        echo "FAIL [bare] expected empty prs_by_repo"
+        fail=$((fail + 1))
+    fi
+    assert_warning_contains "bare" "DAILY_LOG_GH_USER"
+    assert_warning_contains "bare" "DAILY_LOG_GMAIL_IDENTITY"
+    assert_warning_contains "bare" "DAILY_LOG_SIYUAN_URL"
+    assert_warning_contains "bare" "DAILY_LOG_DISCORD_CHANNEL_ID"
+fi
+
+# ------------------------------------------------------------------------
+# Scenario 2: SIYUAN_URL set but unreachable. Should emit a warning about
+# a failed SQL query, not crash. (Local port that isn't listening.)
+# ------------------------------------------------------------------------
+run_scenario "siyuan-unreachable" \
+    DAILY_LOG_SIYUAN_URL="http://127.0.0.1:1"
+if [[ -f "$TMPHOME/last-output.json" ]]; then
+    # Warning specifically about SiYuan failing (not the "unset" warning).
+    if ! jq -e '.warnings | map(select(contains("siyuan"))) | length > 0' \
+        "$TMPHOME/last-output.json" >/dev/null; then
+        echo "FAIL [siyuan-unreachable] expected a siyuan-related warning"
+        fail=$((fail + 1))
+    fi
+    assert_empty_array "siyuan-unreachable" ".siyuan_activity"
+fi
+
+# ------------------------------------------------------------------------
+# Scenario 3: Discord channel set but token unset. Skips with a "token
+# unset" warning, not a network attempt.
+# ------------------------------------------------------------------------
+run_scenario "discord-no-token" \
+    DAILY_LOG_DISCORD_CHANNEL_ID="1234567890123456789"
+if [[ -f "$TMPHOME/last-output.json" ]]; then
+    assert_warning_contains "discord-no-token" "DISCORD_TOKEN"
+    assert_empty_array "discord-no-token" ".postmortems"
+fi
+
+# ------------------------------------------------------------------------
+# Scenario 4: EXTRA_METRICS_SCRIPT points at a non-existent path. Should
+# treat it as "no custom metrics" and not crash.
+# ------------------------------------------------------------------------
+run_scenario "missing-extra-script" \
+    DAILY_LOG_EXTRA_METRICS_SCRIPT="/nonexistent/path/emit.sh"
+if [[ -f "$TMPHOME/last-output.json" ]]; then
+    # custom should be an empty object (script not invoked).
+    if [[ "$(jq -r '.metrics.custom | length' "$TMPHOME/last-output.json")" != "0" ]]; then
+        echo "FAIL [missing-extra-script] expected empty metrics.custom"
+        fail=$((fail + 1))
+    fi
+fi
+
+# ------------------------------------------------------------------------
+# Scenario 5: valid EXTRA_METRICS_SCRIPT. Chassis calls it and merges output.
+# ------------------------------------------------------------------------
+cat >"$TMPHOME/emit-metrics.sh" <<'EMIT'
+#!/bin/bash
+echo '{"dating_swipes": 12, "outreach_sent": 3}'
+EMIT
+chmod +x "$TMPHOME/emit-metrics.sh"
+run_scenario "valid-extra-script" \
+    DAILY_LOG_EXTRA_METRICS_SCRIPT="$TMPHOME/emit-metrics.sh"
+if [[ -f "$TMPHOME/last-output.json" ]]; then
+    if [[ "$(jq -r '.metrics.custom.dating_swipes' "$TMPHOME/last-output.json")" != "12" ]]; then
+        echo "FAIL [valid-extra-script] expected metrics.custom.dating_swipes=12"
+        fail=$((fail + 1))
+    fi
+    if [[ "$(jq -r '.metrics.custom.outreach_sent' "$TMPHOME/last-output.json")" != "3" ]]; then
+        echo "FAIL [valid-extra-script] expected metrics.custom.outreach_sent=3"
+        fail=$((fail + 1))
+    fi
+fi
+
+# ------------------------------------------------------------------------
+# Scenario 6: --now override produces a stable date.
+# ------------------------------------------------------------------------
+out=$(env -i \
+    PATH="$PATH" \
+    HOME="$HOME" \
+    CHASSIS_HOME="$TMPHOME" \
+    python3 "$GATHER" --now 2026-07-02T02:00:00Z 2>/dev/null)
+if ! echo "$out" | jq . >/dev/null 2>&1; then
+    echo "FAIL [now-override] output not valid JSON"
+    fail=$((fail + 1))
+else
+    date_field=$(echo "$out" | jq -r '.date')
+    if [[ "$date_field" != "2026-07-01" ]]; then
+        echo "FAIL [now-override] expected date=2026-07-01 (yesterday of 2026-07-02), got $date_field"
+        fail=$((fail + 1))
+    else
+        pass=$((pass + 1))
+    fi
+fi
+
+# ------------------------------------------------------------------------
+# Summary
+# ------------------------------------------------------------------------
+echo
+echo "test-daily-log-gather: $pass passed, $fail failed"
+if [[ $fail -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Replaces the earlier shell-based daily-log gather with a Python gather that pre-fetches activity across every operational surface Jax touches and emits a single structured JSON payload for the prompt to synthesize. Ships as chassis-level work per Sean's 2026-07-02 directive: the pattern is generalizable to every install, not just his own.

**Four artifacts:**

- `chassis/scripts/daily-log-gather.py` - multi-surface gather with **dynamic repo discovery** via `gh api graphql` viewer query. No hardcoded org allowlist - captures activity on customer-owned repos and any repo they collaborate on (e.g. student project repos on the VCL platform).
- `chassis/scheduled-tasks/daily-log-prompt.md.template` - prompt template with `{{ CUSTOMER_* }}` placeholders. Restructured sections: **Shipped**, **Learnings & Tribal Knowledge**, **Open Threads**, **Metrics Snapshot**, **Reflection** (header kept even when empty per Sean's spec).
- `chassis/docs/heartbeats/daily-log.md` - full env var contract, per-install setup steps, and DAILY_LOG_EXTRA_METRICS_SCRIPT example for install-specific metrics (dating funnel, outreach counts).
- `chassis/scripts/test-daily-log-gather.sh` - 6 smoke scenarios; no network, no credentials, pure JSON contract validation.

`HEARTBEATS.md.template` gains a commented-out `daily-log` block showing the recommended wiring. The heartbeat itself is opt-in per install.

## Surfaces scanned

| Surface | Mechanism |
|---|---|
| **GitHub** | `gh api graphql` viewer -> all repos pushed in last 14d -> `gh pr list` filtered to `DAILY_LOG_GH_USER` in the 24h window. Also open issues where Jax has commented. |
| **Gmail** | Deferred to prompt (`gmail_scan_deferred: true`); prompt uses Gmail MCP with `in:sent from:{{ CUSTOMER_ORG_HANDLES }}` filter. |
| **SiYuan** | HTTP `/api/query/sql` for doc-type blocks updated in window with content length > 200 chars. For docs also created (not just updated), pulls first 300 chars of paragraph content as excerpt hint. |
| **Discord postmortems** | Fetches last 100 messages from `DAILY_LOG_DISCORD_CHANNEL_ID`, regex-filters bot messages against `Surprises:`, `Sanity-check priorities:`, `Root cause:`, `Gotcha:`, `Learned:`, `deviated from spec`, `didn't work`, `broke because`. |

## Env var contract

Every env var is optional. Missing config degrades to a warning + skip, never a crash. JSON output stays valid even on catastrophic gather failure so the dispatcher parse never breaks.

```
CHASSIS_HOME                     - customer install root (already set by dispatcher)
DAILY_LOG_GH_USER                - GitHub username Jax pushes as
DAILY_LOG_GMAIL_IDENTITY         - Gmail address Jax sends from
DAILY_LOG_DISCORD_CHANNEL_ID     - #jax channel ID for postmortem mining
DAILY_LOG_SIYUAN_URL             - SiYuan HTTP API URL (fallback: SIYUAN_URL)
DAILY_LOG_SIYUAN_TOKEN           - SiYuan API token   (fallback: SIYUAN_TOKEN)
DAILY_LOG_EXTRA_METRICS_SCRIPT   - per-install custom metrics extension
DISCORD_TOKEN | DISCORD_BOT_TOKEN - Discord bot token (probes both)
```

## Deployment note

Each install must set the `DAILY_LOG_*` env vars per the new docs (`chassis/docs/heartbeats/daily-log.md`). Existing installs still running `scripts/daily-log-gather.sh` will get a follow-on customer-repo PR to migrate `HEARTBEATS.md` to point at the chassis paths and to deprecate the shell gather. This PR does not touch any customer install.

## Test plan

- [x] `bash chassis/scripts/test-daily-log-gather.sh` - 6/6 smoke scenarios pass
  - bare invocation emits valid JSON with all-empty buckets + populated warnings
  - each surface can be independently disabled via env var absence
  - unreachable SiYuan (localhost:1) surfaces a `siyuan` warning, no crash
  - missing extra-metrics script leaves `metrics.custom = {}`, no crash
  - valid extra-metrics script gets merged under `metrics.custom`
  - `--now 2026-07-02T02:00:00Z` produces stable `date=2026-07-01`
- [x] End-to-end smoke against real GH (`DAILY_LOG_GH_USER=jacketyjax`): dynamic viewer discovery found 3 active repos, 17 merged PRs, 9 open issues, JSON valid
- [ ] Follow-on customer-repo PR migrates existing `~/.behalfbot` install to the new chassis paths and env vars
- [ ] Ratify with Sean before wiring into any downstream install's HEARTBEATS.md

## Constraints observed

- No em dashes anywhere - `-` (space-dash-space) only
- Chassis code assumes only `CHASSIS_HOME`; no customer-specific install layout
- Every env-var absence is a graceful skip with a warning, never a crash
- JSON output is always valid parseable JSON, even on catastrophic gather failure
- Python 3.9+, stdlib only (subprocess + urllib + json + re + pathlib)
- Shells out to `gh` CLI (already a chassis dep for other heartbeats)

Refs Sean's 2026-07-02 Loom answers documenting the 4 design decisions.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>