### PR TITLE
fix(launchd-watchdog): distinguish unloaded (plist present) from missing (plist gone)

### DIFF
--- a/chassis/scripts/gather-launchd-watchdog-health.sh
+++ b/chassis/scripts/gather-launchd-watchdog-health.sh
@@ -7,9 +7,16 @@
 #
 # Background: an installer's persistent watchdogs / daemons can silently
 # unload from `launchctl` after a session cycle, reboot, or stale
-# subprocess teardown. There's no native signal — the agent is just gone.
+# subprocess teardown. There's no native signal - the agent is just gone.
 # This gather catches that class of failure by polling
 # `launchctl print gui/$UID/<label>` for each agent in a configured list.
+#
+# Distinguishes "plist deleted" (truly missing, alertable) from "plist
+# present but not loaded" (deliberately unloaded by the operator, soft
+# signal). Any installer that keeps on-demand agents in the unloaded
+# state - dating-context, testing, feature-gated automation - would
+# otherwise burn a `claude -p` run + a Discord ping every dispatcher
+# tick until they either reload or remove the plist.
 #
 # Configuration:
 #   CHASSIS_WATCHDOG_CRITICAL_AGENTS  Comma- or newline-separated list of
@@ -52,20 +59,34 @@ if (( ${#AGENTS[@]} == 0 )); then
 fi
 
 UID_VAL="$(id -u)"
+PLIST_DIR="$HOME/Library/LaunchAgents"
 MISSING=()
+UNLOADED=()
 
 for agent in "${AGENTS[@]}"; do
   if ! launchctl print "gui/${UID_VAL}/${agent}" >/dev/null 2>&1; then
-    MISSING+=("$agent")
+    # Symlinks count as present via -e. Only "plist file gone" counts as
+    # MISSING (alertable). "plist present, agent unloaded" surfaces in the
+    # unloaded[] list as a soft signal that doesn't drive count.
+    if [[ -e "$PLIST_DIR/${agent}.plist" ]]; then
+      UNLOADED+=("$agent")
+    else
+      MISSING+=("$agent")
+    fi
   fi
 done
 
 COUNT=${#MISSING[@]}
 
-if (( COUNT > 0 )); then
-  printf '{"count": %d, "missing": [%s]}\n' \
-    "$COUNT" \
-    "$(printf '"%s",' "${MISSING[@]}" | sed 's/,$//')"
-else
-  printf '{"count": 0, "missing": []}\n'
-fi
+join_labels() {
+  if (( $# == 0 )); then
+    echo ""
+  else
+    printf '"%s",' "$@" | sed 's/,$//'
+  fi
+}
+
+printf '{"count": %d, "missing": [%s], "unloaded": [%s]}\n' \
+  "$COUNT" \
+  "$(join_labels "${MISSING[@]+"${MISSING[@]}"}")" \
+  "$(join_labels "${UNLOADED[@]+"${UNLOADED[@]}"}")"


### PR DESCRIPTION
## Summary

Ports the install-side fix from **scrollinondubs/new-jaxity#241** to the chassis. Generically applicable - any installer with intentionally-unloaded LaunchAgents hits the same false positive.

## Root cause

The prior `gather-launchd-watchdog-health.sh` classified any `launchctl print` failure as MISSING, which counts toward the alert threshold. Installers with on-demand LaunchAgents (dating automation, testing daemons, feature-gated helpers, seasonal/manual workflows) live in the unloaded state most of the time and were firing an alert on every dispatcher tick.

## Fix

Check whether the plist file (or symlink) still exists in `~/Library/LaunchAgents`:

- **plist file gone** → `missing` (still increments count, still alerts).
- **plist present but not loaded** → `unloaded` (soft signal only, no count increment).

## Output schema

Backward-compatible - existing keys unchanged, new `unloaded[]` array added:

```json
{
  "count": 0,
  "missing": [],
  "unloaded": ["com.installer.on-demand-agent"]
}
```

Downstream prompt / alert templates that only read `count` and `missing` continue to work unchanged. Templates that want to render the soft signal opt into `unloaded`.

## Verified live

Against a real macOS install with a mix of loaded, unloaded, and truly missing agents:

```
$ CHASSIS_WATCHDOG_CRITICAL_AGENTS="com.jax.emulator-watchdog,com.jax.claude-oauth-bridge-sync,com.acme.does-not-exist" bash chassis/scripts/gather-launchd-watchdog-health.sh
{"count": 1, "missing": ["com.acme.does-not-exist"], "unloaded": ["com.jax.emulator-watchdog"]}
```

- `com.jax.emulator-watchdog` - plist exists, agent unloaded → unloaded, no count.
- `com.jax.claude-oauth-bridge-sync` - loaded normally → absent from both lists.
- `com.acme.does-not-exist` - no plist file → MISSING, count=1.

Empty config path (no `CHASSIS_WATCHDOG_CRITICAL_AGENTS`) still emits `{"count": 0, "missing": []}` matching the pre-existing behavior.

## Rollback

Revert this commit. Reverts to "any launchctl-print failure = MISSING" logic which will resume firing on any installer with deliberately-unloaded agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)