### PR TITLE
feat(backup): GFS long-tail retention fanout for nightly S3 backups

### DIFF
--- a/chassis/scripts/apply-s3-lifecycle.sh
+++ b/chassis/scripts/apply-s3-lifecycle.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# apply-s3-lifecycle.sh - Apply the GFS backup-retention lifecycle policy to the
+# S3 backup bucket.
+#
+# Pairs with the BACKUP_GFS_RETENTION fanout in encrypted-s3-upload.sh. The
+# fanout creates monthly/quarterly/yearly copies; this script installs the
+# lifecycle rules that tier them into Glacier Deep Archive and expire them on a
+# grandfather-father-son schedule. See docs/backup-retention.md for the full
+# scheme.
+#
+# This is a FULL REPLACE of the bucket's lifecycle configuration. It includes
+# the nightly-expire rule (30-day daily window) so that existing behavior is
+# preserved, plus the three long-tail rules.
+#
+# Credentials: needs s3:PutLifecycleConfiguration + s3:GetLifecycleConfiguration
+# on the bucket. The chassis backup-writer key (AWS_BACKUP_WRITE_*) is scoped to
+# PutObject only and will NOT work here. Provide an admin credential via the
+# ambient AWS environment or AWS_PROFILE, e.g.:
+#
+#   AWS_PROFILE=my-admin bash chassis/scripts/apply-s3-lifecycle.sh
+#
+# Reads S3_BACKUP_BUCKET + S3_BACKUP_REGION from $CHASSIS_HOME/.env (or the
+# environment). Idempotent - safe to re-run.
+
+set -euo pipefail
+
+CHASSIS_HOME="${CHASSIS_HOME:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+if [[ -f "${CHASSIS_HOME}/.env" ]]; then
+    set -a
+    # shellcheck disable=SC1090,SC1091
+    source "${CHASSIS_HOME}/.env" 2>/dev/null || true
+    set +a
+fi
+
+: "${S3_BACKUP_BUCKET:?set S3_BACKUP_BUCKET in .env or env}"
+: "${S3_BACKUP_REGION:?set S3_BACKUP_REGION in .env or env}"
+
+POLICY_FILE="$(mktemp /tmp/s3-lifecycle-gfs.XXXXXX.json)"
+trap 'rm -f "$POLICY_FILE"' EXIT
+
+cat > "$POLICY_FILE" <<'JSON'
+{
+  "Rules": [
+    {
+      "ID": "nightly-expire",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "nightly/" },
+      "Expiration": { "Days": 30 },
+      "NoncurrentVersionExpiration": { "NoncurrentDays": 30 }
+    },
+    {
+      "ID": "monthly-12mo-deep-archive",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "monthly/" },
+      "Transitions": [ { "Days": 1, "StorageClass": "DEEP_ARCHIVE" } ],
+      "Expiration": { "Days": 365 }
+    },
+    {
+      "ID": "quarterly-3yr-deep-archive",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "quarterly/" },
+      "Transitions": [ { "Days": 1, "StorageClass": "DEEP_ARCHIVE" } ],
+      "Expiration": { "Days": 1095 }
+    },
+    {
+      "ID": "yearly-forever-deep-archive",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "yearly/" },
+      "Transitions": [ { "Days": 1, "StorageClass": "DEEP_ARCHIVE" } ]
+    }
+  ]
+}
+JSON
+
+echo "Applying GFS lifecycle policy to s3://${S3_BACKUP_BUCKET} (${S3_BACKUP_REGION})..."
+echo "This REPLACES the bucket's entire lifecycle configuration."
+
+if ! aws s3api put-bucket-lifecycle-configuration \
+        --bucket "$S3_BACKUP_BUCKET" \
+        --region "$S3_BACKUP_REGION" \
+        --lifecycle-configuration "file://${POLICY_FILE}"; then
+    echo "ERROR: put-bucket-lifecycle-configuration failed." >&2
+    echo "The backup-writer key (AWS_BACKUP_WRITE_*) cannot do this - it is" >&2
+    echo "PutObject-scoped. Re-run with an admin credential (AWS_PROFILE=...)" >&2
+    echo "or apply the rules via the AWS Console (see docs/backup-retention.md)." >&2
+    exit 1
+fi
+
+echo "Applied. Reading back current configuration:"
+aws s3api get-bucket-lifecycle-configuration \
+    --bucket "$S3_BACKUP_BUCKET" \
+    --region "$S3_BACKUP_REGION"
+
+echo "Done."

--- a/chassis/scripts/encrypted-s3-upload.sh
+++ b/chassis/scripts/encrypted-s3-upload.sh
@@ -27,6 +27,14 @@
 #                       dedicated path within the bucket.
 #   BACKUP_NAME       - default "chassis-backup". Embedded in the tarball
 #                       filename + S3 object key.
+#   BACKUP_GFS_RETENTION - default "false". When "true" AND the prefix is the
+#                       default "nightly", server-side-copies each nightly
+#                       object into monthly/, quarterly/, and yearly/ prefixes
+#                       on calendar boundaries (1st of month / quarter / year)
+#                       so a grandfather-father-son retention scheme can be
+#                       enforced by bucket lifecycle rules. OPT-IN: the copies
+#                       accumulate forever unless the companion lifecycle rules
+#                       exist on the bucket. See docs/backup-retention.md.
 #
 # Output (to stdout, single JSON line):
 #   {"count": 0, "issues": [], "s3_key": "...", "size_bytes": N,
@@ -157,6 +165,50 @@ if ! AWS_ACCESS_KEY_ID="$AWS_BACKUP_WRITE_ACCESS_KEY_ID" \
      AWS_DEFAULT_REGION="$S3_BACKUP_REGION" \
      aws s3 cp "$MANIFEST_FILE" "s3://${S3_BACKUP_BUCKET}/${S3_MANIFEST_KEY}" --no-progress >/dev/null 2>&1; then
     fail "s3 cp manifest failed (tarball already uploaded successfully)"
+fi
+
+# --- GFS long-tail retention fanout (opt-in) ---------------------------------
+# On calendar boundaries, server-side-copy the just-uploaded nightly objects
+# (encrypted tarball + manifest) into monthly/, quarterly/, and yearly/
+# prefixes. Bucket lifecycle rules then retain each prefix on its own schedule
+# (grandfather-father-son). Server-side S3 copy => no download, no re-encrypt,
+# no egress. Best-effort: a failed fanout copy is logged to stderr but NEVER
+# fails the nightly, which has already uploaded successfully by this point.
+#
+# Gated on BACKUP_S3_PREFIX == "nightly" so installs that route to a custom
+# prefix are untouched. Requires the companion lifecycle rules on the bucket
+# or the copies accumulate forever - see docs/backup-retention.md.
+if [[ "${BACKUP_GFS_RETENTION:-false}" == "true" && "${BACKUP_S3_PREFIX}" == "nightly" ]]; then
+    gfs_copy_to() {
+        # $1 = destination dir under the bucket (no bucket, no trailing slash).
+        # Copies both the encrypted tarball and its manifest into $1/.
+        local dest_dir="$1" src
+        for src in "$S3_KEY" "$S3_MANIFEST_KEY"; do
+            if ! AWS_ACCESS_KEY_ID="$AWS_BACKUP_WRITE_ACCESS_KEY_ID" \
+                 AWS_SECRET_ACCESS_KEY="$AWS_BACKUP_WRITE_SECRET_ACCESS_KEY" \
+                 AWS_DEFAULT_REGION="$S3_BACKUP_REGION" \
+                 aws s3 cp "s3://${S3_BACKUP_BUCKET}/${src}" \
+                           "s3://${S3_BACKUP_BUCKET}/${dest_dir}/$(basename "$src")" \
+                           --no-progress >/dev/null 2>&1; then
+                echo "warn: GFS fanout copy ${src} -> ${dest_dir}/ failed" >&2
+            fi
+        done
+    }
+
+    GFS_DOM="$(date +%d)"
+    GFS_MONTH="$(date +%m)"
+    GFS_YEAR="$(date +%Y)"
+    if [[ "$GFS_DOM" == "01" ]]; then
+        gfs_copy_to "monthly/${GFS_YEAR}-${GFS_MONTH}"
+        # 10# forces base-10 so 08/09 don't trip the octal parser.
+        if [[ "$GFS_MONTH" =~ ^(01|04|07|10)$ ]]; then
+            GFS_QUARTER=$(( (10#$GFS_MONTH - 1) / 3 + 1 ))
+            gfs_copy_to "quarterly/${GFS_YEAR}-Q${GFS_QUARTER}"
+        fi
+        if [[ "$GFS_MONTH" == "01" ]]; then
+            gfs_copy_to "yearly/${GFS_YEAR}"
+        fi
+    fi
 fi
 
 printf '{"count": 0, "issues": [], "s3_key": "%s", "size_bytes": %s, "sha256": "%s"}\n' \

--- a/docs/backup-retention.md
+++ b/docs/backup-retention.md
@@ -1,0 +1,155 @@
+# Backup retention (grandfather-father-son)
+
+The nightly S3 backup (`chassis/scripts/backup-to-s3.sh` →
+`chassis/scripts/encrypted-s3-upload.sh`) writes one encrypted object per night
+under `nightly/<date>/`. Left alone, that either grows forever or gets a flat
+"expire after N days" rule that throws away all long-term history.
+
+This doc describes the optional **grandfather-father-son (GFS)** scheme: keep a
+dense recent window plus a sparse long tail, so you can restore last night
+instantly and still reach back years for the "corruption we didn't notice for
+three weeks" case, without paying to keep every nightly forever.
+
+## The scheme
+
+Two moving parts, and you need **both** or it doesn't work:
+
+1. **Fanout (script side).** With `BACKUP_GFS_RETENTION=true` in `.env`, the
+   uploader server-side-copies each nightly object into extra prefixes on
+   calendar boundaries. Server-side copy means no download, no re-encrypt, no
+   egress cost - the object never leaves S3.
+
+2. **Retention (bucket side).** Lifecycle rules on each prefix tier the copies
+   into Glacier Deep Archive and expire them on their own schedule. Lifecycle
+   rules can only expire or tier objects that already exist - they cannot
+   create the monthly/quarterly/yearly copies. That is the fanout's job.
+
+If you enable the fanout but never apply the lifecycle rules, the
+monthly/quarterly/yearly copies accumulate forever (slowly - a handful of
+objects per year - but unbounded). That is why the fanout is **opt-in**.
+
+## Prefixes and retention
+
+| Prefix | Written | Storage class | Retention | Retrieval |
+|--------|---------|---------------|-----------|-----------|
+| `nightly/<date>/` | every night | Standard | 30 days | instant |
+| `monthly/<YYYY-MM>/` | 1st of each month | Deep Archive (day 1) | 12 months | 12-48h |
+| `quarterly/<YYYY-QN>/` | 1st of Jan/Apr/Jul/Oct | Deep Archive (day 1) | 3 years | 12-48h |
+| `yearly/<YYYY>/` | Jan 1 | Deep Archive (day 1) | forever | 12-48h |
+
+The last 30 days always sit in instant-retrieval Standard, so the common
+"restore from a recent night" path is fast. Anything older is a real DR event,
+where a 12-48h Deep Archive retrieval is acceptable, and stored at
+~$0.001/GB/mo.
+
+Jan 1 is simultaneously a month, quarter, and year boundary, so that night's
+object is copied into all three prefixes. Intended - each prefix is retained
+independently.
+
+## Enabling it
+
+### 1. Turn on the fanout
+
+In your install `.env`:
+
+```
+BACKUP_GFS_RETENTION=true
+```
+
+Takes effect on the next nightly tick. The first `monthly/` copy appears on the
+next 1st-of-month; quarterly/yearly on their respective boundaries.
+
+### 2. Apply the lifecycle rules to the bucket
+
+**This needs a credential with `s3:PutLifecycleConfiguration`.** The chassis
+backup-writer key (`AWS_BACKUP_WRITE_*`) is scoped to `PutObject` only and
+cannot do this - use an admin profile or the AWS Console.
+
+**Option A - helper script** (needs admin AWS creds in the ambient environment
+or an `AWS_PROFILE`):
+
+```bash
+AWS_PROFILE=<admin-profile> bash chassis/scripts/apply-s3-lifecycle.sh
+```
+
+It reads `S3_BACKUP_BUCKET` / `S3_BACKUP_REGION` from `.env`, applies the
+four-rule policy below, and reads it back to confirm. The policy is a full
+replacement of the bucket's lifecycle config - it includes the `nightly-expire`
+rule so the existing 30-day daily window is preserved.
+
+**Option B - AWS Console.** S3 → your bucket → Management → Lifecycle rules.
+The three long-tail rules are on distinct prefixes (`monthly/`, `quarterly/`,
+`yearly/`), so they do not overlap `nightly-expire` and produce no warnings.
+For each: filter on the prefix, add a transition to Glacier Deep Archive after
+1 day, and set expiration (365 / 1095 days; none for `yearly/`).
+
+## The lifecycle policy
+
+`chassis/scripts/apply-s3-lifecycle.sh` applies exactly this (also usable
+directly with `aws s3api put-bucket-lifecycle-configuration`):
+
+```json
+{
+  "Rules": [
+    {
+      "ID": "nightly-expire",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "nightly/" },
+      "Expiration": { "Days": 30 },
+      "NoncurrentVersionExpiration": { "NoncurrentDays": 30 }
+    },
+    {
+      "ID": "monthly-12mo-deep-archive",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "monthly/" },
+      "Transitions": [ { "Days": 1, "StorageClass": "DEEP_ARCHIVE" } ],
+      "Expiration": { "Days": 365 }
+    },
+    {
+      "ID": "quarterly-3yr-deep-archive",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "quarterly/" },
+      "Transitions": [ { "Days": 1, "StorageClass": "DEEP_ARCHIVE" } ],
+      "Expiration": { "Days": 1095 }
+    },
+    {
+      "ID": "yearly-forever-deep-archive",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "yearly/" },
+      "Transitions": [ { "Days": 1, "StorageClass": "DEEP_ARCHIVE" } ]
+    }
+  ]
+}
+```
+
+All retentions exceed Deep Archive's 180-day minimum-storage-duration charge,
+so nothing gets hit with an early-deletion penalty.
+
+## Restoring from a long-tail snapshot
+
+`chassis/scripts/restore-from-s3.sh` lists and pulls from `nightly/` by default.
+To restore from a monthly/quarterly/yearly snapshot, retrieve the specific
+object first (Deep Archive needs a restore request + wait), then decrypt it the
+same way:
+
+```bash
+# 1. Kick off a Deep Archive restore (Standard tier ~12h; Bulk ~48h, cheaper)
+aws s3api restore-object --bucket "$S3_BACKUP_BUCKET" \
+  --key "monthly/2026-01/<name>-<ts>.tar.gz.age" \
+  --restore-request Days=3,GlacierJobParameters={Tier=Standard}
+
+# 2. Once restored, download + decrypt (age key from your secret store)
+aws s3 cp "s3://$S3_BACKUP_BUCKET/monthly/2026-01/<name>-<ts>.tar.gz.age" ./restore.tar.gz.age
+age -d -i ~/.jax-backup-age.key ./restore.tar.gz.age | tar xzf - -C ./restore/
+```
+
+Each long-tail snapshot ships its own `manifest.json` (copied alongside the
+tarball) with the encrypted `sha256` for integrity verification.
+
+## Cost
+
+At the reduced per-backup footprint (~250-300 MiB after the `data/` exclusions
+in `backup-to-s3.sh`), steady state is roughly 30 daily (Standard) + 12 monthly
++ 12 quarterly + N yearly (nearly all Deep Archive). That is a few dollars a
+year in storage - dominated by the 30 Standard nightlies, with the entire
+archival tail costing pennies.

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -198,3 +198,4 @@ Audit your install against this checklist. If any row is "no", fix it before you
 - [`SELF_INSTALL.md`](SELF_INSTALL.md) — full self-install walkthrough (non-destructive re-anchor in § "Migrating an existing install to a re-anchored chassis")
 - [`containerization.md`](containerization.md) — chassis container architecture (what's bind-mounted vs baked)
 - [`credential-bake.md`](credential-bake.md) — `.env` → `.env.baked` mechanics
+- [`backup-retention.md`](backup-retention.md) - GFS long-tail retention for the nightly S3 backup (monthly/quarterly/yearly)


### PR DESCRIPTION
## Summary

Follow-up to #48. Sean's S3 fire drill (2026-07-03) settled the retention shape: keep a dense 30-day daily window (already enforced by the existing `nightly-expire` lifecycle rule) plus a sparse long tail so we can reach back a year+ after a corruption that goes unnoticed for weeks - without keeping every nightly forever.

Lifecycle rules alone can't do this: they can only expire/tier objects that exist, not *create* the monthly/quarterly/yearly copies. So this adds the fanout that creates them, plus the companion lifecycle policy.

## What's in it

**`chassis/scripts/encrypted-s3-upload.sh` - GFS fanout (opt-in)**
- With `BACKUP_GFS_RETENTION=true` (and the default `nightly` prefix), server-side-copies each nightly object + its manifest into `monthly/<YYYY-MM>/`, `quarterly/<YYYY-QN>/`, `yearly/<YYYY>/` on calendar boundaries (1st of month / 1st of Jan-Apr-Jul-Oct / Jan 1).
- Server-side S3 copy: no download, no re-encrypt, no egress - the object never leaves S3.
- Best-effort: a failed fanout copy logs to stderr and **never** fails the nightly (already uploaded by that point).
- Gated on `BACKUP_S3_PREFIX == nightly` so custom-routed installs are untouched.

**`chassis/scripts/apply-s3-lifecycle.sh` - companion policy installer**
- One-shot `put-bucket-lifecycle-configuration`. Full-replace that **preserves** the existing `nightly-expire` rule (30d Standard) and adds: `monthly/` → Deep Archive @ day 1, expire 365d; `quarterly/` → Deep Archive, expire 1095d; `yearly/` → Deep Archive, keep forever.
- Reads back to confirm. Needs an admin credential - the backup-writer key (`AWS_BACKUP_WRITE_*`) is `PutObject`-scoped and returns AccessDenied on lifecycle actions (verified against the live bucket).

**`docs/backup-retention.md`** - scheme, prefix/retention table, enable steps, the lifecycle JSON, restore-from-long-tail runbook (incl. Deep Archive `restore-object`), cost. Cross-linked from `disaster-recovery.md`.

## Retention

| Prefix | Written | Class | Kept | Retrieval |
|--------|---------|-------|------|-----------|
| `nightly/` | nightly | Standard | 30d | instant |
| `monthly/` | 1st of month | Deep Archive | 12mo | 12-48h |
| `quarterly/` | 1st of quarter | Deep Archive | 3yr | 12-48h |
| `yearly/` | Jan 1 | Deep Archive | forever | 12-48h |

Last 30 days stay instant-retrieval; older is a real DR event where 12-48h is fine. All retentions exceed Deep Archive's 180-day minimum-storage charge - no early-deletion penalties.

## Why opt-in (default off)

The fanout copies accumulate forever unless the companion lifecycle rules exist on the bucket. Defaulting it on would silently reintroduce unbounded growth on installs that haven't applied the rules. So: `BACKUP_GFS_RETENTION` defaults off; enabling it is a two-step (set the flag + apply the policy), both documented.

## Test plan

- [x] `bash -n` clean on both scripts.
- [x] Calendar/quarter fanout logic unit-tested in isolation: Jan 1 → month+Q1+year; Apr/Jul/Oct 1 → month+quarter; 08/09 octal-safe; mid-month → no fanout.
- [x] Verified against the live bucket that `jax-backup-read` and `jax-backup-write` both lack `s3:*LifecycleConfiguration` (drives the "needs admin cred" note).
- [ ] Enable on Jax's install (`BACKUP_GFS_RETENTION=true`), apply the lifecycle policy, confirm the next 1st-of-month tick lands a `monthly/` copy.

## Open question for Sean

Bump `chassis/VERSION` (0.1.1)? This is a feature; leaving it untouched per the "ask before bumping" convention.

🤖 Generated with Claude Code