### PR TITLE
fix(backup): GFS fanout re-uploads local file, not server-side S3 copy

### DIFF
--- a/chassis/scripts/encrypted-s3-upload.sh
+++ b/chassis/scripts/encrypted-s3-upload.sh
@@ -28,13 +28,13 @@
 #   BACKUP_NAME       - default "chassis-backup". Embedded in the tarball
 #                       filename + S3 object key.
 #   BACKUP_GFS_RETENTION - default "false". When "true" AND the prefix is the
-#                       default "nightly", server-side-copies each nightly
-#                       object into monthly/, quarterly/, and yearly/ prefixes
-#                       on calendar boundaries (1st of month / quarter / year)
-#                       so a grandfather-father-son retention scheme can be
-#                       enforced by bucket lifecycle rules. OPT-IN: the copies
-#                       accumulate forever unless the companion lifecycle rules
-#                       exist on the bucket. See docs/backup-retention.md.
+#                       default "nightly", also uploads each nightly artifact
+#                       into monthly/, quarterly/, and yearly/ prefixes on
+#                       calendar boundaries (1st of month / quarter / year) so a
+#                       grandfather-father-son retention scheme can be enforced
+#                       by bucket lifecycle rules. OPT-IN: the copies accumulate
+#                       forever unless the companion lifecycle rules exist on
+#                       the bucket. See docs/backup-retention.md.
 #
 # Output (to stdout, single JSON line):
 #   {"count": 0, "issues": [], "s3_key": "...", "size_bytes": N,
@@ -168,29 +168,38 @@ if ! AWS_ACCESS_KEY_ID="$AWS_BACKUP_WRITE_ACCESS_KEY_ID" \
 fi
 
 # --- GFS long-tail retention fanout (opt-in) ---------------------------------
-# On calendar boundaries, server-side-copy the just-uploaded nightly objects
-# (encrypted tarball + manifest) into monthly/, quarterly/, and yearly/
-# prefixes. Bucket lifecycle rules then retain each prefix on its own schedule
-# (grandfather-father-son). Server-side S3 copy => no download, no re-encrypt,
-# no egress. Best-effort: a failed fanout copy is logged to stderr but NEVER
-# fails the nightly, which has already uploaded successfully by this point.
+# On calendar boundaries, upload the just-produced nightly artifacts (the local
+# encrypted tarball + manifest, still on disk in WORK_DIR) into monthly/,
+# quarterly/, and yearly/ prefixes. Bucket lifecycle rules then retain each
+# prefix on its own schedule (grandfather-father-son).
 #
-# Gated on BACKUP_S3_PREFIX == "nightly" so installs that route to a custom
-# prefix are untouched. Requires the companion lifecycle rules on the bucket
-# or the copies accumulate forever - see docs/backup-retention.md.
+# We re-upload the LOCAL files rather than server-side-copy the nightly S3
+# object on purpose: a server-side S3->S3 copy requires s3:GetObject on the
+# source, but the dedicated backup-writer IAM key is PutObject-scoped (it can
+# write backups, not read them) and 403s on the copy's HeadObject. Re-uploading
+# the local file needs only PutObject, which the key already has. Cost is one
+# extra ~250-300 MiB PUT per boundary (three on Jan 1) - trivial, monthly.
+#
+# Best-effort: a failed fanout upload is logged to stderr but NEVER fails the
+# nightly, which has already uploaded successfully by this point. Gated on
+# BACKUP_S3_PREFIX == "nightly" so installs that route to a custom prefix are
+# untouched. Requires the companion lifecycle rules on the bucket or the copies
+# accumulate forever - see docs/backup-retention.md.
 if [[ "${BACKUP_GFS_RETENTION:-false}" == "true" && "${BACKUP_S3_PREFIX}" == "nightly" ]]; then
     gfs_copy_to() {
         # $1 = destination dir under the bucket (no bucket, no trailing slash).
-        # Copies both the encrypted tarball and its manifest into $1/.
-        local dest_dir="$1" src
-        for src in "$S3_KEY" "$S3_MANIFEST_KEY"; do
+        # Uploads both the local encrypted tarball and its manifest into $1/.
+        # Basenames match the nightly object keys ($ENCRYPTED -> the tarball,
+        # $MANIFEST_FILE -> manifest.json).
+        local dest_dir="$1" f
+        for f in "$ENCRYPTED" "$MANIFEST_FILE"; do
             if ! AWS_ACCESS_KEY_ID="$AWS_BACKUP_WRITE_ACCESS_KEY_ID" \
                  AWS_SECRET_ACCESS_KEY="$AWS_BACKUP_WRITE_SECRET_ACCESS_KEY" \
                  AWS_DEFAULT_REGION="$S3_BACKUP_REGION" \
-                 aws s3 cp "s3://${S3_BACKUP_BUCKET}/${src}" \
-                           "s3://${S3_BACKUP_BUCKET}/${dest_dir}/$(basename "$src")" \
+                 aws s3 cp "$f" \
+                           "s3://${S3_BACKUP_BUCKET}/${dest_dir}/$(basename "$f")" \
                            --no-progress >/dev/null 2>&1; then
-                echo "warn: GFS fanout copy ${src} -> ${dest_dir}/ failed" >&2
+                echo "warn: GFS fanout upload $(basename "$f") -> ${dest_dir}/ failed" >&2
             fi
         done
     }

--- a/docs/backup-retention.md
+++ b/docs/backup-retention.md
@@ -15,9 +15,13 @@ three weeks" case, without paying to keep every nightly forever.
 Two moving parts, and you need **both** or it doesn't work:
 
 1. **Fanout (script side).** With `BACKUP_GFS_RETENTION=true` in `.env`, the
-   uploader server-side-copies each nightly object into extra prefixes on
-   calendar boundaries. Server-side copy means no download, no re-encrypt, no
-   egress cost - the object never leaves S3.
+   uploader also uploads each nightly artifact into extra prefixes on calendar
+   boundaries. It re-uploads the local encrypted file (already on disk from the
+   nightly run) rather than server-side-copying the S3 object, because a
+   server-side S3-to-S3 copy needs `s3:GetObject` on the source and the
+   backup-writer key is `PutObject`-scoped. Re-uploading needs only
+   `PutObject`. Cost is one extra ~250-300 MiB PUT per boundary (three on
+   Jan 1) - trivial, and monthly.
 
 2. **Retention (bucket side).** Lifecycle rules on each prefix tier the copies
    into Glacier Deep Archive and expire them on their own schedule. Lifecycle


### PR DESCRIPTION
## The bug

The GFS fanout from #49 fanned the nightly object into `monthly/`/`quarterly/`/`yearly/` with a server-side S3 copy:

```
aws s3 cp s3://bucket/nightly/<date>/obj  s3://bucket/monthly/<ym>/obj
```

A server-side S3-to-S3 copy requires **`s3:GetObject` on the source**. But the dedicated backup-writer key (`AWS_BACKUP_WRITE_*`) is **`PutObject`-scoped** - it can write backups, not read them.

**Verified against the live bucket** (`jax-backups-scrollinondubs-prod`): the write key returns `403 Forbidden` on the copy's `HeadObject`. Because the fanout is best-effort (failures only warn to stderr), this would have silently produced **zero** long-tail copies - the `monthly/`/`quarterly/`/`yearly/` prefixes would stay empty forever, and nobody would notice until a DR event needed a months-old snapshot that was never written.

## The fix

Re-upload the **local** encrypted tarball + manifest (still on disk in `WORK_DIR` at fanout time, before the `trap` cleanup) to each prefix, instead of server-side-copying the S3 object:

```
aws s3 cp "$ENCRYPTED"      s3://bucket/monthly/<ym>/<name>-<ts>.tar.gz.age
aws s3 cp "$MANIFEST_FILE"  s3://bucket/monthly/<ym>/manifest.json
```

This needs only `PutObject` - exactly what the key already uses for the nightly upload. No IAM change required.

**Cost:** one extra ~250-300 MiB PUT per calendar boundary (three on Jan 1). Trivial, and only monthly. The alternative (granting the writer key `GetObject`) would broaden its scope to read every backup - worse, for no benefit.

## Timing

Caught during post-merge verification, before the first fanout boundary (Aug 1), so no snapshots were missed. `BACKUP_GFS_RETENTION=true` is already set on Jax's install and the S3 lifecycle rules are in place; this fix is what makes the copies actually land.

## Test plan

- [x] `bash -n` clean.
- [x] Root cause reproduced live: `aws s3 cp` (write key) from an existing nightly object → `403 HeadObject`. Local-file `PutObject` with the same key succeeds nightly, so the re-upload path works.
- [x] Doc + header comment corrected (no longer claim "server-side copy, no egress").
- [ ] First real fanout on Aug 1 lands `monthly/2026-08/` objects (will verify then).

🤖 Generated with Claude Code