### PR TITLE
fix(mcp): pin siyuan-mcp to 1.0.4 (@latest 1.1.1 is broken)

### DIFF
--- a/chassis/.mcp.json.template
+++ b/chassis/.mcp.json.template
@@ -41,7 +41,7 @@
       "_role": "second-brain backend (option A) — block-based notes, local-first",
       "_enable_when": "chassis.config.yaml.second_brain.backend == 'siyuan'",
       "command": "npx",
-      "args": ["-y", "siyuan-mcp@latest"],
+      "args": ["-y", "siyuan-mcp@1.0.4"],
       "env": {
         "SIYUAN_URL": "<SIYUAN_URL>",
         "SIYUAN_TOKEN": "<SIYUAN_TOKEN>"


### PR DESCRIPTION
## The bug

`siyuan-mcp` published **v1.1.1 on 2026-06-28**. The chassis template pinned `siyuan-mcp@latest`, so every install's rendered `.mcp.json` auto-pulled 1.1.1 - and **1.1.1 crashes ~700ms into MCP startup**, before completing the handshake. Claude Code logs it as `MCP error -32000: Connection closed`, and the SiYuan MCP tools silently vanish from the session. On Sean's install this presented as "SiYuan MCP down 3rd day," with briefings falling back to the raw HTTP API.

## Root cause (reproduced on Sean's install)

- SiYuan HTTP API healthy throughout: `POST /api/system/version` → 200 from host, over Tailnet, and from inside the container via `host.docker.internal:6806`. Not a connectivity/DNS issue.
- `siyuan-mcp@1.1.1` via npx: returns **nothing** to an `initialize` request (process dies).
- `siyuan-mcp@1.0.4` via npx: completes the handshake cleanly with a valid `initialize` result + tool capabilities.

So it's purely an upstream MCP-package regression in 1.1.x.

## Fix

Pin the template to the last-known-good **`siyuan-mcp@1.0.4`** so a fresh render / re-bootstrap doesn't re-break. Revisit when siyuan-mcp ships a working release above 1.1.1.

## Deploy status

- Sean's **live install already patched on disk** (its `.mcp.json` is gitignored/generated, so the on-disk pin is what restores service now - SiYuan MCP returns on the next session + next container briefing).
- This PR fixes the **tracked template** so all installs + future re-renders inherit the pin.

## Test plan

- [x] Reproduced 1.1.1 failure vs 1.0.4 success via manual `initialize` handshake through npx.
- [x] Confirmed the underlying SiYuan HTTP API was never down.
- [ ] Next containerized briefing on the live install regains `mcp__siyuan__*` tools (will confirm tomorrow).

🤖 Generated with Claude Code