### PR TITLE
feat(loom-vision): ClawHub submission package (prep only, not submitted)

### DIFF
--- a/plugins/loom-vision/CLAWHUB_SUBMISSION.md
+++ b/plugins/loom-vision/CLAWHUB_SUBMISSION.md
@@ -1,0 +1,61 @@
+# ClawHub Submission Runbook - Loom Vision
+
+Everything needed to publish the Loom Vision skill to [ClawHub.ai](https://clawhub.ai), OpenClaw's public registry. Prepared 2026-07-07 by Jax. Nothing has been submitted - every step below is manual and yours.
+
+Verified against the live docs on 2026-07-07:
+- https://docs.openclaw.ai/clawhub (overview)
+- https://docs.openclaw.ai/clawhub/publishing
+- https://docs.openclaw.ai/clawhub/skill-format
+- https://docs.openclaw.ai/clawhub/cli
+- https://docs.openclaw.ai/clawhub/auth
+
+## What ClawHub expects
+
+ClawHub hosts two artifact types: **skills** (versioned text bundles: a folder with `SKILL.md` plus supporting text files) and **plugins** (npm-style packages with `package.json` + `openclaw.compat.pluginApi` metadata). Loom Vision is a skill bundle - SKILL.md + one shell script - so we submit it as a **skill**, not a plugin. That path needs no package.json, no npm scope, and no `openclaw.plugin.json` (that file stays chassis-only).
+
+Submission is via the `clawhub` CLI (`clawhub skill publish <folder>`), authenticated through GitHub sign-in at clawhub.ai. There is no PR-to-a-registry-repo flow and no web upload form for local folders (the web GitHub importer exists but only scans public non-fork repos for SKILL.md files - the CLI is the recommended and more controllable path).
+
+## Staged files (this PR)
+
+| File | Purpose |
+|---|---|
+| `clawhub/loom-vision/SKILL.md` | The publishable skill definition. ClawHub parses its YAML frontmatter for registry metadata: `name`, `description` (becomes the search/UI summary), `version`, and `metadata.openclaw` (emoji, homepage, `requires.bins`, install specs for loom-dl + ffmpeg, and optional `envVars`). The env vars the script reads are declared with `required: false` because ClawHub's automated security analysis flags undeclared env var usage as a metadata mismatch. Chassis-only frontmatter (`plugin:`, `enabled_when:`) removed. |
+| `clawhub/loom-vision/process-loom.sh` | Standalone copy of the chassis script. Only differences from the canonical `skills/loom-vision/process-loom.sh`: default `OUTPUT_ROOT` is `${TMPDIR:-/tmp}/loom-vision` instead of `${CHASSIS_HOME}/temp`, and chassis/setup.sh references are gone from comments. Publishing uploads the whole folder, so this ships inside the bundle - `{baseDir}` in SKILL.md resolves to it at runtime. |
+| `clawhub/loom-vision/README.md` | Optional supporting file (allowed; only text files are accepted). Chassis install instructions replaced with `clawhub install`, plus the Behalf.bot pointer. No license section - see the licensing note below. |
+| `CLAWHUB_SUBMISSION.md` | This runbook. Not part of the published bundle (it lives one level above the skill folder, and publish only uploads `clawhub/loom-vision/`). |
+
+The chassis plugin (`openclaw.plugin.json`, `setup.sh`, `skills/loom-vision/`) is untouched. The `clawhub/loom-vision/` folder is the exact directory you point the publish command at; its folder name becomes the default slug (`loom-vision`).
+
+## Decide before you publish: licensing
+
+ClawHub publishes **all** skills under **MIT-0** (public domain equivalent: anyone may use, modify, redistribute, commercially, no attribution). Per-skill license overrides are not supported, and conflicting license terms in SKILL.md are explicitly disallowed. This repo is O'Saasy (MIT + SaaS-compete restriction). You are the copyright holder, so publishing is effectively dual-licensing this one bundle as MIT-0. If you are not comfortable releasing Loom Vision under MIT-0, stop here - there is no other license option on ClawHub.
+
+## Submit checklist
+
+1. Merge this PR (or check out the branch) so `plugins/loom-vision/clawhub/loom-vision/` exists on disk.
+2. Confirm the licensing decision above: publishing releases this bundle under MIT-0.
+3. Create the account: go to https://clawhub.ai and click "Sign in with GitHub". Use your `scrollinondubs` GitHub account (uploads require a GitHub account old enough to pass ClawHub's anti-abuse gate; a years-old account passes). Your publisher handle is derived from the GitHub account.
+4. Install the CLI: `npm i -g clawhub` (Node required). Verify with `clawhub --help`.
+5. Authenticate: run `clawhub login` - it opens the browser to clawhub.ai/cli/auth, you complete GitHub sign-in, and the CLI stores an API token in `~/Library/Application Support/clawhub/config.json`. (Headless alternative: `clawhub login --device`.)
+6. Verify auth: `clawhub whoami` should print your handle. Note it - it is the `@owner` in the published URL.
+7. Dry run from the repo root:
+   `clawhub skill publish plugins/loom-vision/clawhub/loom-vision --dry-run`
+   This resolves the full publish plan (slug `loom-vision`, version `1.0.0` for a new skill, file list) without uploading. Fix anything it flags before continuing.
+8. Publish:
+   `clawhub skill publish plugins/loom-vision/clawhub/loom-vision --slug loom-vision --name "Loom Vision"`
+   No `--version` needed - new skills start at 1.0.0. No `--owner` needed unless you want to publish under an org publisher handle instead of your personal one (org scope must match an owner you control).
+9. Expect a security-scan hold: ClawHub runs automated checks on new releases, and a new skill may stay out of public catalog/install surfaces until scanning and verification finish. Track status at https://clawhub.ai/dashboard (owner-visible even while held). The declared env vars and bins in the frontmatter were written to match exactly what process-loom.sh uses, so the metadata-mismatch check should pass.
+10. Verify it is live:
+    - `clawhub inspect @<your-handle>/loom-vision --files` (metadata + file list)
+    - open `https://clawhub.ai/<your-handle>/loom-vision`
+11. Test a real install in a scratch directory:
+    `cd $(mktemp -d) && clawhub install @<your-handle>/loom-vision && cat skills/loom-vision/SKILL.md`
+    Or the native flow on an OpenClaw machine: `openclaw skills install @<your-handle>/loom-vision`.
+12. Future updates: edit the files under `plugins/loom-vision/clawhub/loom-vision/`, then re-run the publish command - changed content auto-bumps the next patch version (pass `--version` for minor/major). Optional automation: ClawHub's reusable GitHub Actions workflow `openclaw/clawhub/.github/workflows/skill-publish.yml` with a `CLAWHUB_TOKEN` repo secret (get the token via `clawhub token`).
+
+## Gotchas
+
+- Keep `clawhub/loom-vision/` in sync with the canonical chassis script by hand - the two copies intentionally differ only in OUTPUT_ROOT default and comments.
+- Do not add pricing or license text to SKILL.md; ClawHub rejects/ignores both.
+- Only text-based files are accepted in the bundle; the .sh is fine (scripts are scanned after upload). Bundle limit 50MB - ours is ~12KB.
+- `CLAWHUB_DISABLE_TELEMETRY=1` disables the CLI's install-count telemetry if you care.

--- a/plugins/loom-vision/clawhub/loom-vision/README.md
+++ b/plugins/loom-vision/clawhub/loom-vision/README.md
@@ -1,0 +1,62 @@
+# Loom Vision
+
+**See the frames, not just the transcript.** Drop a Loom share URL into your agent session and get full visual + audio context for code reviews, bug repros, walkthroughs, and demos.
+
+## What it does
+
+Loom's auto-transcript captures only what was said aloud. For most technical Loom videos - code walkthroughs, design reviews, bug repros - the screen contents matter more than the audio. Loom Vision closes that gap:
+
+1. Downloads the source video and Loom's auto-transcript.
+2. Samples frames at 1 frame per 5 seconds (configurable).
+3. Hands both to the agent as multimodal context.
+
+The agent then reads the transcript to anchor timing and browses the frames that fall in the relevant window - IDE state, error popups, on-screen code, design mockups, and UI transitions that the audio narration skipped.
+
+## Example uses
+
+- "Here's a 7-minute Loom of the bug - what did I click on at minute 4 that triggered the 500?"
+- "Walk me through this design review and pull out every comment about contrast ratios."
+- "Loom of my PR walkthrough - summarize the diff strategy I described."
+- "I recorded my onboarding flow - where does the UX get confusing?"
+
+## Install
+
+```bash
+clawhub install @<owner>/loom-vision
+```
+
+Two CLI dependencies (declared in the skill's install specs, so OpenClaw can install them for you):
+
+- `loom-dl` - `npm install -g loom-dl` (Node-based; not on Homebrew)
+- `ffmpeg` - `brew install ffmpeg` (macOS) or your distro's package manager (Linux)
+
+Both are idempotent.
+
+## Usage
+
+The skill triggers automatically when you paste a Loom share URL or ask the agent to process Loom video content. You can also invoke the underlying script directly:
+
+```bash
+bash process-loom.sh "https://www.loom.com/share/<32-hex-id>/..."
+```
+
+The script prints the output directory path to stdout. The directory contains:
+
+- `video.mp4` - original video (kept for re-sampling at different intervals)
+- `transcript.vtt` - Loom's auto-transcript with timestamps
+- `frame_NNN.jpg` - sampled frames
+
+Frame N corresponds to timestamp `(N - 1) * FRAME_INTERVAL_SECONDS` from the start.
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `FRAME_INTERVAL_SECONDS` | `5` | Lower for fast-changing UI, higher for slow walkthroughs. |
+| `FRAME_MAX_WIDTH_PX` | `1280` | Bump up if code fonts get too small to read. |
+| `FRAME_QUALITY` | `3` | ffmpeg `-q:v` scale (1-31, lower = better quality). |
+| `OUTPUT_ROOT` | `${TMPDIR:-/tmp}/loom-vision` | Where per-video output folders are written. |
+
+## Built by
+
+Loom Vision ships standard with [Behalf.bot](https://behalf.bot) - battery-included AI assistant installs for solo operators. If Loom Vision is useful to you on its own, the rest of the Behalf.bot plugin catalog is probably interesting too.

--- a/plugins/loom-vision/clawhub/loom-vision/SKILL.md
+++ b/plugins/loom-vision/clawhub/loom-vision/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: loom-vision
+description: Process a Loom share URL into multimodal context - downloaded video, sampled frames at one frame per 5 seconds, and the auto-generated transcript. Triggers when the user shares a Loom URL, asks what is happening in a Loom video, or wants visual context beyond the transcript.
+version: 1.0.0
+homepage: https://behalf.bot
+metadata:
+  openclaw:
+    emoji: "🎥"
+    homepage: https://behalf.bot
+    requires:
+      bins:
+        - loom-dl
+        - ffmpeg
+    install:
+      - id: node-loom-dl
+        kind: node
+        package: loom-dl
+        bins: [loom-dl]
+        label: Install loom-dl (npm)
+      - id: brew-ffmpeg
+        kind: brew
+        formula: ffmpeg
+        bins: [ffmpeg]
+        label: Install ffmpeg (brew)
+    envVars:
+      - name: OUTPUT_ROOT
+        required: false
+        description: Directory where per-video output folders are written. Defaults to a loom-vision folder under the system temp directory.
+      - name: FRAME_INTERVAL_SECONDS
+        required: false
+        description: Seconds between sampled frames. Default 5. Lower for fast-changing UI, higher for slow walkthroughs.
+      - name: FRAME_MAX_WIDTH_PX
+        required: false
+        description: Max width in pixels for sampled frames. Default 1280.
+      - name: FRAME_QUALITY
+        required: false
+        description: ffmpeg -q:v JPEG quality, 1-31, lower is better. Default 3.
+---
+
+# Loom Vision
+
+Use this skill whenever:
+
+- The user pastes a Loom share URL (`https://www.loom.com/share/<32-hex-id>` or similar).
+- The user asks you to "watch", "review", "summarize", or "explain" a Loom video.
+- The user references a Loom video they recorded and asks a question that needs visual context (e.g. "what was the error on screen at minute 3", "did I click the right button", "what's the diff in that PR walkthrough").
+
+The skill exists because Loom's auto-transcript captures only what was said aloud - not what was on screen. For code walkthroughs, design reviews, and bug repros, the screen contents are often more important than the audio.
+
+## How to invoke
+
+Run the processor script with the Loom share URL. It downloads the mp4, samples frames, and prints the output directory path.
+
+```bash
+bash {baseDir}/process-loom.sh "<loom-share-url>"
+```
+
+The script prints the output directory path to stdout. Inside that directory:
+
+- `video.mp4` - the original video (kept in case you want to re-process at a different frame interval)
+- `transcript.vtt` - Loom's auto-transcript with timestamps
+- `frame_001.jpg`, `frame_002.jpg`, ... - sampled frames at 1 frame per N seconds (default 5)
+
+## What to do with the output
+
+Read the transcript first to anchor timing, then browse the frames that fall in the relevant time window. For a 10-minute video at 5-second sampling that's 120 frames - review them in batches or jump to the specific window the user asked about.
+
+Frame N corresponds to timestamp `(N - 1) * FRAME_INTERVAL_SECONDS` from the start of the video. Default interval is 5 seconds, so frame_007.jpg is at the 30-second mark.
+
+## Working with the output
+
+Common patterns:
+
+- **Summarize the whole video.** Read the full transcript, then sample every 6th frame (one per 30 seconds) for the visual narrative. Combine.
+- **Answer a specific question.** Search the transcript for the relevant keyword, find the timestamp, look at the frame(s) within plus or minus 10 seconds.
+- **Spot what's missing from the transcript.** Errors, popup dialogs, UI states, and on-screen code rarely make it into the spoken audio - go directly to the frames.
+
+## Configuration
+
+All knobs are environment variables, set before invoking the script:
+
+- `FRAME_INTERVAL_SECONDS` - default 5. Lower for densely visual content (animations, fast UI changes), higher for slow walkthroughs.
+- `FRAME_MAX_WIDTH_PX` - default 1280. Bump up for tiny-font code review videos.
+- `FRAME_QUALITY` - default 3 (ffmpeg `-q:v` scale, 1-31, lower = better).
+- `OUTPUT_ROOT` - default `${TMPDIR:-/tmp}/loom-vision`.
+
+## Dependencies
+
+Two system CLIs are required (declared in the install specs above so OpenClaw can offer to install them):
+
+- `loom-dl` - install with `npm install -g loom-dl` (Node CLI, not on Homebrew)
+- `ffmpeg` - install with `brew install ffmpeg` (macOS) or your distro's package manager (Linux)
+
+Both installs are idempotent.
+
+## Why this exists
+
+Most Loom-style integrations treat the video as audio-with-pictures: they ingest the transcript and stop. That loses the entire visual half of a walkthrough - IDE state, error popups, on-screen code, design mockups, the actual change in a PR review.
+
+Sampling at 1 frame per 5 seconds is the sweet spot for code/UI content: dense enough to catch transient errors and UI transitions, sparse enough that a 10-minute video yields 120 frames (manageable batch size for multimodal review). The transcript provides the audio narrative; the frames provide everything else.

--- a/plugins/loom-vision/clawhub/loom-vision/process-loom.sh
+++ b/plugins/loom-vision/clawhub/loom-vision/process-loom.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# process-loom.sh - Download a Loom video, extract key frames + transcript.
+#
+# Standalone (ClawHub) variant of the Behalf.bot chassis script. Canonical
+# chassis source: plugins/loom-vision/skills/loom-vision/process-loom.sh.
+#
+# Usage:
+#   bash process-loom.sh <loom-share-url>
+#
+# Output:
+#   Creates ${OUTPUT_ROOT}/loom-<video_id>/ containing:
+#     - video.mp4         (full source video, kept for re-sampling)
+#     - transcript.vtt    (Loom auto-transcript with timestamps)
+#     - frame_NNN.jpg     (sampled frames at FRAME_INTERVAL_SECONDS cadence)
+#   Prints the output directory path to stdout. Progress messages go to stderr.
+#
+# Configuration (env vars):
+#   OUTPUT_ROOT               default ${TMPDIR:-/tmp}/loom-vision
+#   FRAME_INTERVAL_SECONDS    default 5
+#   FRAME_MAX_WIDTH_PX        default 1280
+#   FRAME_QUALITY             default 3 (ffmpeg -q:v, 1-31, lower = better)
+#
+# Dependencies:
+#   - loom-dl (npm install -g loom-dl)
+#   - ffmpeg  (brew install ffmpeg, or your distro's package manager)
+
+set -euo pipefail
+
+URL="${1:-}"
+if [[ -z "$URL" ]]; then
+  echo "ERROR: Usage: process-loom.sh <loom-share-url>" >&2
+  exit 1
+fi
+
+OUTPUT_ROOT="${OUTPUT_ROOT:-${TMPDIR:-/tmp}/loom-vision}"
+FRAME_INTERVAL_SECONDS="${FRAME_INTERVAL_SECONDS:-5}"
+FRAME_MAX_WIDTH_PX="${FRAME_MAX_WIDTH_PX:-1280}"
+FRAME_QUALITY="${FRAME_QUALITY:-3}"
+
+# Sanity-check deps so the script fails loudly with a clear message instead
+# of midway through the pipeline.
+if ! command -v loom-dl >/dev/null 2>&1; then
+  echo "ERROR: loom-dl not found in PATH. Install with: npm install -g loom-dl" >&2
+  exit 2
+fi
+if ! command -v ffmpeg >/dev/null 2>&1; then
+  echo "ERROR: ffmpeg not found in PATH. Install with: brew install ffmpeg" >&2
+  exit 2
+fi
+
+# Extract video ID from URL - Loom share URLs are .../share/<32-hex>/...
+VIDEO_ID=$(echo "$URL" | grep -oE '[a-f0-9]{32}' | head -1)
+if [[ -z "$VIDEO_ID" ]]; then
+  echo "ERROR: Could not extract a 32-hex video ID from URL: $URL" >&2
+  echo "       Expected format: https://www.loom.com/share/<32-hex-id>/..." >&2
+  exit 1
+fi
+
+OUTPUT_DIR="$OUTPUT_ROOT/loom-$VIDEO_ID"
+mkdir -p "$OUTPUT_DIR"
+
+echo "Downloading Loom video $VIDEO_ID..." >&2
+loom-dl --url "$URL" --out "$OUTPUT_DIR/video.mp4" --transcript 2>&2
+
+echo "Sampling frames (1 per ${FRAME_INTERVAL_SECONDS}s, max width ${FRAME_MAX_WIDTH_PX}px)..." >&2
+ffmpeg -y -i "$OUTPUT_DIR/video.mp4" \
+  -vf "fps=1/${FRAME_INTERVAL_SECONDS},scale=${FRAME_MAX_WIDTH_PX}:-1" \
+  -q:v "$FRAME_QUALITY" \
+  "$OUTPUT_DIR/frame_%03d.jpg" 2>/dev/null
+
+FRAME_COUNT=$(ls "$OUTPUT_DIR"/frame_*.jpg 2>/dev/null | wc -l | tr -d ' ')
+DURATION=$(ffmpeg -i "$OUTPUT_DIR/video.mp4" 2>&1 | grep Duration | awk '{print $2}' | tr -d ',' || echo "unknown")
+
+echo "Processed: $FRAME_COUNT frames, duration $DURATION" >&2
+echo "$OUTPUT_DIR"


### PR DESCRIPTION
## What this is

A submission-ready package for publishing the Loom Vision skill to [ClawHub.ai](https://clawhub.ai) (OpenClaw's public registry). **Nothing is submitted by this PR** - it stages the publishable bundle plus a runbook you follow to publish it yourself.

## What's in it

- `plugins/loom-vision/clawhub/loom-vision/` - the exact folder you point `clawhub skill publish` at:
  - `SKILL.md` - ClawHub-ready frontmatter (name/description/version, `metadata.openclaw` with emoji, homepage, `requires.bins`, install specs for loom-dl + ffmpeg, and optional `envVars` declared so the registry's security analysis passes). Chassis-only fields (`plugin:`, `enabled_when:`) removed.
  - `process-loom.sh` - standalone copy of the chassis script (only diffs: OUTPUT_ROOT defaults to `${TMPDIR:-/tmp}/loom-vision` instead of `${CHASSIS_HOME}/temp`; chassis references dropped from comments).
  - `README.md` - bundle README with `clawhub install` instructions and the Behalf.bot pointer.
- `plugins/loom-vision/CLAWHUB_SUBMISSION.md` - the numbered submit checklist (account, CLI, auth, dry run, publish, scan hold, verification), verified against docs.openclaw.ai/clawhub on 2026-07-07.

Chassis plugin files (`openclaw.plugin.json`, `setup.sh`, `skills/loom-vision/`) are untouched.

## Key findings from the docs

- Loom Vision goes to ClawHub as a **skill** (SKILL.md bundle), not a plugin package - no package.json/npm scope needed. Submission is CLI-only: `clawhub skill publish <folder>` after GitHub sign-in at clawhub.ai.
- **Licensing decision needed before you publish:** ClawHub releases ALL skills under MIT-0 (no attribution, commercial use allowed, no per-skill overrides). This repo is O'Saasy. You own the copyright, so publishing dual-licenses this one bundle as MIT-0 - flagged prominently in the runbook.
- New releases sit in a security-scan hold before appearing on public install surfaces; status visible at clawhub.ai/dashboard.

## Submit checklist (short form)

1. Merge this PR, decide on the MIT-0 licensing point
2. Sign in at clawhub.ai with GitHub (scrollinondubs)
3. `npm i -g clawhub && clawhub login && clawhub whoami`
4. `clawhub skill publish plugins/loom-vision/clawhub/loom-vision --dry-run`
5. Same command without `--dry-run` (plus `--slug loom-vision --name "Loom Vision"`)
6. Watch the scan at clawhub.ai/dashboard, then verify with `clawhub inspect @<handle>/loom-vision --files` and a scratch-dir `clawhub install`

Full detail in `plugins/loom-vision/CLAWHUB_SUBMISSION.md`.