### PR TITLE
feat(second-brain): Obsidian adapter over direct vault file IO (#55)

### DIFF
--- a/chassis/second_brain/factory.py
+++ b/chassis/second_brain/factory.py
@@ -98,7 +98,7 @@ def _resolve_env(value: Any) -> Any:
 def get_adapter(config_path: Path | None = None) -> SecondBrainAdapter:
     """Return the adapter configured in chassis.config.yaml.
 
-    Reads `second_brain.backend` and the matching backend block (siyuan / notion).
+    Reads `second_brain.backend` and the matching backend block (siyuan / notion / obsidian).
     Resolves `${VAR}` env-var references against the chassis .env (assumed loaded
     by the caller — chassis bootstrap does this in its launchd-equivalent unit).
     """
@@ -108,7 +108,7 @@ def get_adapter(config_path: Path | None = None) -> SecondBrainAdapter:
     if not backend:
         raise ValueError(
             "chassis.config.yaml is missing second_brain.backend. "
-            "Set it to one of: siyuan, notion."
+            "Set it to one of: siyuan, notion, obsidian."
         )
     backend_config = sb_config.get(backend) or {}
     if backend == "siyuan":
@@ -130,7 +130,15 @@ def get_adapter(config_path: Path | None = None) -> SecondBrainAdapter:
             natural_keys=backend_config.get("natural_keys") or {},
             active_database=backend_config.get("active_database"),
         )
+    if backend == "obsidian":
+        from chassis.second_brain.obsidian import ObsidianAdapter
+
+        return ObsidianAdapter(
+            vault_path=_resolve_env(backend_config.get("vault_path", "")),
+            vault_name=_resolve_env(backend_config.get("vault_name", "")) or None,
+            read_only=bool(backend_config.get("read_only", False)),
+        )
     raise ValueError(
         f"Unsupported second_brain.backend={backend!r}. "
-        f"V1 supports: siyuan, notion. Obsidian deferred to V2."
+        f"Supported backends: siyuan, notion, obsidian."
     )

--- a/chassis/second_brain/obsidian.py
+++ b/chassis/second_brain/obsidian.py
@@ -1,0 +1,258 @@
+"""Obsidian adapter - markdown vault over direct file IO.
+
+An Obsidian vault is a plain directory of markdown files, so this adapter
+needs no Obsidian process, plugin, or API - it reads and writes the vault
+directly. Doc ids are vault-relative paths (e.g. `Briefings/2026-07-09.md`);
+the `.md` suffix is optional on input and normalized on output.
+
+Read-only vaults are a first-class case, not an error state. A pull-only
+install (e.g. a git clone synced through a read-only deploy key) sets
+`read_only: true` in config, and the adapter also checks the filesystem at
+write time. Config states intent; the filesystem states truth; when they
+disagree the write is refused and the error says which side blocked it.
+Writes that do proceed are atomic (temp file in the target directory, then
+`os.replace`) so an interrupted write can never truncate an existing note.
+
+Database surface is NOT implemented - Obsidian has no native structured-row
+semantics. Use NotesAdapter only.
+
+Config (chassis.config.yaml):
+
+    second_brain:
+      backend: obsidian
+      obsidian:
+        vault_path: /home/user/second-brain   # absolute path to the vault root
+        vault_name: second-brain               # for obsidian:// deeplinks; defaults to the directory name
+        read_only: false                       # true for pull-only vault clones
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from urllib.parse import quote
+
+from chassis.second_brain.base import (
+    NotImplementedDatabase,
+    NotesAdapter,
+    SearchHit,
+    SecondBrainAdapter,
+)
+
+# Vault housekeeping directories that search should never surface.
+_SKIP_DIRS = {".obsidian", ".git", ".trash", ".github"}
+
+_SNIPPET_LEN = 200
+
+
+class ObsidianError(RuntimeError):
+    """Raised on vault IO failures - missing docs, bad paths, unreadable files."""
+
+
+class ObsidianReadOnlyError(ObsidianError):
+    """Raised when a write is attempted against a read-only vault.
+
+    Named separately so callers can distinguish "the vault forbids writes"
+    (expected on pull-only installs) from genuine IO failures.
+    """
+
+
+class ObsidianNotes(NotesAdapter):
+    def __init__(
+        self,
+        vault_path: str,
+        vault_name: str | None = None,
+        read_only: bool = False,
+    ) -> None:
+        if not vault_path:
+            raise ObsidianError(
+                "second_brain.obsidian.vault_path is not set in chassis.config.yaml. "
+                "Point it at the vault's root directory."
+            )
+        self._vault = Path(vault_path).expanduser().resolve()
+        if not self._vault.is_dir():
+            raise ObsidianError(
+                f"Obsidian vault_path {str(self._vault)!r} does not exist or is not a directory."
+            )
+        self._vault_name = vault_name or self._vault.name
+        self._read_only = read_only
+
+    # -- path safety ---------------------------------------------------------
+
+    def _resolve(self, doc_id: str) -> Path:
+        """Map a vault-relative doc id to an absolute path inside the vault.
+
+        Rejects absolute paths and traversal (`../`) - a doc id must never
+        resolve outside the vault root, whichever direction it came from.
+        """
+        if not doc_id or not doc_id.strip():
+            raise ObsidianError("doc_id is empty - expected a vault-relative path.")
+        raw = doc_id.strip()
+        if Path(raw).is_absolute():
+            raise ObsidianError(
+                f"doc_id {doc_id!r} is an absolute path - doc ids are vault-relative."
+            )
+        candidate = (self._vault / raw).resolve()
+        if candidate != self._vault and self._vault not in candidate.parents:
+            raise ObsidianError(
+                f"doc_id {doc_id!r} resolves outside the vault root - refusing."
+            )
+        if candidate == self._vault:
+            raise ObsidianError(
+                f"doc_id {doc_id!r} resolves to the vault root itself, not a note."
+            )
+        if candidate.suffix != ".md":
+            candidate = candidate.with_suffix(candidate.suffix + ".md")
+        return candidate
+
+    def _rel_id(self, path: Path) -> str:
+        return path.relative_to(self._vault).as_posix()
+
+    # -- write safety --------------------------------------------------------
+
+    def _ensure_writable(self, op: str, directory: Path) -> None:
+        """Refuse writes when config or the filesystem says the vault is read-only.
+
+        Config states intent, the filesystem states truth. Both are checked;
+        when they disagree, the error says so, and the write is refused either
+        way - a pull-only vault (e.g. synced via a read-only deploy key) must
+        fail loudly here, never half-write or silently no-op.
+        """
+        probe = directory if directory.exists() else self._vault
+        fs_writable = os.access(probe, os.W_OK)
+        if self._read_only:
+            detail = (
+                " (the filesystem currently permits writes, but config intent wins)"
+                if fs_writable
+                else ""
+            )
+            raise ObsidianReadOnlyError(
+                f"NotesAdapter.{op} refused: vault {str(self._vault)!r} is configured "
+                f"read_only: true in chassis.config.yaml{detail}. This is expected for "
+                f"pull-only vault clones - nothing was written."
+            )
+        if not fs_writable:
+            raise ObsidianReadOnlyError(
+                f"NotesAdapter.{op} refused: {str(probe)!r} is not writable by this "
+                f"process, even though config does not set read_only: true - the "
+                f"filesystem is the source of truth here. Nothing was written."
+            )
+
+    @staticmethod
+    def _atomic_write(target: Path, text: str) -> None:
+        """Write via temp file + rename so a crash can never truncate a note."""
+        fd, tmp_name = tempfile.mkstemp(
+            dir=str(target.parent), prefix=".obsidian-adapter-", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(text)
+            os.replace(tmp_name, target)
+        except BaseException:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
+
+    # -- NotesAdapter --------------------------------------------------------
+
+    def create_doc(self, parent: str, title: str, body: str) -> str:
+        # `parent` is a vault-relative directory like `Briefings/`; empty means
+        # the vault root (the configured default for this backend).
+        if not title or not title.strip():
+            raise ObsidianError("create_doc requires a non-empty title.")
+        rel = f"{parent.strip().strip('/')}/{title.strip()}" if parent.strip() else title.strip()
+        target = self._resolve(rel)
+        if target.exists():
+            raise ObsidianError(
+                f"create_doc refused: {self._rel_id(target)!r} already exists - "
+                f"refusing to overwrite. Use append_to_doc to add to it."
+            )
+        self._ensure_writable("create_doc", target.parent)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        self._atomic_write(target, body)
+        return self._rel_id(target)
+
+    def append_to_doc(self, doc_id: str, content: str) -> None:
+        target = self._resolve(doc_id)
+        if not target.is_file():
+            raise ObsidianError(
+                f"append_to_doc: doc {doc_id!r} not found in vault {str(self._vault)!r}."
+            )
+        self._ensure_writable("append_to_doc", target.parent)
+        existing = target.read_text(encoding="utf-8")
+        separator = "" if not existing or existing.endswith("\n") else "\n"
+        self._atomic_write(target, existing + separator + content)
+
+    def read_doc(self, doc_id: str) -> str:
+        target = self._resolve(doc_id)
+        if not target.is_file():
+            raise ObsidianError(
+                f"read_doc: doc {doc_id!r} not found in vault {str(self._vault)!r}."
+            )
+        return target.read_text(encoding="utf-8")
+
+    def get_deeplink(self, doc_id: str) -> str:
+        rel = self._rel_id(self._resolve(doc_id))
+        return (
+            f"obsidian://open?vault={quote(self._vault_name, safe='')}"
+            f"&file={quote(rel, safe='')}"
+        )
+
+    def link_blocks(self, from_id: str, to_id: str) -> None:
+        raise NotImplementedError(
+            "NotesAdapter.link_blocks is not implemented for backend='obsidian'. "
+            "Obsidian has no block ids in the SiYuan sense - fall back to appending "
+            "an inline markdown link (append_to_doc with a [[wikilink]] or relative "
+            "markdown link). See docs/second-brain-adapters.md."
+        )
+
+    def search(self, query: str, limit: int = 10) -> list[SearchHit]:
+        needle = query.lower()
+        hits: list[SearchHit] = []
+        for path in sorted(self._vault.rglob("*.md")):
+            rel_parts = path.relative_to(self._vault).parts
+            if any(part in _SKIP_DIRS for part in rel_parts):
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            name_match = needle in path.stem.lower()
+            body_index = text.lower().find(needle)
+            if not name_match and body_index < 0:
+                continue
+            if body_index >= 0:
+                start = max(0, body_index - 60)
+                snippet = text[start : start + _SNIPPET_LEN].strip()
+            else:
+                snippet = text[:_SNIPPET_LEN].strip()
+            rel = self._rel_id(path)
+            score = (2.0 if name_match else 0.0) + (1.0 if body_index >= 0 else 0.0)
+            hits.append(
+                SearchHit(
+                    id=rel,
+                    title=path.stem,
+                    snippet=snippet,
+                    deeplink=self.get_deeplink(rel),
+                    score=score,
+                    raw={"path": str(path)},
+                )
+            )
+        hits.sort(key=lambda hit: hit.score, reverse=True)
+        return hits[: int(limit)]
+
+
+class ObsidianAdapter(SecondBrainAdapter):
+    backend = "obsidian"
+
+    def __init__(
+        self,
+        vault_path: str,
+        vault_name: str | None = None,
+        read_only: bool = False,
+    ) -> None:
+        self.notes = ObsidianNotes(vault_path, vault_name, read_only)
+        self.database = NotImplementedDatabase("obsidian")

--- a/chassis/second_brain/tests/test_obsidian.py
+++ b/chassis/second_brain/tests/test_obsidian.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""test_obsidian.py - Unit tests for the Obsidian second-brain adapter.
+
+Everything runs against throwaway temp-dir vaults - no Obsidian process, no
+network. Covers: read, search, deeplink, create, append, writes against a
+read-only vault (config-declared and filesystem-enforced), path-traversal
+rejection, and the factory branch.
+
+Run:
+    python3 -m pytest chassis/second_brain/tests/test_obsidian.py -v
+    # or directly:
+    python3 chassis/second_brain/tests/test_obsidian.py
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Ensure the repo root is importable so `chassis.second_brain` resolves
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from chassis.second_brain.base import NotImplementedDatabase, SearchHit  # noqa: E402
+from chassis.second_brain.factory import get_adapter  # noqa: E402
+from chassis.second_brain.obsidian import (  # noqa: E402
+    ObsidianAdapter,
+    ObsidianError,
+    ObsidianNotes,
+    ObsidianReadOnlyError,
+)
+
+
+def _make_vault(root: Path) -> Path:
+    """Build a small vault: two notes, one nested, plus housekeeping dirs."""
+    vault = root / "second-brain"
+    (vault / "Briefings").mkdir(parents=True)
+    (vault / ".obsidian").mkdir()
+    (vault / "Inbox.md").write_text(
+        "# Inbox\n\nCall the notary about the apartment paperwork.\n",
+        encoding="utf-8",
+    )
+    (vault / "Briefings" / "2026-07-09.md").write_text(
+        "# Morning briefing\n\nThree items today - lead follow-ups, notary, padel.\n",
+        encoding="utf-8",
+    )
+    (vault / ".obsidian" / "workspace.md").write_text("notary", encoding="utf-8")
+    return vault
+
+
+class ObsidianVaultTestCase(unittest.TestCase):
+    """Shared temp-vault scaffolding."""
+
+    def setUp(self) -> None:
+        self._tmp = Path(tempfile.mkdtemp(prefix="obsidian-adapter-test-"))
+        self.vault = _make_vault(self._tmp)
+        self.notes = ObsidianNotes(str(self.vault))
+        self.addCleanup(self._cleanup)
+
+    def _cleanup(self) -> None:
+        # Restore write bits so rmtree can clean read-only test vaults
+        for dirpath, _dirnames, _filenames in os.walk(self._tmp):
+            os.chmod(dirpath, stat.S_IRWXU)
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+
+class TestReadDoc(ObsidianVaultTestCase):
+    def test_read_doc_returns_markdown_body(self):
+        body = self.notes.read_doc("Briefings/2026-07-09.md")
+        self.assertIn("# Morning briefing", body)
+
+    def test_read_doc_md_suffix_optional(self):
+        self.assertEqual(
+            self.notes.read_doc("Inbox"),
+            self.notes.read_doc("Inbox.md"),
+        )
+
+    def test_read_doc_missing_raises(self):
+        with self.assertRaises(ObsidianError) as ctx:
+            self.notes.read_doc("Briefings/nope.md")
+        self.assertIn("not found", str(ctx.exception))
+
+
+class TestSearch(ObsidianVaultTestCase):
+    def test_search_matches_content(self):
+        hits = self.notes.search("notary")
+        ids = [hit.id for hit in hits]
+        self.assertIn("Inbox.md", ids)
+        self.assertIn("Briefings/2026-07-09.md", ids)
+
+    def test_search_matches_filename(self):
+        hits = self.notes.search("2026-07-09")
+        self.assertEqual(hits[0].id, "Briefings/2026-07-09.md")
+        self.assertEqual(hits[0].title, "2026-07-09")
+
+    def test_search_returns_searchhit_shape(self):
+        hit = self.notes.search("notary", limit=1)[0]
+        self.assertIsInstance(hit, SearchHit)
+        self.assertTrue(hit.snippet)
+        self.assertTrue(hit.deeplink.startswith("obsidian://open?vault="))
+        self.assertGreater(hit.score, 0.0)
+
+    def test_search_respects_limit(self):
+        self.assertEqual(len(self.notes.search("notary", limit=1)), 1)
+
+    def test_search_skips_housekeeping_dirs(self):
+        ids = [hit.id for hit in self.notes.search("notary", limit=50)]
+        self.assertNotIn(".obsidian/workspace.md", ids)
+
+    def test_search_no_match_returns_empty(self):
+        self.assertEqual(self.notes.search("zzz-no-such-token"), [])
+
+
+class TestDeeplink(ObsidianVaultTestCase):
+    def test_deeplink_format_and_encoding(self):
+        link = self.notes.get_deeplink("Briefings/2026-07-09.md")
+        self.assertEqual(
+            link,
+            "obsidian://open?vault=second-brain&file=Briefings%2F2026-07-09.md",
+        )
+
+    def test_deeplink_uses_configured_vault_name(self):
+        notes = ObsidianNotes(str(self.vault), vault_name="My Vault")
+        self.assertIn("vault=My%20Vault", notes.get_deeplink("Inbox.md"))
+
+
+class TestWrites(ObsidianVaultTestCase):
+    def test_create_doc_writes_and_returns_id(self):
+        doc_id = self.notes.create_doc("Briefings/", "2026-07-10", "# Tomorrow\n")
+        self.assertEqual(doc_id, "Briefings/2026-07-10.md")
+        self.assertEqual(self.notes.read_doc(doc_id), "# Tomorrow\n")
+
+    def test_create_doc_empty_parent_uses_vault_root(self):
+        doc_id = self.notes.create_doc("", "Scratch", "hello")
+        self.assertEqual(doc_id, "Scratch.md")
+
+    def test_create_doc_creates_missing_parent_dirs(self):
+        doc_id = self.notes.create_doc("Projects/Chassis", "Notes", "body")
+        self.assertEqual(doc_id, "Projects/Chassis/Notes.md")
+
+    def test_create_doc_refuses_overwrite(self):
+        with self.assertRaises(ObsidianError) as ctx:
+            self.notes.create_doc("", "Inbox", "clobber")
+        self.assertIn("already exists", str(ctx.exception))
+        self.assertIn("notary", self.notes.read_doc("Inbox.md"))
+
+    def test_append_to_doc(self):
+        self.notes.append_to_doc("Inbox.md", "New line.\n")
+        body = self.notes.read_doc("Inbox.md")
+        self.assertTrue(body.endswith("New line.\n"))
+        self.assertIn("notary", body)
+
+    def test_append_to_missing_doc_raises(self):
+        with self.assertRaises(ObsidianError):
+            self.notes.append_to_doc("nope.md", "content")
+
+    def test_link_blocks_not_implemented(self):
+        with self.assertRaises(NotImplementedError) as ctx:
+            self.notes.link_blocks("Inbox.md", "Briefings/2026-07-09.md")
+        self.assertIn("obsidian", str(ctx.exception).lower())
+
+
+class TestReadOnlyVault(ObsidianVaultTestCase):
+    def test_config_read_only_blocks_create(self):
+        notes = ObsidianNotes(str(self.vault), read_only=True)
+        with self.assertRaises(ObsidianReadOnlyError) as ctx:
+            notes.create_doc("Briefings/", "2026-07-10", "body")
+        self.assertIn("read_only: true", str(ctx.exception))
+        self.assertFalse((self.vault / "Briefings" / "2026-07-10.md").exists())
+
+    def test_config_read_only_blocks_append(self):
+        notes = ObsidianNotes(str(self.vault), read_only=True)
+        before = (self.vault / "Inbox.md").read_text(encoding="utf-8")
+        with self.assertRaises(ObsidianReadOnlyError):
+            notes.append_to_doc("Inbox.md", "should never land")
+        self.assertEqual((self.vault / "Inbox.md").read_text(encoding="utf-8"), before)
+
+    def test_config_read_only_still_reads(self):
+        notes = ObsidianNotes(str(self.vault), read_only=True)
+        self.assertIn("notary", notes.read_doc("Inbox.md"))
+        self.assertTrue(notes.search("notary"))
+
+    @unittest.skipIf(os.geteuid() == 0, "root ignores permission bits")
+    def test_filesystem_read_only_blocks_write_and_names_cause(self):
+        # Config claims writable; the filesystem says otherwise. The filesystem wins.
+        for dirpath, _dirnames, _filenames in os.walk(self.vault):
+            os.chmod(dirpath, stat.S_IRUSR | stat.S_IXUSR)
+        with self.assertRaises(ObsidianReadOnlyError) as ctx:
+            self.notes.append_to_doc("Inbox.md", "should never land")
+        self.assertIn("not writable", str(ctx.exception))
+        with self.assertRaises(ObsidianReadOnlyError):
+            self.notes.create_doc("", "Scratch", "body")
+
+    @unittest.skipIf(os.geteuid() == 0, "root ignores permission bits")
+    def test_filesystem_read_only_leaves_no_partial_files(self):
+        for dirpath, _dirnames, _filenames in os.walk(self.vault):
+            os.chmod(dirpath, stat.S_IRUSR | stat.S_IXUSR)
+        with self.assertRaises(ObsidianReadOnlyError):
+            self.notes.create_doc("", "Scratch", "body")
+        os.chmod(self.vault, stat.S_IRWXU)
+        leftovers = [p.name for p in self.vault.iterdir() if p.name.startswith(".obsidian-adapter-")]
+        self.assertEqual(leftovers, [])
+        self.assertFalse((self.vault / "Scratch.md").exists())
+
+
+class TestPathTraversal(ObsidianVaultTestCase):
+    def test_read_traversal_rejected(self):
+        with self.assertRaises(ObsidianError) as ctx:
+            self.notes.read_doc("../../etc/passwd")
+        self.assertIn("outside the vault root", str(ctx.exception))
+
+    def test_absolute_path_rejected(self):
+        with self.assertRaises(ObsidianError) as ctx:
+            self.notes.read_doc("/etc/passwd")
+        self.assertIn("absolute path", str(ctx.exception))
+
+    def test_write_traversal_rejected(self):
+        outside = self._tmp / "escape.md"
+        with self.assertRaises(ObsidianError):
+            self.notes.create_doc("..", "escape", "body")
+        self.assertFalse(outside.exists())
+
+    def test_sneaky_nested_traversal_rejected(self):
+        with self.assertRaises(ObsidianError):
+            self.notes.read_doc("Briefings/../../outside.md")
+
+
+class TestFactory(ObsidianVaultTestCase):
+    def _write_config(self, extra: str = "") -> Path:
+        config = self._tmp / "chassis.config.yaml"
+        config.write_text(
+            "second_brain:\n"
+            "  backend: obsidian\n"
+            "  obsidian:\n"
+            f"    vault_path: {self.vault}\n"
+            f"{extra}",
+            encoding="utf-8",
+        )
+        return config
+
+    def test_factory_returns_obsidian_adapter(self):
+        adapter = get_adapter(self._write_config())
+        self.assertIsInstance(adapter, ObsidianAdapter)
+        self.assertEqual(adapter.backend, "obsidian")
+        self.assertIsInstance(adapter.database, NotImplementedDatabase)
+        self.assertIn("notary", adapter.notes.read_doc("Inbox.md"))
+
+    def test_factory_passes_read_only_through(self):
+        adapter = get_adapter(self._write_config("    read_only: true\n"))
+        with self.assertRaises(ObsidianReadOnlyError):
+            adapter.notes.create_doc("", "Scratch", "body")
+
+    def test_factory_unknown_backend_lists_all_three(self):
+        config = self._tmp / "chassis.config.yaml"
+        config.write_text("second_brain:\n  backend: roam\n", encoding="utf-8")
+        with self.assertRaises(ValueError) as ctx:
+            get_adapter(config)
+        self.assertIn("siyuan, notion, obsidian", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/docs/second-brain-adapters.md
+++ b/docs/second-brain-adapters.md
@@ -13,7 +13,7 @@ A second brain has both prose and structured semantics. We split them into two c
 | `notes` | Briefings, content stubs, daily logs, Pacman proposals, free-form prose | Page/block APIs |
 | `database` | LP CRM rows, deal pipelines, contacts, tasks, scheduling | Database / property APIs |
 
-Notion implements both natively. SiYuan implements `notes` natively and raises `NotImplementedError` on `database`. Obsidian (V2) will likely fake `database` via structured frontmatter index files.
+Notion implements both natively. SiYuan and Obsidian implement `notes` natively and raise `NotImplementedError` on `database`. Faking `database` via structured frontmatter index files in Obsidian is a possible follow-up.
 
 ## V1 backends
 
@@ -21,7 +21,7 @@ Notion implements both natively. SiYuan implements `notes` natively and raises `
 |---|---|---|
 | `siyuan` | ✅ V1 (notes only; `database` raises `NotImplementedError`) | Sean's primary; HTTP kernel API + SQL search |
 | `notion` | ✅ V1 (both surfaces) | V1 installer #1 primary; Notion REST API |
-| `obsidian` | ❌ V2 | Marc's Protocol Labs leaning; deferred |
+| `obsidian` | ✅ V1 (notes only; `database` raises `NotImplementedError`) | Direct file IO on the vault directory; read-only vaults first-class ([#55](https://github.com/scrollinondubs/behalfbot/issues/55)) |
 
 ## Configuration
 
@@ -55,6 +55,21 @@ second_brain:
       startup_pipeline: deal_name
     active_database: lp_crm                             # default for upsert/query
 ```
+
+### Obsidian
+
+```yaml
+second_brain:
+  backend: obsidian
+  obsidian:
+    vault_path: /home/hugues/second-brain   # absolute path to the vault root
+    vault_name: second-brain                 # for obsidian:// deeplinks; defaults to the directory name
+    read_only: true                          # pull-only vault clone (e.g. read-only deploy key)
+```
+
+Doc ids are vault-relative paths (`Briefings/2026-07-09.md`; the `.md` suffix is optional on input). `create_doc` treats `parent` as a vault-relative directory and empty `parent` as the vault root. No Obsidian process or plugin is required - the adapter reads and writes the vault files directly.
+
+Read-only vaults are first-class: with `read_only: true`, or when the filesystem itself denies writes (pull-only git clone through a read-only deploy key), `create_doc` / `append_to_doc` raise `ObsidianReadOnlyError` naming the cause. Config states intent, the filesystem states truth - a write is refused if either side blocks it, and the error says which. Writes that do proceed are atomic (temp file + rename), doc ids that resolve outside the vault root are rejected, and `create_doc` refuses to overwrite an existing note.
 
 `${VAR}` references resolve against `os.environ` at import time; chassis bootstrap loads `.env` before any plugin imports the adapter.
 
@@ -110,10 +125,10 @@ The `SearchHit` dataclass is the canonical return shape for both `notes.search` 
 
 ## Migration to V2
 
-When Obsidian + multi-backend writes land:
+Obsidian landed in V1 via [#55](https://github.com/scrollinondubs/behalfbot/issues/55) (`chassis/second_brain/obsidian.py`, direct file IO, `obsidian` branch in `factory.get_adapter`). Still V2:
 
-1. Add `chassis/second_brain/obsidian.py` implementing `NotesAdapter` over the Local REST API plugin or direct file IO.
-2. Extend `factory.get_adapter` with the `obsidian` branch.
-3. Decide migration tool placement — likely `chassis/scripts/sb-migrate.py` running source→destination via the adapter interfaces.
+1. Multi-backend writes / migration tooling - likely `chassis/scripts/sb-migrate.py` running source→destination via the adapter interfaces.
+2. Obsidian `database` surface faked via structured frontmatter index files, if an installer needs it.
+3. Obsidian Local REST API plugin integration (live-app features like block-level linking), if direct file IO proves insufficient.
 
-Until then, the adapters above cover the V1 installer set (SiYuan / Notion).
+Until then, the adapters above cover the V1 installer set (SiYuan / Notion / Obsidian).


### PR DESCRIPTION
## Summary

Implements the Obsidian second-brain adapter behind the existing factory abstraction: `chassis/second_brain/obsidian.py` conforming to the `NotesAdapter` protocol in `base.py`, over direct file IO on the vault directory - no Obsidian process, plugin, or API needed. Unblocks Hugues Borel's live install (`second_brain.backend: obsidian` on his Hetzner VPS) which would otherwise hit the factory's `ValueError` at first briefing.

Closes #55

## What changed

- `chassis/second_brain/obsidian.py` (new) - `read_doc`, `search` (content + filename over the vault's markdown, skipping `.obsidian`/`.git`/`.trash`), `create_doc`, `append_to_doc`, `get_deeplink` (`obsidian://open?vault=...&file=<url-encoded-path>`). `link_blocks` raises `NotImplementedError` naming Obsidian (no block ids in the SiYuan sense); database half reuses `NotImplementedDatabase(backend="obsidian")` exactly as `siyuan.py` does.
- `chassis/second_brain/factory.py` - `obsidian` branch wired in; both error messages now list all three backends.
- `chassis/second_brain/tests/test_obsidian.py` (new) - 30 unit tests, unittest style matching the existing `plugins/restaurant-booking/tests/` layout, runnable directly or via pytest.
- `docs/second-brain-adapters.md` - table row flipped to V1, Obsidian config section added, migration section rewritten to reflect what shipped vs what remains V2.

## Read-only vaults are first-class

Hugues' vault is a pull-only git clone through a read-only GitHub deploy key. His stated single greatest fear is data loss, so the write path is built around refusing loudly and never damaging anything:

- `second_brain.obsidian.read_only: true` declares intent in config; the filesystem is probed at write time as truth. A write is refused if either side blocks it, and the `ObsidianReadOnlyError` message names which one (and notes the disagreement when config and filesystem differ).
- Writes are atomic: temp file in the target directory then `os.replace`, temp file unlinked on any failure - an interrupted write can never truncate an existing note, and verified no partial or temp files are left behind.
- `doc_id` values are vault-relative; absolute paths and traversal (`../../etc/passwd`) are rejected before any IO.
- `create_doc` refuses to overwrite an existing note.

## Test plan

- [x] `python3 chassis/second_brain/tests/test_obsidian.py` - 30 tests, all pass (Python 3.14, no PyYAML: exercises the factory's minimal-YAML fallback)
- [x] `python3 -m pytest chassis/second_brain/tests/ plugins/restaurant-booking/tests/ -q` in a venv with PyYAML installed - 46 passed (30 new + 16 pre-existing, production parse path)
- [x] Live E2E: throwaway vault + real `chassis.config.yaml`, loaded through `factory.get_adapter()` - `read_doc`, `search`, `create_doc`, `append_to_doc`, deeplink all verified by observed output
- [x] `chmod -R a-w` on the vault: `append_to_doc`/`create_doc` raise `ObsidianReadOnlyError` naming the unwritable path, reads still work, existing notes byte-identical, zero temp-file leftovers
- [x] `read_only: true` on a writable vault: write refused with an error stating config intent wins and the filesystem currently permits writes
- [ ] After merge: flip Hugues' install to the new chassis version and confirm his first briefing reads the vault

## Notes

- SiYuan and Notion adapters untouched.
- `chassis/VERSION` not bumped - Sean's call per the ask-first convention; this is a feature so it warrants a minor bump if desired (currently no bump keeps the version-validate workflow quiet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)