### PR TITLE
feat(second-brain): Stage 1 - secondbrain MCP server, second_brain.mode, list_recent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,19 @@ VAULTWARDEN_DOMAIN=http://localhost:8222
 # Token: SiYuan Settings > About > API token.
 # SIYUAN_URL=http://host.docker.internal:6806
 # SIYUAN_TOKEN=
+#
+# Deeplink prefix. A block id is appended to this verbatim, so it MUST end with
+# whatever separator the target expects (a trailing `=` or `/`).
+#
+# The chassis default is `siyuan://blocks/`, which opens the SiYuan DESKTOP APP.
+# It does NOT open on a phone. For links that are clickable on mobile, point this
+# at your SiYuan web UI instead - the shape is:
+#
+#   https://<your-siyuan-host>:6806/stage/build/desktop/?id=
+#
+# Substitute your own reachable hostname (public DNS, Tailnet, reverse proxy).
+# Set it here, in ONE place: the host moves, the code should not.
+# SIYUAN_DEEPLINK_BASE=
 
 # Notion. Internal integration token from notion.so/my-integrations. The target
 # pages must be explicitly shared with the integration.

--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,22 @@ VAULTWARDEN_ADMIN_TOKEN=CHANGEME_run_openssl_rand_base64_32
 # public-facing URL.
 VAULTWARDEN_HOST_PORT=8222
 VAULTWARDEN_DOMAIN=http://localhost:8222
+
+# --- Second brain -----------------------------------------------------------
+# Credentials for the backend named in chassis.config.yaml `second_brain.backend`.
+# ONE source for both modes: the native MCP server (mode: direct) and the
+# chassis `secondbrain` adapter server (mode: adapter) read these same vars.
+# Set only the pair matching your backend; leave the rest unset.
+#
+# SiYuan. From inside the chassis container the kernel lives on the HOST, so
+# host.docker.internal - NOT 127.0.0.1, which resolves to the container itself.
+# Token: SiYuan Settings > About > API token.
+# SIYUAN_URL=http://host.docker.internal:6806
+# SIYUAN_TOKEN=
+
+# Notion. Internal integration token from notion.so/my-integrations. The target
+# pages must be explicitly shared with the integration.
+# NOTION_API_TOKEN=
+
+# Obsidian needs no credential - set second_brain.obsidian.vault_path in
+# chassis.config.yaml instead.

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,41 @@
+name: Python tests
+
+# First pytest workflow in the repo (added with the second-brain Stage 1 PR -
+# before this, no CI ran the Python suites at all). Scoped to the paths the
+# suite actually covers so unrelated PRs don't pay for it.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'chassis/second_brain/**'
+      - 'chassis/scripts/hydrate-mcp-json.py'
+      - 'chassis/.mcp.json.template'
+      - 'chassis.config.yaml'
+      - 'requirements.txt'
+      - '.github/workflows/python-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'chassis/second_brain/**'
+      - 'chassis/scripts/hydrate-mcp-json.py'
+      - 'chassis/.mcp.json.template'
+      - 'chassis.config.yaml'
+      - 'requirements.txt'
+      - '.github/workflows/python-tests.yml'
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      # Install only what the suite needs, not the full chassis image deps
+      # (psycopg/pillow/boto3 are runtime-only and slow the job for nothing).
+      # mcp is pinned to the same version as requirements.txt so the e2e
+      # server test exercises what the image ships.
+      - run: pip install pytest pyyaml mcp==1.28.1
+      - run: python3 -m pytest chassis/second_brain/tests/ -v

--- a/chassis.config.yaml
+++ b/chassis.config.yaml
@@ -125,8 +125,50 @@ second_brain:
   organization_pattern: para               # Tiago Forte: Projects / Areas / Resources / Archives
   databases:
     primary_crm: TBD_at_install             # Notion database id
-    notes_root: TBD_at_install              # Page id for free-form prose writes
+    notes_root: TBD_at_install              # Page id for free-form prose writes. Doubles as the
+                                            # default write target for the adapter (SiYuan
+                                            # notebook_id / Notion notes_root) unless the
+                                            # per-backend block below overrides it.
   scaffold_para_if_missing: true            # If their Notion isn't PARA-shaped, scaffold it
+
+  # ---------------------------------------------------------------------------
+  # Per-backend blocks - OPTIONAL OVERRIDES ONLY. Leave them commented out.
+  #
+  # CREDENTIALS COME FROM .env, NOT FROM HERE. Adapter mode (`mode: adapter`)
+  # and direct mode read the SAME vars, so a secret is never duplicated:
+  #
+  #   siyuan   -> SIYUAN_URL, SIYUAN_TOKEN
+  #   notion   -> NOTION_API_TOKEN
+  #   obsidian -> no credential; vault_path below is required (it is a path,
+  #               not a secret)
+  #
+  # Uncomment a key only to override the default. NEVER put a real token in
+  # this file - it is committed. Use a ${VAR} reference if you must name one.
+  # ---------------------------------------------------------------------------
+
+  # siyuan:
+  #   base_url: http://127.0.0.1:6806         # Default. From inside the chassis container the
+  #                                           # kernel is on the HOST: use
+  #                                           # http://host.docker.internal:6806
+  #   token: ${SIYUAN_TOKEN}                  # Default: env SIYUAN_TOKEN. Empty = hard error.
+  #   notebook_id: 20231101120000-abc123      # Default: second_brain.databases.notes_root
+  #   deeplink_template: siyuan://blocks/     # Default. Point at a reverse proxy
+  #                                           # (https://siyuan.example.com/?id=) for links
+  #                                           # that open on a phone.
+
+  # notion:
+  #   token: ${NOTION_API_TOKEN}              # Default: env NOTION_API_TOKEN
+  #   notes_root: 1234abcd-...                # Default: second_brain.databases.notes_root
+  #   databases:                              # Named databases for the structured surface
+  #     lp_crm: aaaa1111-...
+  #   natural_keys:                           # Uniqueness key per database, for upserts
+  #     lp_crm: email
+  #   active_database: lp_crm                 # Default database for upsert/query
+
+  # obsidian:
+  #   vault_path: /home/<installer>/second-brain   # REQUIRED for the obsidian backend
+  #   vault_name: second-brain                     # For obsidian:// deeplinks; defaults to dir name
+  #   read_only: false                             # true for a pull-only vault clone
 
 modules:
   admin: true                               # Rescheduling, travel, event research, email drafting

--- a/chassis.config.yaml
+++ b/chassis.config.yaml
@@ -137,7 +137,7 @@ second_brain:
   # CREDENTIALS COME FROM .env, NOT FROM HERE. Adapter mode (`mode: adapter`)
   # and direct mode read the SAME vars, so a secret is never duplicated:
   #
-  #   siyuan   -> SIYUAN_URL, SIYUAN_TOKEN
+  #   siyuan   -> SIYUAN_URL, SIYUAN_TOKEN, SIYUAN_DEEPLINK_BASE
   #   notion   -> NOTION_API_TOKEN
   #   obsidian -> no credential; vault_path below is required (it is a path,
   #               not a secret)
@@ -152,9 +152,14 @@ second_brain:
   #                                           # http://host.docker.internal:6806
   #   token: ${SIYUAN_TOKEN}                  # Default: env SIYUAN_TOKEN. Empty = hard error.
   #   notebook_id: 20231101120000-abc123      # Default: second_brain.databases.notes_root
-  #   deeplink_template: siyuan://blocks/     # Default. Point at a reverse proxy
-  #                                           # (https://siyuan.example.com/?id=) for links
-  #                                           # that open on a phone.
+  #   deeplink_template: siyuan://blocks/     # Default: env SIYUAN_DEEPLINK_BASE, else this.
+  #                                           # A block id is appended verbatim, so keep the
+  #                                           # trailing separator. `siyuan://blocks/` opens the
+  #                                           # DESKTOP APP and does NOT work on a phone. For
+  #                                           # mobile-clickable links use the web UI shape:
+  #                                           # https://<siyuan-host>:6806/stage/build/desktop/?id=
+  #                                           # Prefer setting SIYUAN_DEEPLINK_BASE in .env - the
+  #                                           # host changes, and .env is not committed.
 
   # notion:
   #   token: ${NOTION_API_TOKEN}              # Default: env NOTION_API_TOKEN

--- a/chassis.config.yaml
+++ b/chassis.config.yaml
@@ -110,6 +110,17 @@ surfaces:
 
 second_brain:
   backend: notion                           # notion | siyuan | obsidian
+  mode: direct                              # direct | adapter
+                                            # direct  = register the backend's own MCP server and keep
+                                            #           today's behavior (the default, also assumed when
+                                            #           this key is absent - installs that predate it
+                                            #           see zero change)
+                                            # adapter = register the chassis-owned `secondbrain` MCP
+                                            #           server INSTEAD of the native backend server, so
+                                            #           prompts see one tool namespace on every backend.
+                                            #           Note: obsidian has no native MCP server today,
+                                            #           so obsidian installs only get a second-brain
+                                            #           MCP surface in adapter mode.
   workspace: <installer-notion-workspace>   # Real workspace_id via Vaultwarden
   organization_pattern: para               # Tiago Forte: Projects / Areas / Resources / Archives
   databases:

--- a/chassis/.mcp.json.template
+++ b/chassis/.mcp.json.template
@@ -34,12 +34,12 @@
     },
 
     "_second-brain-pick-one": {
-      "_role": "Choose ONE based on chassis.config.yaml.second_brain.backend. Comment out / delete the unused entry."
+      "_role": "Second-brain surface is picked by chassis.config.yaml: second_brain.mode == 'adapter' registers ONLY the chassis-owned `secondbrain` server; mode 'direct' (the default, and what a missing mode key means) registers the backend's native server per second_brain.backend. Obsidian has no native MCP server - obsidian installs get a second-brain MCP surface only in adapter mode."
     },
 
     "siyuan": {
-      "_role": "second-brain backend (option A) — block-based notes, local-first",
-      "_enable_when": "chassis.config.yaml.second_brain.backend == 'siyuan'",
+      "_role": "second-brain backend (direct mode, option A) - block-based notes, local-first",
+      "_enable_when": "chassis.config.yaml.second_brain.backend == 'siyuan' && chassis.config.yaml.second_brain.mode != 'adapter'",
       "command": "npx",
       "args": ["-y", "siyuan-mcp@1.0.4"],
       "env": {
@@ -49,14 +49,22 @@
     },
 
     "notion": {
-      "_role": "second-brain backend (option B) — page+block model, cloud",
-      "_enable_when": "chassis.config.yaml.second_brain.backend == 'notion'",
+      "_role": "second-brain backend (direct mode, option B) - page+block model, cloud",
+      "_enable_when": "chassis.config.yaml.second_brain.backend == 'notion' && chassis.config.yaml.second_brain.mode != 'adapter'",
       "_install_note": "MCP package: @suekou/mcp-notion-server (popular community option). Verify before installing.",
       "command": "npx",
       "args": ["-y", "@suekou/mcp-notion-server"],
       "env": {
         "NOTION_API_TOKEN": "<NOTION_INTEGRATION_TOKEN>"
       }
+    },
+
+    "secondbrain": {
+      "_role": "second-brain surface (adapter mode) - ONE chassis-owned server over the chassis/second_brain adapter factory; identical tool names on every backend (create_doc, append_to_doc, read_doc, search, list_recent, get_deeplink)",
+      "_enable_when": "chassis.config.yaml.second_brain.mode == 'adapter'",
+      "_install_note": "In adapter mode the native backend server (siyuan/notion) is deliberately NOT registered - tool availability is the guardrail that keeps prompts backend-neutral. CHASSIS_ROOT is baked into the container image (/app/chassis); host-side layouts should point args at their vendored chassis tree, e.g. $CUSTOMER_HOME/chassis/chassis/second_brain/mcp_server.py.",
+      "command": "python3",
+      "args": ["${CHASSIS_ROOT:-/app/chassis}/second_brain/mcp_server.py"]
     },
 
     "_optional-feature-gated": {

--- a/chassis/.mcp.json.template
+++ b/chassis/.mcp.json.template
@@ -69,6 +69,7 @@
       "env": {
         "SIYUAN_URL": "<SIYUAN_URL>",
         "SIYUAN_TOKEN": "<SIYUAN_TOKEN>",
+        "SIYUAN_DEEPLINK_BASE": "<SIYUAN_DEEPLINK_BASE>",
         "NOTION_API_TOKEN": "<NOTION_INTEGRATION_TOKEN>"
       }
     },

--- a/chassis/.mcp.json.template
+++ b/chassis/.mcp.json.template
@@ -63,8 +63,14 @@
       "_role": "second-brain surface (adapter mode) - ONE chassis-owned server over the chassis/second_brain adapter factory; identical tool names on every backend (create_doc, append_to_doc, read_doc, search, list_recent, get_deeplink)",
       "_enable_when": "chassis.config.yaml.second_brain.mode == 'adapter'",
       "_install_note": "In adapter mode the native backend server (siyuan/notion) is deliberately NOT registered - tool availability is the guardrail that keeps prompts backend-neutral. CHASSIS_ROOT is baked into the container image (/app/chassis); host-side layouts should point args at their vendored chassis tree, e.g. $CUSTOMER_HOME/chassis/chassis/second_brain/mcp_server.py.",
+      "_env_note": "Same credential vars the native servers use, so adapter mode and direct mode read ONE source (.env) and no installer duplicates secrets into chassis.config.yaml. The factory reads whichever pair matches second_brain.backend and ignores the rest, so the vars for backends you do not run are expected to stay unset. Obsidian needs none - its vault_path is a config value, not a credential.",
       "command": "python3",
-      "args": ["${CHASSIS_ROOT:-/app/chassis}/second_brain/mcp_server.py"]
+      "args": ["${CHASSIS_ROOT:-/app/chassis}/second_brain/mcp_server.py"],
+      "env": {
+        "SIYUAN_URL": "<SIYUAN_URL>",
+        "SIYUAN_TOKEN": "<SIYUAN_TOKEN>",
+        "NOTION_API_TOKEN": "<NOTION_INTEGRATION_TOKEN>"
+      }
     },
 
     "_optional-feature-gated": {

--- a/chassis/scripts/hydrate-mcp-json.py
+++ b/chassis/scripts/hydrate-mcp-json.py
@@ -128,23 +128,45 @@ def parse_literal(token):
     return None
 
 
-def evaluate_enable_when(predicate, config):
-    """Evaluate a simple `<dotted.path> == <literal>` predicate.
+def evaluate_clause(clause, config):
+    """Evaluate one `<dotted.path> == <literal>` or `<dotted.path> != <literal>` clause.
 
-    Returns True if the LHS resolves and equals the literal, False otherwise.
+    Missing-key semantics differ by operator, deliberately:
+      - `==` on a missing path is False (an absent flag never enables).
+      - `!=` on a missing path is True (None != literal) - this is what lets
+        `second_brain.mode != 'adapter'` keep today's servers registered on
+        configs that predate the mode key.
+    """
+    if '!=' in clause and '==' not in clause:
+        lhs, _, rhs = clause.partition('!=')
+        parsed = parse_literal(rhs)
+        if parsed is None:
+            return False
+        _, expected = parsed
+        return resolve_path(config, lhs.strip()) != expected
+    if '==' in clause:
+        lhs, _, rhs = clause.partition('==')
+        parsed = parse_literal(rhs)
+        if parsed is None:
+            return False
+        _, expected = parsed
+        return resolve_path(config, lhs.strip()) == expected
+    return False
+
+
+def evaluate_enable_when(predicate, config):
+    """Evaluate an `_enable_when` predicate against the loaded config.
+
+    Supported grammar: one or more `<dotted.path> == <literal>` /
+    `<dotted.path> != <literal>` clauses joined by `&&` (all must hold).
     Conservatively returns False on any unrecognized predicate shape - we
     prefer dropping an entry over emitting a broken one when the predicate
     cannot be parsed.
     """
-    if '==' not in predicate:
+    clauses = [c.strip() for c in predicate.split('&&')]
+    if not clauses or any(not c for c in clauses):
         return False
-    lhs, _, rhs = predicate.partition('==')
-    actual = resolve_path(config, lhs.strip())
-    parsed = parse_literal(rhs)
-    if parsed is None:
-        return False
-    _, expected = parsed
-    return actual == expected
+    return all(evaluate_clause(clause, config) for clause in clauses)
 
 
 _PLACEHOLDER_PAT = re.compile(r'<([A-Z_][A-Z0-9_]*)>')

--- a/chassis/second_brain/__init__.py
+++ b/chassis/second_brain/__init__.py
@@ -25,7 +25,7 @@ from chassis.second_brain.base import (
     SearchHit,
     SecondBrainAdapter,
 )
-from chassis.second_brain.factory import get_adapter
+from chassis.second_brain.factory import get_adapter, get_mode
 
 __all__ = [
     "DatabaseAdapter",
@@ -33,4 +33,5 @@ __all__ = [
     "SearchHit",
     "SecondBrainAdapter",
     "get_adapter",
+    "get_mode",
 ]

--- a/chassis/second_brain/base.py
+++ b/chassis/second_brain/base.py
@@ -60,8 +60,9 @@ class NotesAdapter(Protocol):
         """Return a URL that, when clicked, opens the doc in the user's app/device.
 
         Per-backend conventions:
-          - SiYuan: typically `<deeplink_template>{id}` where the template is set
-            in chassis.config.yaml (e.g. `https://s.grid7.com/?id=`)
+          - SiYuan: `<deeplink_template>{id}`, where the template comes from
+            SIYUAN_DEEPLINK_BASE in .env (or a chassis.config.yaml override).
+            The per-install host is never hardcoded - see siyuan.py.
           - Notion: `https://www.notion.so/<workspace>/<page-id-without-hyphens>`
           - Obsidian: `obsidian://open?vault=<vault>&file=<path>`
         """

--- a/chassis/second_brain/base.py
+++ b/chassis/second_brain/base.py
@@ -18,6 +18,7 @@ Per-backend caveats live in each implementation module's docstring.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Protocol, runtime_checkable
 
 
@@ -77,6 +78,39 @@ class NotesAdapter(Protocol):
 
     def search(self, query: str, limit: int = 10) -> list[SearchHit]:
         """Full-text search prose. Returns hits ordered by relevance."""
+        ...
+
+    def list_recent(
+        self,
+        since: datetime,
+        until: datetime,
+        min_content_len: int = 0,
+        limit: int = 50,
+    ) -> list[SearchHit]:
+        """Docs created or modified in [since, until), newest first.
+
+        Naive datetimes are interpreted as local time; aware datetimes are
+        converted per backend. `min_content_len` filters out docs whose body is
+        shorter than the threshold, using the closest measure each backend can
+        offer honestly - the three are NOT byte-identical:
+
+          - SiYuan: block `updated` timestamps (kernel-local clock, second
+            granularity). Body length = SUM(LENGTH(content)) over the doc's
+            child blocks - the doc row's own `content` column holds only the
+            title, so it cannot be used for length filtering.
+          - Obsidian: filesystem mtime scan of `*.md`. mtime is noisier than
+            SiYuan's block timestamps - a git pull, iCloud resync, or any
+            sync tool that touches files produces false "activity". Body
+            length is approximated by file size in bytes (frontmatter and
+            markdown syntax count toward it).
+          - Notion: `last_edited_time` via the search API (minute granularity,
+            descending scan with client-side windowing - the search endpoint
+            has no timestamp filter). Only pages shared with the integration
+            are visible. `min_content_len` > 0 costs one extra API call per
+            candidate page.
+
+        See docs/second-brain-adapters.md for the full divergence table.
+        """
         ...
 
 

--- a/chassis/second_brain/factory.py
+++ b/chassis/second_brain/factory.py
@@ -95,6 +95,27 @@ def _resolve_env(value: Any) -> Any:
     return out
 
 
+def _first_set(*candidates: Any) -> str:
+    """First candidate that resolves to a non-empty string, '' when none do.
+
+    Each candidate is passed through `_resolve_env` first, so a config value of
+    `${SIYUAN_TOKEN}` that expands to nothing falls through to the next
+    candidate instead of shadowing it.
+    """
+    for candidate in candidates:
+        # A key present but blank (`notes_root:`) parses as None under PyYAML and
+        # as an empty dict under the fallback parser in _parse_yaml_minimal. Both
+        # mean "unset" - never let str({}) == '{}' through as a real value.
+        if candidate is None or isinstance(candidate, (dict, list)):
+            continue
+        value = _resolve_env(candidate)
+        if not isinstance(value, str):
+            value = str(value)
+        if value.strip():
+            return value
+    return ""
+
+
 VALID_MODES = ("direct", "adapter")
 
 
@@ -140,18 +161,60 @@ def get_adapter(config_path: Path | None = None) -> SecondBrainAdapter:
     if backend == "siyuan":
         from chassis.second_brain.siyuan import SiYuanAdapter
 
+        # Credentials come from the SAME source direct mode uses: SIYUAN_URL /
+        # SIYUAN_TOKEN in .env, passed to the server process by .mcp.json. The
+        # `second_brain.siyuan` YAML block is an optional override. Before this,
+        # adapter mode read ONLY that block - which ships in no template and
+        # exists in no install - so it built an adapter with an empty token and
+        # every call came back "Auth failed [session]".
+        databases = sb_config.get("databases") or {}
+        base_url = _first_set(
+            backend_config.get("base_url"),
+            os.environ.get("SIYUAN_URL"),
+            "http://127.0.0.1:6806",
+        )
+        token = _first_set(backend_config.get("token"), os.environ.get("SIYUAN_TOKEN"))
+        notebook_id = _first_set(
+            backend_config.get("notebook_id"),
+            databases.get("notes_root"),
+        )
+        deeplink_template = _first_set(
+            backend_config.get("deeplink_template"), "siyuan://blocks/"
+        )
+        if not token:
+            raise ValueError(
+                "SiYuan adapter has no API token. Set SIYUAN_TOKEN in the chassis .env "
+                "(the same var direct mode uses), or second_brain.siyuan.token in "
+                "chassis.config.yaml to override it. The kernel rejects an empty token "
+                "with 'Auth failed [session]' on every call."
+            )
+        if not notebook_id:
+            raise ValueError(
+                "SiYuan adapter has no notebook_id. Set second_brain.databases.notes_root "
+                "in chassis.config.yaml (the default write target), or "
+                "second_brain.siyuan.notebook_id to override it. Without it, create_doc "
+                "has nowhere to write."
+            )
         return SiYuanAdapter(
-            base_url=_resolve_env(backend_config.get("base_url", "http://127.0.0.1:6806")),
-            token=_resolve_env(backend_config.get("token", "")),
-            notebook_id=_resolve_env(backend_config.get("notebook_id", "")),
-            deeplink_template=_resolve_env(backend_config.get("deeplink_template", "siyuan://blocks/")),
+            base_url=base_url,
+            token=token,
+            notebook_id=notebook_id,
+            deeplink_template=deeplink_template,
         )
     if backend == "notion":
         from chassis.second_brain.notion import NotionAdapter
 
+        # Same credential source as the native notion MCP server (.env), same
+        # notes_root fallback as siyuan. Notion adapter mode is not validated as
+        # hard as siyuan yet - see docs/second-brain-adapters.md.
+        databases = sb_config.get("databases") or {}
         return NotionAdapter(
-            token=_resolve_env(backend_config.get("token", "")),
-            notes_root=_resolve_env(backend_config.get("notes_root", "")),
+            token=_first_set(
+                backend_config.get("token"), os.environ.get("NOTION_API_TOKEN")
+            ),
+            notes_root=_first_set(
+                backend_config.get("notes_root"), databases.get("notes_root")
+            ),
             databases={k: _resolve_env(v) for k, v in (backend_config.get("databases") or {}).items()},
             natural_keys=backend_config.get("natural_keys") or {},
             active_database=backend_config.get("active_database"),

--- a/chassis/second_brain/factory.py
+++ b/chassis/second_brain/factory.py
@@ -178,8 +178,16 @@ def get_adapter(config_path: Path | None = None) -> SecondBrainAdapter:
             backend_config.get("notebook_id"),
             databases.get("notes_root"),
         )
+        # The deeplink prefix a block id gets appended to. Customer-specific and
+        # it MOVES - it was a public https host, became a Tailnet address when
+        # DNS broke, and will move back. So it is a parameter, set in one place.
+        # The chassis default `siyuan://blocks/` is a desktop-app URI that does
+        # NOT open on a phone; installs that want clickable links set
+        # SIYUAN_DEEPLINK_BASE in .env.
         deeplink_template = _first_set(
-            backend_config.get("deeplink_template"), "siyuan://blocks/"
+            backend_config.get("deeplink_template"),
+            os.environ.get("SIYUAN_DEEPLINK_BASE"),
+            "siyuan://blocks/",
         )
         if not token:
             raise ValueError(

--- a/chassis/second_brain/factory.py
+++ b/chassis/second_brain/factory.py
@@ -95,6 +95,32 @@ def _resolve_env(value: Any) -> Any:
     return out
 
 
+VALID_MODES = ("direct", "adapter")
+
+
+def get_mode(config_path: Path | None = None) -> str:
+    """Return `second_brain.mode` from chassis.config.yaml.
+
+    Modes:
+      - `direct` (default, and the value assumed when the key is absent so
+        installs that predate the key see zero behavior change): the backend's
+        own MCP server is registered and chassis scripts talk to the backend
+        natively - today's behavior.
+      - `adapter`: the chassis-owned `secondbrain` MCP server is registered
+        INSTEAD of the native backend server, and callers go through
+        `get_adapter()`.
+    """
+    config = _load_config(config_path)
+    sb_config = config.get("second_brain") or {}
+    mode = sb_config.get("mode") or "direct"
+    if mode not in VALID_MODES:
+        raise ValueError(
+            f"Unsupported second_brain.mode={mode!r} in chassis.config.yaml. "
+            f"Supported modes: {', '.join(VALID_MODES)}."
+        )
+    return mode
+
+
 def get_adapter(config_path: Path | None = None) -> SecondBrainAdapter:
     """Return the adapter configured in chassis.config.yaml.
 

--- a/chassis/second_brain/mcp_server.py
+++ b/chassis/second_brain/mcp_server.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""secondbrain MCP server - ONE tool namespace over whichever backend is configured.
+
+Why this exists
+===============
+Prompts name concrete MCP tools. If each backend registers its own MCP server
+(`mcp__siyuan__*`, `mcp__notion__*`, ...), the same prompt text cannot work
+across installs - three servers means three tool namespaces. This server is
+the fix ratified in the second-brain cutover plan: one chassis-owned server,
+registered under the fixed name `secondbrain` on every install running
+`second_brain.mode: adapter`, resolving its backend at startup via
+`chassis.second_brain.get_adapter()`. The per-backend complexity lives in the
+adapter classes (siyuan.py / notion.py / obsidian.py), not in per-backend MCP
+surfaces.
+
+In adapter mode the native backend MCP server is NOT registered at all - tool
+availability is the guardrail. If `mcp__siyuan__*` stayed on the menu, models
+would keep reaching for it and the abstraction would be silently bypassed.
+
+Tools (mirroring the NotesAdapter protocol in base.py):
+
+    create_doc(parent, title, body) -> {id, deeplink}
+    append_to_doc(doc_id, content)
+    read_doc(doc_id) -> markdown
+    search(query, limit) -> hits[]
+    list_recent(since, until, min_content_len, limit) -> hits[]
+    get_deeplink(doc_id) -> url
+
+Doc ids are backend-specific opaque strings (SiYuan block id, Notion page id,
+Obsidian vault-relative path). Callers must treat them as opaque - pass back
+what a tool returned, never construct one.
+
+Runtime
+=======
+Uses the official MCP Python SDK (`mcp` in requirements.txt) over stdio - the
+repo had no prior MCP server implementation to follow. Configuration comes
+from chassis.config.yaml, located via CHASSIS_HOME exactly like
+`factory._load_config` (the .mcp.json entry passes the env through).
+
+Run directly:
+
+    python3 chassis/second_brain/mcp_server.py
+
+Registered by chassis/.mcp.json.template under `_enable_when:
+second_brain.mode == 'adapter'`.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+# Make `chassis.second_brain` importable when run as a script from any cwd.
+# parents[2] is the directory that CONTAINS the `chassis` package, in both the
+# standalone-repo and vendored-subtree layouts, because the path is resolved
+# relative to this file.
+_PACKAGE_PARENT = Path(__file__).resolve().parents[2]
+if str(_PACKAGE_PARENT) not in sys.path:
+    sys.path.insert(0, str(_PACKAGE_PARENT))
+
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+
+from chassis.second_brain.base import SearchHit, SecondBrainAdapter  # noqa: E402
+from chassis.second_brain.factory import get_adapter  # noqa: E402
+
+mcp = FastMCP("secondbrain")
+
+_adapter: SecondBrainAdapter | None = None
+
+
+def _notes():
+    global _adapter
+    if _adapter is None:
+        _adapter = get_adapter()
+    return _adapter.notes
+
+
+def _hit_to_dict(hit: SearchHit) -> dict[str, Any]:
+    return {
+        "id": hit.id,
+        "title": hit.title,
+        "snippet": hit.snippet,
+        "deeplink": hit.deeplink,
+        "score": hit.score,
+    }
+
+
+def _parse_iso(label: str, raw: str) -> datetime:
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(
+            f"{label}={raw!r} is not an ISO-8601 datetime "
+            f"(expected e.g. '2026-07-09T02:00:00' or '2026-07-09T02:00:00+01:00')."
+        ) from exc
+
+
+@mcp.tool()
+def create_doc(parent: str, title: str, body: str) -> dict[str, str]:
+    """Create a new doc/page under `parent` in the second brain.
+
+    `parent` is backend-specific (SiYuan hpath like '/Briefings', Notion parent
+    page id, Obsidian vault-relative directory like 'Briefings/'); empty string
+    means the configured default location. Returns the new doc's id and a
+    clickable deeplink.
+    """
+    notes = _notes()
+    doc_id = notes.create_doc(parent, title, body)
+    return {"id": doc_id, "deeplink": notes.get_deeplink(doc_id)}
+
+
+@mcp.tool()
+def append_to_doc(doc_id: str, content: str) -> str:
+    """Append markdown `content` to the existing doc identified by `doc_id`."""
+    _notes().append_to_doc(doc_id, content)
+    return f"appended {len(content)} chars to {doc_id}"
+
+
+@mcp.tool()
+def read_doc(doc_id: str) -> str:
+    """Return the doc's markdown body. Errors if the doc does not exist."""
+    return _notes().read_doc(doc_id)
+
+
+@mcp.tool()
+def search(query: str, limit: int = 10) -> list[dict[str, Any]]:
+    """Full-text search the second brain. Returns hits ordered by relevance."""
+    return [_hit_to_dict(hit) for hit in _notes().search(query, limit=limit)]
+
+
+@mcp.tool()
+def list_recent(
+    since: str,
+    until: str,
+    min_content_len: int = 0,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Docs created or modified in [since, until), newest first.
+
+    `since` / `until` are ISO-8601 datetimes (naive values are interpreted as
+    local time). `min_content_len` filters short docs using the closest measure
+    the backend offers - see docs/second-brain-adapters.md for per-backend
+    divergences (Obsidian uses file mtime and size, which are noisier than
+    SiYuan's block timestamps; Notion's last_edited_time has minute
+    granularity).
+    """
+    hits = _notes().list_recent(
+        _parse_iso("since", since),
+        _parse_iso("until", until),
+        min_content_len=min_content_len,
+        limit=limit,
+    )
+    return [_hit_to_dict(hit) for hit in hits]
+
+
+@mcp.tool()
+def get_deeplink(doc_id: str) -> str:
+    """Return a URL that opens the doc in the user's app/device."""
+    return _notes().get_deeplink(doc_id)
+
+
+def main() -> None:
+    # Resolve the adapter eagerly so a broken config fails the server at
+    # startup (visible in `claude mcp list` / server logs) instead of on the
+    # first tool call mid-task.
+    adapter = _notes()
+    print(
+        f"secondbrain MCP server: backend={getattr(_adapter, 'backend', '?')} "
+        f"({type(adapter).__name__})",
+        file=sys.stderr,
+    )
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/chassis/second_brain/notion.py
+++ b/chassis/second_brain/notion.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import json
 import urllib.error
 import urllib.request
+from datetime import datetime, timezone
 from typing import Any
 
 from chassis.second_brain.base import (
@@ -45,6 +46,27 @@ from chassis.second_brain.base import (
 
 NOTION_API_VERSION = "2022-06-28"
 NOTION_API_ROOT = "https://api.notion.com/v1"
+
+# list_recent scans the /search endpoint newest-first until it walks past the
+# window. Cap the scan so a huge workspace cannot turn one call into an
+# unbounded crawl - 500 pages (5 API calls) covers any sane daily window.
+_LIST_RECENT_SCAN_CAP = 500
+
+
+def _to_utc(value: datetime) -> datetime:
+    """Normalize to aware-UTC. Naive datetimes are interpreted as local time
+    (that is `datetime.astimezone`'s behavior for naive input)."""
+    return value.astimezone(timezone.utc)
+
+
+def _parse_notion_ts(raw: str | None) -> datetime | None:
+    """Parse Notion's ISO-8601 timestamps (e.g. `2026-07-09T10:00:00.000Z`)."""
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
 
 
 class NotionError(RuntimeError):
@@ -198,6 +220,71 @@ class NotionNotes(NotesAdapter):
                     raw=page,
                 )
             )
+        return hits
+
+    def list_recent(
+        self,
+        since: datetime,
+        until: datetime,
+        min_content_len: int = 0,
+        limit: int = 50,
+    ) -> list[SearchHit]:
+        """Pages with `last_edited_time` in [since, until), newest first.
+
+        Honest divergences from the SiYuan implementation:
+          - Notion's /search endpoint has NO timestamp filter, only a sort.
+            This scans newest-first and windows client-side, stopping as soon
+            as results predate `since` (or after `_LIST_RECENT_SCAN_CAP`
+            pages, whichever comes first).
+          - `last_edited_time` has MINUTE granularity - Notion truncates
+            seconds. Edits within the same minute as a window boundary can
+            fall on either side of it.
+          - Only pages shared with the integration are visible at all.
+          - `min_content_len` costs one extra API call per candidate page
+            (Notion does not expose content length on search results); the
+            length measured is the reconstructed-markdown length of the first
+            100 blocks.
+        """
+        since_utc = _to_utc(since)
+        until_utc = _to_utc(until)
+        hits: list[SearchHit] = []
+        cursor: str | None = None
+        scanned = 0
+        while scanned < _LIST_RECENT_SCAN_CAP:
+            payload: dict[str, Any] = {
+                "page_size": 100,
+                "sort": {"direction": "descending", "timestamp": "last_edited_time"},
+                "filter": {"value": "page", "property": "object"},
+            }
+            if cursor:
+                payload["start_cursor"] = cursor
+            result = _request(self._token, "POST", "/search", payload)
+            for page in result.get("results", []):
+                scanned += 1
+                edited = _parse_notion_ts(page.get("last_edited_time"))
+                if edited is None or edited >= until_utc:
+                    continue
+                if edited < since_utc:
+                    return hits  # sorted descending - everything after is older
+                if min_content_len > 0:
+                    body = self.read_doc(page.get("id", ""))
+                    if len(body) < min_content_len:
+                        continue
+                page_id = page.get("id", "")
+                hits.append(
+                    SearchHit(
+                        id=page_id,
+                        title=_extract_page_title(page),
+                        snippet="",
+                        deeplink=f"https://www.notion.so/{page_id.replace('-', '')}",
+                        raw=page,
+                    )
+                )
+                if len(hits) >= limit:
+                    return hits
+            if not result.get("has_more"):
+                break
+            cursor = result.get("next_cursor")
         return hits
 
 

--- a/chassis/second_brain/obsidian.py
+++ b/chassis/second_brain/obsidian.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from datetime import datetime
 from pathlib import Path
 from urllib.parse import quote
 
@@ -243,6 +244,61 @@ class ObsidianNotes(NotesAdapter):
             )
         hits.sort(key=lambda hit: hit.score, reverse=True)
         return hits[: int(limit)]
+
+    def list_recent(
+        self,
+        since: datetime,
+        until: datetime,
+        min_content_len: int = 0,
+        limit: int = 50,
+    ) -> list[SearchHit]:
+        """Notes with filesystem mtime in [since, until), newest first.
+
+        Honest divergence from SiYuan's block timestamps: mtime says a FILE
+        changed, not that a HUMAN edited it. A git pull, iCloud resync, or any
+        sync tool that rewrites files produces false "activity" here. Callers
+        that narrate recent activity (e.g. daily-log prompts) should treat
+        these hits as candidates, not facts.
+
+        `min_content_len` is approximated by file size in bytes - frontmatter
+        and markdown syntax count toward it, and multi-byte characters count
+        per byte, not per character. Naive datetimes are interpreted as local
+        time (`datetime.timestamp()` semantics), matching st_mtime's epoch.
+        """
+        since_ts = since.timestamp()
+        until_ts = until.timestamp()
+        candidates: list[tuple[float, int, Path]] = []
+        for path in self._vault.rglob("*.md"):
+            rel_parts = path.relative_to(self._vault).parts
+            if any(part in _SKIP_DIRS for part in rel_parts):
+                continue
+            try:
+                stat_result = path.stat()
+            except OSError:
+                continue
+            if not since_ts <= stat_result.st_mtime < until_ts:
+                continue
+            if stat_result.st_size < min_content_len:
+                continue
+            candidates.append((stat_result.st_mtime, stat_result.st_size, path))
+        candidates.sort(key=lambda item: item[0], reverse=True)
+        hits: list[SearchHit] = []
+        for mtime, size, path in candidates[: int(limit)]:
+            try:
+                snippet = path.read_text(encoding="utf-8")[:_SNIPPET_LEN].strip()
+            except (OSError, UnicodeDecodeError):
+                snippet = ""
+            rel = self._rel_id(path)
+            hits.append(
+                SearchHit(
+                    id=rel,
+                    title=path.stem,
+                    snippet=snippet,
+                    deeplink=self.get_deeplink(rel),
+                    raw={"path": str(path), "mtime": mtime, "size_bytes": size},
+                )
+            )
+        return hits
 
 
 class ObsidianAdapter(SecondBrainAdapter):

--- a/chassis/second_brain/siyuan.py
+++ b/chassis/second_brain/siyuan.py
@@ -42,12 +42,7 @@ from chassis.second_brain.base import (
 
 
 class SiYuanError(RuntimeError):
-    """Raised when SiYuan API returns a non-zero `code`."""
-
-
-# Backslash is not special inside a sqlite string literal, so it is a safe
-# LIKE escape character and needs no doubling in the emitted SQL.
-LIKE_ESCAPE_CHAR = "\\"
+    """Raised when SiYuan API returns a non-zero `code`, or refuses a SQL query."""
 
 
 def _siyuan_stamp(value: datetime) -> str:
@@ -95,6 +90,34 @@ class SiYuanNotes(NotesAdapter):
             raise SiYuanError(f"SiYuan {path} returned code={data.get('code')}: {data.get('msg')!r}")
         return data.get("data")
 
+    def _query_sql(self, stmt: str) -> list[dict[str, Any]]:
+        """Run a SQL statement against /api/query/sql. Raise on a refused query.
+
+        SiYuan answers a query it will not run with `{"code": 0, "msg": "",
+        "data": null}` - success-shaped, but null. The old `result if
+        isinstance(result, list) else []` at each call site turned that into an
+        empty result set, so an unsupported statement looked exactly like "no
+        matches". That is how an ESCAPE clause SiYuan does not accept made
+        search() silently return zero hits against a kernel holding 397.
+
+        A genuinely empty result comes back as `[]`, not null (verified against
+        a live kernel), so treating null as an error is safe. Only the SQL path
+        is hardened - other endpoints return null legitimately (appendBlock).
+        """
+        result = self._post("/api/query/sql", {"stmt": stmt})
+        if result is None:
+            raise SiYuanError(
+                "SiYuan refused the SQL query (code=0 but data=null - it answers a "
+                "statement it will not run this way, and an empty result set would "
+                f"have been []). Statement: {stmt[:300]!r}"
+            )
+        if not isinstance(result, list):
+            raise SiYuanError(
+                f"SiYuan /api/query/sql returned {type(result).__name__}, expected a "
+                f"list of rows. Statement: {stmt[:300]!r}"
+            )
+        return result
+
     def create_doc(self, parent: str, title: str, body: str) -> str:
         # `parent` is interpreted as the SiYuan hpath (e.g. "/Briefings"). If it
         # looks like a block id, we resolve to its hpath via SQL.
@@ -135,13 +158,29 @@ class SiYuanNotes(NotesAdapter):
         self.append_to_doc(from_id, f"(({to_id} '{anchor}'))")
 
     def search(self, query: str, limit: int = 10) -> list[SearchHit]:
+        """Substring search over block content, newest first.
+
+        WILDCARDS PASS THROUGH. `%` and `_` in `query` are live LIKE wildcards:
+        a search for `50%` also matches `50 percent`, and `a_b` matches `axb`.
+        This is a deliberate, known tradeoff, not an oversight.
+
+        SiYuan's SQL endpoint does NOT accept an `ESCAPE` clause - verified
+        against a live kernel, where `LIKE '%Vibecode%' ESCAPE '\\'` returns
+        `data: null` (zero rows) for any escape character, while the same query
+        without it returns 397 rows. So the wildcards cannot be escaped, and the
+        query is passed as-is.
+
+        This is safe: the single-quote escaping in `_escape` is what prevents
+        injection (the query can never break out of the string literal), and the
+        result set is LIMIT-capped. The only cost is that a query containing a
+        wildcard matches more broadly than the caller may have intended.
+        """
         sql = (
             "SELECT id, content, hpath FROM blocks "
-            f"WHERE content LIKE '%{self._escape_like(query)}%' ESCAPE '{LIKE_ESCAPE_CHAR}' "
+            f"WHERE content LIKE '%{self._escape(query)}%' "
             f"ORDER BY updated DESC LIMIT {int(limit)}"
         )
-        result = self._post("/api/query/sql", {"stmt": sql})
-        rows = result if isinstance(result, list) else []
+        rows = self._query_sql(sql)
         return [
             SearchHit(
                 id=row.get("id", ""),
@@ -190,8 +229,7 @@ class SiYuanNotes(NotesAdapter):
             "ORDER BY updated DESC "
             f"LIMIT {int(limit)}"
         )
-        result = self._post("/api/query/sql", {"stmt": sql})
-        rows = result if isinstance(result, list) else []
+        rows = self._query_sql(sql)
         return [
             SearchHit(
                 id=row.get("id", ""),
@@ -206,34 +244,21 @@ class SiYuanNotes(NotesAdapter):
 
     def _block_to_hpath(self, block_id: str) -> str:
         sql = f"SELECT hpath FROM blocks WHERE id = '{self._escape(block_id)}' LIMIT 1"
-        result = self._post("/api/query/sql", {"stmt": sql})
-        rows = result if isinstance(result, list) else []
+        rows = self._query_sql(sql)
         return rows[0].get("hpath", "/") if rows else "/"
 
     def _block_title(self, block_id: str) -> str:
         sql = f"SELECT content FROM blocks WHERE id = '{self._escape(block_id)}' LIMIT 1"
-        result = self._post("/api/query/sql", {"stmt": sql})
-        rows = result if isinstance(result, list) else []
+        rows = self._query_sql(sql)
         return rows[0].get("content", "") if rows else ""
 
     @staticmethod
     def _escape(value: str) -> str:
-        # SiYuan SQL is sqlite. Escape for a single-quoted string literal.
+        # SiYuan SQL is sqlite. Escape for a single-quoted string literal. This
+        # is the whole injection defense and it is sufficient: a value can never
+        # terminate the literal it sits in. LIKE wildcards inside `value` stay
+        # live - see search() for why they cannot be escaped on this backend.
         return value.replace("'", "''")
-
-    @classmethod
-    def _escape_like(cls, value: str) -> str:
-        # For values interpolated into a LIKE pattern. search() is exposed as an
-        # MCP tool by second_brain/mcp_server.py, so `query` is arbitrary
-        # model-supplied or user-supplied text - not the chassis-internal-only
-        # surface this adapter originally had. A bare quote-escape leaves the
-        # LIKE wildcards live: '%' and '_' in a query would silently widen the
-        # match. Escape the escape char first, then the wildcards, then quote
-        # for the literal. Callers MUST pair this with an ESCAPE clause.
-        escaped = value.replace(LIKE_ESCAPE_CHAR, LIKE_ESCAPE_CHAR * 2)
-        for wildcard in ("%", "_"):
-            escaped = escaped.replace(wildcard, LIKE_ESCAPE_CHAR + wildcard)
-        return cls._escape(escaped)
 
 
 class SiYuanAdapter(SecondBrainAdapter):

--- a/chassis/second_brain/siyuan.py
+++ b/chassis/second_brain/siyuan.py
@@ -7,15 +7,22 @@ kernel, typically reverse-proxied through `s.grid7.com` for iPhone deeplinks.
 Database surface is NOT implemented — SiYuan has SQL search but no native
 property/database semantics that match Notion's. Use NotesAdapter only.
 
-Config (chassis.config.yaml):
+Credentials come from the chassis .env - SIYUAN_URL and SIYUAN_TOKEN, the same
+two vars direct mode passes to the native siyuan MCP server. The factory reads
+them; nothing has to be duplicated into YAML. `notebook_id` defaults to
+`second_brain.databases.notes_root`, the canonical write target.
+
+Every key below is an OPTIONAL override in chassis.config.yaml:
 
     second_brain:
       backend: siyuan
       siyuan:
-        base_url: http://127.0.0.1:6806     # local kernel
-        token: ${SIYUAN_TOKEN}               # from .env
-        notebook_id: 20231101120000-abc123    # default notebook for create_doc
-        deeplink_template: https://s.grid7.com/?id=
+        base_url: http://127.0.0.1:6806        # default; env SIYUAN_URL wins over this default
+        token: ${SIYUAN_TOKEN}                  # default: env SIYUAN_TOKEN
+        notebook_id: 20231101120000-abc123      # default: second_brain.databases.notes_root
+        deeplink_template: siyuan://blocks/     # default; set to a reverse-proxy URL
+                                                # (e.g. https://siyuan.example.com/?id=)
+                                                # for phone-clickable links
 """
 
 from __future__ import annotations
@@ -36,6 +43,11 @@ from chassis.second_brain.base import (
 
 class SiYuanError(RuntimeError):
     """Raised when SiYuan API returns a non-zero `code`."""
+
+
+# Backslash is not special inside a sqlite string literal, so it is a safe
+# LIKE escape character and needs no doubling in the emitted SQL.
+LIKE_ESCAPE_CHAR = "\\"
 
 
 def _siyuan_stamp(value: datetime) -> str:
@@ -125,7 +137,7 @@ class SiYuanNotes(NotesAdapter):
     def search(self, query: str, limit: int = 10) -> list[SearchHit]:
         sql = (
             "SELECT id, content, hpath FROM blocks "
-            f"WHERE content LIKE '%{self._escape(query)}%' "
+            f"WHERE content LIKE '%{self._escape_like(query)}%' ESCAPE '{LIKE_ESCAPE_CHAR}' "
             f"ORDER BY updated DESC LIMIT {int(limit)}"
         )
         result = self._post("/api/query/sql", {"stmt": sql})
@@ -206,10 +218,22 @@ class SiYuanNotes(NotesAdapter):
 
     @staticmethod
     def _escape(value: str) -> str:
-        # SiYuan SQL is sqlite — naive single-quote escape is sufficient given the
-        # adapter only takes input from chassis-internal callers (no user-supplied
-        # SQL). Tighten if this surface widens.
+        # SiYuan SQL is sqlite. Escape for a single-quoted string literal.
         return value.replace("'", "''")
+
+    @classmethod
+    def _escape_like(cls, value: str) -> str:
+        # For values interpolated into a LIKE pattern. search() is exposed as an
+        # MCP tool by second_brain/mcp_server.py, so `query` is arbitrary
+        # model-supplied or user-supplied text - not the chassis-internal-only
+        # surface this adapter originally had. A bare quote-escape leaves the
+        # LIKE wildcards live: '%' and '_' in a query would silently widen the
+        # match. Escape the escape char first, then the wildcards, then quote
+        # for the literal. Callers MUST pair this with an ESCAPE clause.
+        escaped = value.replace(LIKE_ESCAPE_CHAR, LIKE_ESCAPE_CHAR * 2)
+        for wildcard in ("%", "_"):
+            escaped = escaped.replace(wildcard, LIKE_ESCAPE_CHAR + wildcard)
+        return cls._escape(escaped)
 
 
 class SiYuanAdapter(SecondBrainAdapter):

--- a/chassis/second_brain/siyuan.py
+++ b/chassis/second_brain/siyuan.py
@@ -2,7 +2,8 @@
 
 Ports the call patterns Sean's V1 <v1-reference-install> instance uses (briefing-siyuan-crosslink.py,
 generate-dossier.py, pacman-queue-add.py). Every operation hits the local SiYuan
-kernel, typically reverse-proxied through `s.grid7.com` for iPhone deeplinks.
+kernel, typically reverse-proxied through a per-install host for phone-clickable
+deeplinks (see SIYUAN_DEEPLINK_BASE below - the host is never hardcoded here).
 
 Database surface is NOT implemented — SiYuan has SQL search but no native
 property/database semantics that match Notion's. Use NotesAdapter only.
@@ -20,9 +21,14 @@ Every key below is an OPTIONAL override in chassis.config.yaml:
         base_url: http://127.0.0.1:6806        # default; env SIYUAN_URL wins over this default
         token: ${SIYUAN_TOKEN}                  # default: env SIYUAN_TOKEN
         notebook_id: 20231101120000-abc123      # default: second_brain.databases.notes_root
-        deeplink_template: siyuan://blocks/     # default; set to a reverse-proxy URL
-                                                # (e.g. https://siyuan.example.com/?id=)
-                                                # for phone-clickable links
+        deeplink_template: siyuan://blocks/     # default: env SIYUAN_DEEPLINK_BASE, else this
+
+`deeplink_template` is a PREFIX - a block id is appended verbatim, so it keeps its
+trailing separator. The `siyuan://blocks/` default opens the SiYuan DESKTOP APP and
+does NOT open on a phone. Installs that need mobile-clickable links set
+SIYUAN_DEEPLINK_BASE in .env to their web-UI prefix
+(https://<siyuan-host>:6806/stage/build/desktop/?id=). The host is per-install and
+it moves, so it lives in .env, never in code.
 """
 
 from __future__ import annotations

--- a/chassis/second_brain/siyuan.py
+++ b/chassis/second_brain/siyuan.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import json
 import urllib.error
 import urllib.request
+from datetime import datetime
 from typing import Any
 
 from chassis.second_brain.base import (
@@ -35,6 +36,17 @@ from chassis.second_brain.base import (
 
 class SiYuanError(RuntimeError):
     """Raised when SiYuan API returns a non-zero `code`."""
+
+
+def _siyuan_stamp(value: datetime) -> str:
+    """Format a datetime as SiYuan's `YYYYMMDDHHMMSS` block-timestamp string.
+
+    Aware datetimes are converted to this process's local timezone (SiYuan
+    stores kernel-local wall-clock time); naive datetimes pass through as-is.
+    """
+    if value.tzinfo is not None:
+        value = value.astimezone()
+    return value.strftime("%Y%m%d%H%M%S")
 
 
 class SiYuanNotes(NotesAdapter):
@@ -122,6 +134,57 @@ class SiYuanNotes(NotesAdapter):
             SearchHit(
                 id=row.get("id", ""),
                 title=row.get("hpath", "").rsplit("/", 1)[-1] or "(untitled)",
+                snippet=(row.get("content") or "")[:200],
+                deeplink=self.get_deeplink(row.get("id", "")),
+                raw=row,
+            )
+            for row in rows
+        ]
+
+    def list_recent(
+        self,
+        since: datetime,
+        until: datetime,
+        min_content_len: int = 0,
+        limit: int = 50,
+    ) -> list[SearchHit]:
+        """Docs updated in [since, until), newest first, via SQL on the block table.
+
+        Timestamps: SiYuan's `blocks.updated` column stores the KERNEL's local
+        clock as a `YYYYMMDDHHMMSS` string. Naive datetimes are passed through
+        as-is (assumed to be in the kernel's timezone); aware datetimes are
+        converted to this process's local time first, which matches the kernel
+        only when both run on the same host - the chassis default.
+
+        Body length: the doc row's own `content` column holds the TITLE, not
+        the body (verified against a live kernel - max LENGTH(content) over
+        283 type='d' rows was 81). `min_content_len` therefore filters on
+        SUM(LENGTH(content)) over the doc's child blocks via a correlated
+        subquery.
+        """
+        since_stamp = _siyuan_stamp(since)
+        until_stamp = _siyuan_stamp(until)
+        body_len_sql = (
+            "(SELECT COALESCE(SUM(LENGTH(b2.content)), 0) FROM blocks b2 "
+            "WHERE b2.root_id = blocks.id AND b2.type != 'd')"
+        )
+        sql = (
+            f"SELECT id, hpath, content, updated, created, {body_len_sql} AS body_len "
+            "FROM blocks "
+            "WHERE type = 'd' "
+            f"AND updated >= '{since_stamp}' "
+            f"AND updated < '{until_stamp}' "
+            f"AND {body_len_sql} >= {int(min_content_len)} "
+            "ORDER BY updated DESC "
+            f"LIMIT {int(limit)}"
+        )
+        result = self._post("/api/query/sql", {"stmt": sql})
+        rows = result if isinstance(result, list) else []
+        return [
+            SearchHit(
+                id=row.get("id", ""),
+                title=(row.get("hpath") or "").rsplit("/", 1)[-1]
+                or (row.get("content") or "(untitled)"),
                 snippet=(row.get("content") or "")[:200],
                 deeplink=self.get_deeplink(row.get("id", "")),
                 raw=row,

--- a/chassis/second_brain/tests/test_factory_credentials.py
+++ b/chassis/second_brain/tests/test_factory_credentials.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""test_factory_credentials.py - get_adapter() resolves REAL credentials, or fails loudly.
+
+The gap this closes
+===================
+Adapter mode and direct mode used to read SiYuan credentials from two disjoint
+sources. Direct mode got `SIYUAN_URL` / `SIYUAN_TOKEN` from `.env` via the
+`siyuan` entry in .mcp.json. Adapter mode read `second_brain.siyuan.{base_url,
+token,notebook_id}` from chassis.config.yaml - a sub-block that existed in NO
+shipped template and in NO real install. `get_adapter()` therefore built a
+SiYuanAdapter with token='' and notebook_id='', and a live kernel answers that
+with `{"code":-1,"msg":"Auth failed [session]"}`. Flipping `mode: adapter` made
+the second brain go dark.
+
+The pre-existing suite missed it because test_mcp_json_render.py only exercises
+the hydrator (never the factory) and the mcp_server e2e test only runs Obsidian
+against a hand-written fixture config. This test drives the factory against the
+REAL shipped chassis.config.yaml, which is where the missing sub-block lived.
+
+Run:
+    python3 -m pytest chassis/second_brain/tests/test_factory_credentials.py -v
+"""
+from __future__ import annotations
+
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from chassis.second_brain.factory import _load_config, get_adapter  # noqa: E402
+
+SHIPPED_CONFIG = REPO_ROOT / "chassis.config.yaml"
+
+FAKE_URL = "http://host.docker.internal:6806"
+FAKE_TOKEN = "test-token-not-a-real-secret"
+FAKE_ENV = {"SIYUAN_URL": FAKE_URL, "SIYUAN_TOKEN": FAKE_TOKEN}
+
+
+def _shipped_as_siyuan(raw: str, siyuan_block: str = "") -> str:
+    """The REAL shipped config text, backend flipped to siyuan.
+
+    Text substitution rather than a YAML round-trip so the file stays
+    byte-identical to what installers get, comments included. The
+    substitution-count assertion means a restructured template fails this test
+    loudly instead of silently testing a fixture that no longer resembles the
+    shipped one.
+    """
+    patched, count = re.subn(
+        r"^(\s*)backend:\s*\w+.*$",
+        lambda m: f"{m.group(1)}backend: siyuan" + siyuan_block,
+        raw,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    assert count == 1, "expected exactly one second_brain.backend key in chassis.config.yaml"
+    return patched
+
+
+class SiYuanCredentialResolutionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory(prefix="sb-factory-creds-")
+        self.tmp_dir = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        self.shipped_raw = SHIPPED_CONFIG.read_text(encoding="utf-8")
+        self.config_path = self._write("shipped-siyuan.yaml", _shipped_as_siyuan(self.shipped_raw))
+
+    def _write(self, name: str, text: str) -> Path:
+        path = self.tmp_dir / name
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def test_env_credentials_reach_the_adapter(self) -> None:
+        # The shipped config carries no second_brain.siyuan block, so .env is
+        # the only credential source an install actually has. Adapter mode must
+        # read it. This is the bug: it used to yield token=''.
+        with mock.patch.dict("os.environ", FAKE_ENV):
+            adapter = get_adapter(self.config_path)
+        notes = adapter.notes
+        self.assertEqual(adapter.backend, "siyuan")
+        self.assertTrue(notes._token, "token must not be empty - the live kernel rejects it")
+        self.assertEqual(notes._token, FAKE_TOKEN)
+        self.assertEqual(notes._base_url, FAKE_URL)
+
+    def test_notebook_id_falls_back_to_databases_notes_root(self) -> None:
+        # notes_root is the canonical "page id for free-form prose writes" key
+        # that every install already fills in. No installer should have to
+        # duplicate it under second_brain.siyuan.notebook_id.
+        expected = _load_config(self.config_path)["second_brain"]["databases"]["notes_root"]
+        self.assertTrue(expected, "shipped config lost second_brain.databases.notes_root")
+        with mock.patch.dict("os.environ", FAKE_ENV):
+            adapter = get_adapter(self.config_path)
+        self.assertTrue(adapter.notes._notebook_id, "notebook_id must not be empty")
+        self.assertEqual(adapter.notes._notebook_id, expected)
+
+    def test_missing_token_raises_instead_of_building_a_dead_adapter(self) -> None:
+        # No token in config, no token in env. The old code silently returned an
+        # adapter that fails auth on every call. It must fail at construction.
+        with mock.patch.dict("os.environ", {}, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                get_adapter(self.config_path)
+        message = str(ctx.exception)
+        self.assertIn("SIYUAN_TOKEN", message)
+        self.assertIn("second_brain.siyuan.token", message)
+
+    def test_missing_notebook_id_raises(self) -> None:
+        # Same contract for the write target: an empty notebook_id sends
+        # createDocWithMd into the void.
+        blanked = self.shipped_raw.replace("notes_root: TBD_at_install", "notes_root:")
+        self.assertNotIn("notes_root: TBD_at_install", blanked)
+        path = self._write("no-notes-root.yaml", _shipped_as_siyuan(blanked))
+        with mock.patch.dict("os.environ", FAKE_ENV):
+            with self.assertRaises(ValueError) as ctx:
+                get_adapter(path)
+        self.assertIn("notebook_id", str(ctx.exception))
+
+    def test_yaml_block_overrides_env(self) -> None:
+        # The YAML keys stay available as an explicit override for installs that
+        # want a non-default kernel, notebook, or deeplink host.
+        override = (
+            "\n  siyuan:"
+            "\n    base_url: http://kernel.internal:6806"
+            "\n    token: yaml-wins"
+            "\n    notebook_id: 20231101120000-abc123"
+            "\n    deeplink_template: https://s.example.com/?id="
+        )
+        path = self._write(
+            "siyuan-override.yaml", _shipped_as_siyuan(self.shipped_raw, override)
+        )
+        with mock.patch.dict("os.environ", FAKE_ENV):
+            adapter = get_adapter(path)
+        notes = adapter.notes
+        self.assertEqual(notes._token, "yaml-wins")
+        self.assertEqual(notes._base_url, "http://kernel.internal:6806")
+        self.assertEqual(notes._notebook_id, "20231101120000-abc123")
+        self.assertEqual(notes._deeplink_template, "https://s.example.com/?id=")
+
+    def test_env_ref_in_yaml_that_expands_to_nothing_falls_through(self) -> None:
+        # A config shipping `token: ${SIYUAN_TOKEN}` must not shadow the env
+        # fallback when the var is unset - it resolves to '' and has to fall
+        # through to the same ValueError, not build a dead adapter.
+        override = "\n  siyuan:\n    token: ${SIYUAN_TOKEN}"
+        path = self._write(
+            "siyuan-envref.yaml", _shipped_as_siyuan(self.shipped_raw, override)
+        )
+        with mock.patch.dict("os.environ", {}, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                get_adapter(path)
+        self.assertIn("SIYUAN_TOKEN", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/chassis/second_brain/tests/test_factory_credentials.py
+++ b/chassis/second_brain/tests/test_factory_credentials.py
@@ -39,6 +39,9 @@ SHIPPED_CONFIG = REPO_ROOT / "chassis.config.yaml"
 FAKE_URL = "http://host.docker.internal:6806"
 FAKE_TOKEN = "test-token-not-a-real-secret"
 FAKE_ENV = {"SIYUAN_URL": FAKE_URL, "SIYUAN_TOKEN": FAKE_TOKEN}
+# Fake host. The real deeplink host is customer-specific, it moves, and it never
+# belongs in this repo - that is the whole reason it is a parameter.
+FAKE_DEEPLINK_BASE = "https://siyuan.invalid:6806/stage/build/desktop/?id="
 
 
 def _shipped_as_siyuan(raw: str, siyuan_block: str = "") -> str:
@@ -138,6 +141,41 @@ class SiYuanCredentialResolutionTest(unittest.TestCase):
         self.assertEqual(notes._base_url, "http://kernel.internal:6806")
         self.assertEqual(notes._notebook_id, "20231101120000-abc123")
         self.assertEqual(notes._deeplink_template, "https://s.example.com/?id=")
+
+    def test_deeplink_falls_back_to_the_desktop_uri_default(self) -> None:
+        # Neither YAML nor env: the chassis default. Note this URI does NOT open
+        # on a phone - that is why the env var below exists.
+        with mock.patch.dict("os.environ", FAKE_ENV, clear=True):
+            adapter = get_adapter(self.config_path)
+        self.assertEqual(adapter.notes._deeplink_template, "siyuan://blocks/")
+        self.assertEqual(
+            adapter.notes.get_deeplink("20231101120000-abc123"),
+            "siyuan://blocks/20231101120000-abc123",
+        )
+
+    def test_deeplink_comes_from_env_when_yaml_is_absent(self) -> None:
+        # The real-use path: an install sets SIYUAN_DEEPLINK_BASE in .env to its
+        # web-UI prefix so links are clickable on a phone. Fake host on purpose -
+        # the real one is customer-specific and never lives in this repo.
+        env = dict(FAKE_ENV, SIYUAN_DEEPLINK_BASE=FAKE_DEEPLINK_BASE)
+        with mock.patch.dict("os.environ", env, clear=True):
+            adapter = get_adapter(self.config_path)
+        self.assertEqual(adapter.notes._deeplink_template, FAKE_DEEPLINK_BASE)
+        # The id is appended verbatim, so the prefix keeps its trailing separator.
+        self.assertEqual(
+            adapter.notes.get_deeplink("20231101120000-abc123"),
+            FAKE_DEEPLINK_BASE + "20231101120000-abc123",
+        )
+
+    def test_deeplink_yaml_overrides_env(self) -> None:
+        override = "\n  siyuan:\n    deeplink_template: https://yaml.invalid/?id="
+        path = self._write(
+            "siyuan-deeplink.yaml", _shipped_as_siyuan(self.shipped_raw, override)
+        )
+        env = dict(FAKE_ENV, SIYUAN_DEEPLINK_BASE=FAKE_DEEPLINK_BASE)
+        with mock.patch.dict("os.environ", env, clear=True):
+            adapter = get_adapter(path)
+        self.assertEqual(adapter.notes._deeplink_template, "https://yaml.invalid/?id=")
 
     def test_env_ref_in_yaml_that_expands_to_nothing_falls_through(self) -> None:
         # A config shipping `token: ${SIYUAN_TOKEN}` must not shadow the env

--- a/chassis/second_brain/tests/test_list_recent.py
+++ b/chassis/second_brain/tests/test_list_recent.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""test_list_recent.py - Unit tests for NotesAdapter.list_recent on all three backends.
+
+Obsidian runs against a throwaway temp-dir vault with controlled mtimes.
+SiYuan and Notion run against stubbed HTTP transports (the adapters' `_post` /
+`_request` seams) - no network, no live backend.
+
+Run:
+    python3 -m pytest chassis/second_brain/tests/test_list_recent.py -v
+    # or directly:
+    python3 chassis/second_brain/tests/test_list_recent.py
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from chassis.second_brain import notion as notion_module  # noqa: E402
+from chassis.second_brain.base import SearchHit  # noqa: E402
+from chassis.second_brain.notion import NotionNotes  # noqa: E402
+from chassis.second_brain.obsidian import ObsidianNotes  # noqa: E402
+from chassis.second_brain.siyuan import SiYuanNotes, _siyuan_stamp  # noqa: E402
+
+
+class ObsidianListRecentTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = Path(tempfile.mkdtemp(prefix="obsidian-list-recent-"))
+        self.vault = self._tmp / "vault"
+        (self.vault / "Briefings").mkdir(parents=True)
+        (self.vault / ".obsidian").mkdir()
+        self.now = datetime(2026, 7, 9, 12, 0, 0)  # naive == local by convention
+
+        self._write("old.md", "ancient note " * 10, self.now - timedelta(days=30))
+        self._write("Briefings/yesterday.md", "y" * 500, self.now - timedelta(hours=20))
+        self._write("Briefings/today.md", "t" * 500, self.now - timedelta(hours=2))
+        self._write("tiny.md", "x", self.now - timedelta(hours=1))
+        self._write(".obsidian/workspace.md", "w" * 500, self.now - timedelta(hours=1))
+
+        self.notes = ObsidianNotes(vault_path=str(self.vault))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _write(self, rel: str, body: str, mtime: datetime) -> None:
+        path = self.vault / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+        os.utime(path, (mtime.timestamp(), mtime.timestamp()))
+
+    def test_window_filters_and_orders_newest_first(self) -> None:
+        hits = self.notes.list_recent(self.now - timedelta(days=1), self.now)
+        ids = [hit.id for hit in hits]
+        self.assertEqual(
+            ids, ["tiny.md", "Briefings/today.md", "Briefings/yesterday.md"]
+        )
+        self.assertNotIn("old.md", ids)
+        self.assertTrue(all(".obsidian" not in hit.id for hit in hits))
+
+    def test_window_is_half_open(self) -> None:
+        # until is exclusive: a file whose mtime equals `until` must not appear.
+        boundary = self.now - timedelta(hours=2)
+        hits = self.notes.list_recent(self.now - timedelta(days=1), boundary)
+        self.assertEqual([hit.id for hit in hits], ["Briefings/yesterday.md"])
+
+    def test_min_content_len_uses_file_size(self) -> None:
+        hits = self.notes.list_recent(
+            self.now - timedelta(days=1), self.now, min_content_len=100
+        )
+        ids = [hit.id for hit in hits]
+        self.assertNotIn("tiny.md", ids)
+        self.assertIn("Briefings/today.md", ids)
+
+    def test_limit_and_hit_shape(self) -> None:
+        hits = self.notes.list_recent(self.now - timedelta(days=1), self.now, limit=1)
+        self.assertEqual(len(hits), 1)
+        hit = hits[0]
+        self.assertIsInstance(hit, SearchHit)
+        self.assertEqual(hit.id, "tiny.md")
+        self.assertTrue(hit.deeplink.startswith("obsidian://open?vault="))
+        self.assertIn("mtime", hit.raw)
+        self.assertIn("size_bytes", hit.raw)
+
+    def test_empty_window_returns_empty(self) -> None:
+        hits = self.notes.list_recent(
+            self.now + timedelta(days=1), self.now + timedelta(days=2)
+        )
+        self.assertEqual(hits, [])
+
+
+class _StubbedSiYuanNotes(SiYuanNotes):
+    """Capture SQL statements; return canned rows instead of hitting a kernel."""
+
+    def __init__(self, rows: list[dict]) -> None:
+        super().__init__(
+            base_url="http://127.0.0.1:1",
+            token="stub",
+            notebook_id="stub-notebook",
+            deeplink_template="siyuan://blocks/",
+        )
+        self.rows = rows
+        self.statements: list[str] = []
+
+    def _post(self, path: str, payload: dict):
+        assert path == "/api/query/sql", f"unexpected endpoint {path}"
+        self.statements.append(payload["stmt"])
+        return self.rows
+
+
+class SiYuanListRecentTest(unittest.TestCase):
+    def test_sql_carries_window_and_length_filter(self) -> None:
+        notes = _StubbedSiYuanNotes(rows=[])
+        since = datetime(2026, 7, 8, 2, 0, 0)
+        until = datetime(2026, 7, 9, 2, 0, 0)
+        notes.list_recent(since, until, min_content_len=200, limit=7)
+        stmt = notes.statements[0]
+        self.assertIn("updated >= '20260708020000'", stmt)
+        self.assertIn("updated < '20260709020000'", stmt)
+        self.assertIn("type = 'd'", stmt)
+        self.assertIn("LIMIT 7", stmt)
+        # min_content_len must NOT filter on the doc row's own content column
+        # (that column holds the title) - it must aggregate child blocks.
+        self.assertIn("SUM(LENGTH(b2.content))", stmt)
+        self.assertIn(">= 200", stmt)
+
+    def test_rows_map_to_search_hits(self) -> None:
+        rows = [
+            {
+                "id": "20260709031008-ummgaxh",
+                "hpath": "/Introspection/Daily Logs/2026-07-09",
+                "content": "2026-07-09",
+                "updated": "20260709031008",
+                "created": "20260709031008",
+                "body_len": 3811,
+            }
+        ]
+        notes = _StubbedSiYuanNotes(rows=rows)
+        hits = notes.list_recent(datetime(2026, 7, 9), datetime(2026, 7, 10))
+        self.assertEqual(len(hits), 1)
+        hit = hits[0]
+        self.assertEqual(hit.id, "20260709031008-ummgaxh")
+        self.assertEqual(hit.title, "2026-07-09")
+        self.assertEqual(hit.deeplink, "siyuan://blocks/20260709031008-ummgaxh")
+        self.assertEqual(hit.raw["body_len"], 3811)
+
+    def test_aware_datetimes_convert_to_local_stamp(self) -> None:
+        aware = datetime(2026, 7, 9, 10, 30, 0, tzinfo=timezone.utc)
+        expected = aware.astimezone().strftime("%Y%m%d%H%M%S")
+        self.assertEqual(_siyuan_stamp(aware), expected)
+
+    def test_naive_datetime_passes_through(self) -> None:
+        self.assertEqual(_siyuan_stamp(datetime(2026, 7, 9, 10, 30, 0)), "20260709103000")
+
+
+def _notion_page(page_id: str, edited_iso: str, title: str) -> dict:
+    return {
+        "id": page_id,
+        "last_edited_time": edited_iso,
+        "properties": {
+            "title": {
+                "type": "title",
+                "title": [{"plain_text": title}],
+            }
+        },
+    }
+
+
+class NotionListRecentTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.requests: list[tuple[str, str, dict | None]] = []
+        self._original_request = notion_module._request
+
+    def tearDown(self) -> None:
+        notion_module._request = self._original_request
+
+    def _install(self, responder) -> None:
+        def fake_request(token, method, path, payload=None):
+            self.requests.append((method, path, payload))
+            return responder(method, path, payload)
+
+        notion_module._request = fake_request
+
+    def test_windows_client_side_and_stops_at_since(self) -> None:
+        pages = [
+            _notion_page("p-future", "2026-07-09T12:00:00.000Z", "too new"),
+            _notion_page("p-in-1", "2026-07-09T01:00:00.000Z", "in window 1"),
+            _notion_page("p-in-2", "2026-07-08T20:00:00.000Z", "in window 2"),
+            _notion_page("p-old", "2026-07-01T00:00:00.000Z", "older than since"),
+            _notion_page("p-older", "2026-06-01T00:00:00.000Z", "never reached"),
+        ]
+
+        def responder(method, path, payload):
+            assert path == "/search"
+            return {"results": pages, "has_more": False}
+
+        self._install(responder)
+        notes = NotionNotes(token="stub", notes_root="root")
+        since = datetime(2026, 7, 8, 2, 0, 0, tzinfo=timezone.utc)
+        until = datetime(2026, 7, 9, 2, 0, 0, tzinfo=timezone.utc)
+        hits = notes.list_recent(since, until)
+        self.assertEqual([hit.id for hit in hits], ["p-in-1", "p-in-2"])
+        self.assertEqual(hits[0].title, "in window 1")
+        self.assertEqual(hits[0].deeplink, "https://www.notion.so/pin1")
+        # descending sort requested from the API
+        self.assertEqual(
+            self.requests[0][2]["sort"],
+            {"direction": "descending", "timestamp": "last_edited_time"},
+        )
+
+    def test_paginates_until_window_exhausted(self) -> None:
+        page_one = [_notion_page("p-1", "2026-07-09T01:00:00.000Z", "one")]
+        page_two = [_notion_page("p-2", "2026-07-08T23:00:00.000Z", "two")]
+
+        def responder(method, path, payload):
+            if payload.get("start_cursor") == "cursor-2":
+                return {"results": page_two, "has_more": False}
+            return {"results": page_one, "has_more": True, "next_cursor": "cursor-2"}
+
+        self._install(responder)
+        notes = NotionNotes(token="stub", notes_root="root")
+        hits = notes.list_recent(
+            datetime(2026, 7, 8, 2, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 7, 9, 2, 0, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual([hit.id for hit in hits], ["p-1", "p-2"])
+        self.assertEqual(len(self.requests), 2)
+
+    def test_min_content_len_fetches_body(self) -> None:
+        pages = [
+            _notion_page("p-long", "2026-07-09T01:00:00.000Z", "long"),
+            _notion_page("p-short", "2026-07-09T00:30:00.000Z", "short"),
+        ]
+
+        def responder(method, path, payload):
+            if path == "/search":
+                return {"results": pages, "has_more": False}
+            if path.startswith("/blocks/p-long"):
+                return {
+                    "results": [
+                        {
+                            "type": "paragraph",
+                            "paragraph": {"rich_text": [{"plain_text": "b" * 300}]},
+                        }
+                    ]
+                }
+            return {"results": []}
+
+        self._install(responder)
+        notes = NotionNotes(token="stub", notes_root="root")
+        hits = notes.list_recent(
+            datetime(2026, 7, 8, 2, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 7, 9, 2, 0, 0, tzinfo=timezone.utc),
+            min_content_len=200,
+        )
+        self.assertEqual([hit.id for hit in hits], ["p-long"])
+
+    def test_limit_short_circuits(self) -> None:
+        pages = [
+            _notion_page(f"p-{n}", "2026-07-09T01:00:00.000Z", f"page {n}")
+            for n in range(5)
+        ]
+
+        def responder(method, path, payload):
+            return {"results": pages, "has_more": False}
+
+        self._install(responder)
+        notes = NotionNotes(token="stub", notes_root="root")
+        hits = notes.list_recent(
+            datetime(2026, 7, 8, 2, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 7, 9, 2, 0, 0, tzinfo=timezone.utc),
+            limit=2,
+        )
+        self.assertEqual(len(hits), 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/chassis/second_brain/tests/test_mcp_json_render.py
+++ b/chassis/second_brain/tests/test_mcp_json_render.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""test_mcp_json_render.py - .mcp.json renders correctly for every (backend, mode) combination.
+
+Drives the REAL template (chassis/.mcp.json.template) through the REAL
+hydrator (chassis/scripts/hydrate-mcp-json.py) with fixture configs, and
+asserts which second-brain servers land in the output:
+
+    (siyuan,   direct)  -> siyuan only
+    (siyuan,   adapter) -> secondbrain only
+    (notion,   direct)  -> notion only
+    (notion,   adapter) -> secondbrain only
+    (obsidian, direct)  -> NO second-brain server at all. This combination is
+                           effectively invalid: there is no Obsidian MCP server
+                           in the template because none exists that fits the
+                           chassis (the community options need the Obsidian
+                           desktop app + Local REST API plugin, which a
+                           headless container install does not run). Obsidian
+                           installs are adapter-mode-only.
+    (obsidian, adapter) -> secondbrain only
+
+Plus the compatibility case that protects existing installs: a config with NO
+mode key renders exactly like mode: direct.
+
+Run:
+    python3 -m pytest chassis/second_brain/tests/test_mcp_json_render.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+TEMPLATE_PATH = REPO_ROOT / "chassis" / ".mcp.json.template"
+HYDRATOR_PATH = REPO_ROOT / "chassis" / "scripts" / "hydrate-mcp-json.py"
+
+_spec = importlib.util.spec_from_file_location("hydrate_mcp_json", HYDRATOR_PATH)
+hydrator = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hydrator)
+
+SECOND_BRAIN_SERVERS = {"siyuan", "notion", "secondbrain"}
+
+
+def _render(backend: str, mode: str | None) -> dict:
+    sb: dict = {"backend": backend}
+    if mode is not None:
+        sb["mode"] = mode
+    config = {"second_brain": sb}
+    template = hydrator.load_json(str(TEMPLATE_PATH))
+    hydrated, _unresolved = hydrator.hydrate(config, template, env={})
+    return hydrated["mcpServers"]
+
+
+class McpJsonRenderMatrixTest(unittest.TestCase):
+    def _assert_second_brain_servers(self, servers: dict, expected: set[str]) -> None:
+        present = SECOND_BRAIN_SERVERS & set(servers)
+        self.assertEqual(present, expected)
+
+    def test_siyuan_direct(self) -> None:
+        self._assert_second_brain_servers(_render("siyuan", "direct"), {"siyuan"})
+
+    def test_siyuan_adapter(self) -> None:
+        self._assert_second_brain_servers(_render("siyuan", "adapter"), {"secondbrain"})
+
+    def test_notion_direct(self) -> None:
+        self._assert_second_brain_servers(_render("notion", "direct"), {"notion"})
+
+    def test_notion_adapter(self) -> None:
+        self._assert_second_brain_servers(_render("notion", "adapter"), {"secondbrain"})
+
+    def test_obsidian_direct_has_no_second_brain_server(self) -> None:
+        # Invalid-but-tolerated combination: no native Obsidian MCP server
+        # exists, so direct mode leaves the install with no second-brain MCP.
+        self._assert_second_brain_servers(_render("obsidian", "direct"), set())
+
+    def test_obsidian_adapter(self) -> None:
+        self._assert_second_brain_servers(
+            _render("obsidian", "adapter"), {"secondbrain"}
+        )
+
+    def test_missing_mode_means_direct(self) -> None:
+        # Installs that predate the mode key must see zero change.
+        self._assert_second_brain_servers(_render("siyuan", None), {"siyuan"})
+        self._assert_second_brain_servers(_render("notion", None), {"notion"})
+        self._assert_second_brain_servers(_render("obsidian", None), set())
+
+    def test_default_on_servers_survive_in_both_modes(self) -> None:
+        for mode in ("direct", "adapter"):
+            servers = _render("siyuan", mode)
+            for name in ("memory", "playwright", "context7", "github"):
+                self.assertIn(name, servers, f"{name} missing in mode={mode}")
+
+    def test_adapter_entry_shape(self) -> None:
+        servers = _render("notion", "adapter")
+        entry = servers["secondbrain"]
+        self.assertEqual(entry["command"], "python3")
+        self.assertIn("second_brain/mcp_server.py", entry["args"][0])
+        # Meta keys must be stripped from the hydrated output.
+        self.assertFalse([k for k in entry if k.startswith("_")])
+
+
+class EnableWhenEvaluatorTest(unittest.TestCase):
+    CONFIG = {"second_brain": {"backend": "siyuan", "mode": "adapter"}}
+
+    def _eval(self, predicate: str, config=None) -> bool:
+        return hydrator.evaluate_enable_when(
+            predicate, self.CONFIG if config is None else config
+        )
+
+    def test_equality(self) -> None:
+        self.assertTrue(self._eval("chassis.config.yaml.second_brain.backend == 'siyuan'"))
+        self.assertFalse(self._eval("chassis.config.yaml.second_brain.backend == 'notion'"))
+
+    def test_inequality(self) -> None:
+        self.assertFalse(self._eval("chassis.config.yaml.second_brain.mode != 'adapter'"))
+        self.assertTrue(self._eval("chassis.config.yaml.second_brain.mode != 'direct'"))
+
+    def test_inequality_on_missing_path_is_true(self) -> None:
+        config = {"second_brain": {"backend": "siyuan"}}
+        self.assertTrue(
+            self._eval("chassis.config.yaml.second_brain.mode != 'adapter'", config)
+        )
+
+    def test_equality_on_missing_path_is_false(self) -> None:
+        config = {"second_brain": {"backend": "siyuan"}}
+        self.assertFalse(
+            self._eval("chassis.config.yaml.second_brain.mode == 'adapter'", config)
+        )
+
+    def test_conjunction(self) -> None:
+        self.assertTrue(
+            self._eval(
+                "chassis.config.yaml.second_brain.backend == 'siyuan' "
+                "&& chassis.config.yaml.second_brain.mode == 'adapter'"
+            )
+        )
+        self.assertFalse(
+            self._eval(
+                "chassis.config.yaml.second_brain.backend == 'siyuan' "
+                "&& chassis.config.yaml.second_brain.mode != 'adapter'"
+            )
+        )
+
+    def test_unparsable_predicates_are_false(self) -> None:
+        self.assertFalse(self._eval("garbage"))
+        self.assertFalse(self._eval(""))
+        self.assertFalse(self._eval("a == 'x' && "))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/chassis/second_brain/tests/test_mcp_server.py
+++ b/chassis/second_brain/tests/test_mcp_server.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""test_mcp_server.py - End-to-end test of the `secondbrain` MCP server over stdio.
+
+Spawns chassis/second_brain/mcp_server.py as a subprocess - exactly how Claude
+Code launches it - against a throwaway Obsidian vault, speaks newline-delimited
+JSON-RPC on its stdin/stdout, and exercises every tool: initialize handshake,
+tools/list, create_doc, read_doc, append_to_doc, search, list_recent,
+get_deeplink. No network, no live backend.
+
+Requires the `mcp` package (in requirements.txt); the whole module is skipped
+when it is not importable so the rest of the suite stays runnable on a bare
+interpreter.
+
+Run:
+    python3 -m pytest chassis/second_brain/tests/test_mcp_server.py -v
+"""
+from __future__ import annotations
+
+import json
+import os
+import select
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SERVER_PATH = REPO_ROOT / "chassis" / "second_brain" / "mcp_server.py"
+
+try:
+    import mcp  # noqa: F401
+
+    HAVE_MCP = True
+except ImportError:
+    HAVE_MCP = False
+
+READ_TIMEOUT_SECONDS = 30
+
+
+@unittest.skipUnless(HAVE_MCP, "mcp SDK not installed (pip install mcp)")
+class SecondBrainMcpServerTest(unittest.TestCase):
+    """One server process for the whole class - the handshake is stateful."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._tmp = Path(tempfile.mkdtemp(prefix="secondbrain-mcp-e2e-"))
+        cls.vault = cls._tmp / "vault"
+        (cls.vault / "Briefings").mkdir(parents=True)
+        (cls.vault / "Inbox.md").write_text(
+            "# Inbox\n\nCall the notary about the apartment paperwork.\n",
+            encoding="utf-8",
+        )
+        customer_home = cls._tmp / "customer"
+        customer_home.mkdir()
+        (customer_home / "chassis.config.yaml").write_text(
+            "second_brain:\n"
+            "  backend: obsidian\n"
+            "  mode: adapter\n"
+            "  obsidian:\n"
+            f"    vault_path: {cls.vault}\n"
+            "    vault_name: e2e-vault\n",
+            encoding="utf-8",
+        )
+        env = dict(os.environ)
+        env["CHASSIS_HOME"] = str(customer_home)
+        cls.proc = subprocess.Popen(
+            [sys.executable, str(SERVER_PATH)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            text=True,
+            bufsize=1,
+        )
+        cls._next_id = 0
+        cls._initialize()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.proc.terminate()
+        try:
+            cls.proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            cls.proc.kill()
+            cls.proc.wait(timeout=5)
+        shutil.rmtree(cls._tmp, ignore_errors=True)
+
+    # -- JSON-RPC plumbing ----------------------------------------------------
+
+    @classmethod
+    def _send(cls, message: dict) -> None:
+        cls.proc.stdin.write(json.dumps(message) + "\n")
+        cls.proc.stdin.flush()
+
+    @classmethod
+    def _read_response(cls, expect_id: int) -> dict:
+        deadline_fd = cls.proc.stdout
+        while True:
+            ready, _, _ = select.select([deadline_fd], [], [], READ_TIMEOUT_SECONDS)
+            if not ready:
+                stderr = cls.proc.stderr.read() if cls.proc.poll() is not None else ""
+                raise AssertionError(
+                    f"no response within {READ_TIMEOUT_SECONDS}s waiting for id={expect_id}; "
+                    f"server rc={cls.proc.poll()}, stderr tail: {stderr[-2000:]}"
+                )
+            line = deadline_fd.readline()
+            if not line:
+                raise AssertionError(
+                    f"server closed stdout waiting for id={expect_id} "
+                    f"(rc={cls.proc.poll()})"
+                )
+            message = json.loads(line)
+            if message.get("id") == expect_id:
+                return message
+            # Skip server-initiated notifications/logs.
+
+    @classmethod
+    def _request(cls, method: str, params: dict | None = None) -> dict:
+        cls._next_id += 1
+        request_id = cls._next_id
+        payload = {"jsonrpc": "2.0", "id": request_id, "method": method}
+        if params is not None:
+            payload["params"] = params
+        cls._send(payload)
+        return cls._read_response(request_id)
+
+    @classmethod
+    def _initialize(cls) -> None:
+        response = cls._request(
+            "initialize",
+            {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "chassis-e2e-test", "version": "0"},
+            },
+        )
+        assert "result" in response, f"initialize failed: {response}"
+        cls.server_info = response["result"]
+        cls._send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+    def _call_tool(self, name: str, arguments: dict) -> dict:
+        response = self._request(
+            "tools/call", {"name": name, "arguments": arguments}
+        )
+        self.assertIn("result", response, f"{name} errored: {response}")
+        result = response["result"]
+        self.assertFalse(
+            result.get("isError"),
+            f"{name} returned isError: {json.dumps(result)[:800]}",
+        )
+        return result
+
+    @staticmethod
+    def _text_of(result: dict) -> str:
+        return "\n".join(
+            item.get("text", "")
+            for item in result.get("content", [])
+            if item.get("type") == "text"
+        )
+
+    # -- the actual drill (numbered: later steps read earlier steps' writes) --
+
+    def test_01_server_identifies_as_secondbrain(self) -> None:
+        self.assertEqual(self.server_info["serverInfo"]["name"], "secondbrain")
+
+    def test_02_tools_list_exposes_the_protocol_surface(self) -> None:
+        response = self._request("tools/list")
+        tools = {tool["name"] for tool in response["result"]["tools"]}
+        self.assertEqual(
+            tools,
+            {
+                "create_doc",
+                "append_to_doc",
+                "read_doc",
+                "search",
+                "list_recent",
+                "get_deeplink",
+            },
+        )
+
+    def test_03_create_doc_returns_id_and_deeplink(self) -> None:
+        result = self._call_tool(
+            "create_doc",
+            {
+                "parent": "Briefings/",
+                "title": "2026-07-09-e2e",
+                "body": "# E2E\n\nqueued from the drill\n",
+            },
+        )
+        text = self._text_of(result)
+        self.assertIn("Briefings/2026-07-09-e2e.md", text)
+        self.assertIn("obsidian://open?vault=e2e-vault", text)
+        self.assertTrue((self.vault / "Briefings" / "2026-07-09-e2e.md").is_file())
+
+    def test_04_read_doc_round_trips(self) -> None:
+        result = self._call_tool(
+            "read_doc", {"doc_id": "Briefings/2026-07-09-e2e.md"}
+        )
+        self.assertIn("queued from the drill", self._text_of(result))
+
+    def test_05_append_is_visible_in_next_read(self) -> None:
+        self._call_tool(
+            "append_to_doc",
+            {
+                "doc_id": "Briefings/2026-07-09-e2e.md",
+                "content": "appended-by-e2e-marker",
+            },
+        )
+        result = self._call_tool(
+            "read_doc", {"doc_id": "Briefings/2026-07-09-e2e.md"}
+        )
+        self.assertIn("appended-by-e2e-marker", self._text_of(result))
+
+    def test_06_search_finds_seeded_content(self) -> None:
+        result = self._call_tool("search", {"query": "notary", "limit": 5})
+        self.assertIn("Inbox", self._text_of(result))
+
+    def test_07_list_recent_sees_the_created_doc(self) -> None:
+        since = (datetime.now() - timedelta(hours=1)).isoformat()
+        until = (datetime.now() + timedelta(hours=1)).isoformat()
+        result = self._call_tool(
+            "list_recent", {"since": since, "until": until, "limit": 10}
+        )
+        self.assertIn("Briefings/2026-07-09-e2e.md", self._text_of(result))
+
+    def test_08_list_recent_empty_future_window(self) -> None:
+        since = (datetime.now() + timedelta(days=10)).isoformat()
+        until = (datetime.now() + timedelta(days=11)).isoformat()
+        result = self._call_tool(
+            "list_recent", {"since": since, "until": until}
+        )
+        self.assertNotIn("2026-07-09-e2e", self._text_of(result))
+
+    def test_09_get_deeplink(self) -> None:
+        result = self._call_tool("get_deeplink", {"doc_id": "Inbox.md"})
+        self.assertIn("obsidian://open?vault=e2e-vault&file=Inbox.md", self._text_of(result))
+
+    def test_10_bad_datetime_surfaces_as_tool_error_not_crash(self) -> None:
+        response = self._request(
+            "tools/call",
+            {
+                "name": "list_recent",
+                "arguments": {"since": "not-a-date", "until": "also-not"},
+            },
+        )
+        result = response.get("result", {})
+        self.assertTrue(result.get("isError"), f"expected isError, got {response}")
+        self.assertIn("ISO-8601", json.dumps(result))
+        # Server must still answer after the failed call.
+        alive = self._call_tool("get_deeplink", {"doc_id": "Inbox.md"})
+        self.assertIn("Inbox.md", self._text_of(alive))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/chassis/second_brain/tests/test_siyuan_search_escaping.py
+++ b/chassis/second_brain/tests/test_siyuan_search_escaping.py
@@ -1,13 +1,21 @@
 #!/usr/bin/env python3
-"""test_siyuan_search_escaping.py - SiYuanNotes.search() escapes its LIKE pattern.
+"""test_siyuan_search_escaping.py - what SiYuanNotes may and may not put in its SQL.
 
-search() is exposed as an MCP tool by second_brain/mcp_server.py, so `query` is
-arbitrary model-supplied or user-supplied text. It is interpolated into a sqlite
-`LIKE '%...%'` pattern, where a bare quote-escape leaves the wildcards live: a
-query containing `%` or `_` would silently match far more than the user asked
-for, and a `'` would break out of the literal.
+Two contracts, both learned the hard way against a live kernel:
 
-No network - _post is stubbed to capture the SQL the adapter would have sent.
+1. NO `ESCAPE` CLAUSE. SiYuan's /api/query/sql does not accept one. A query with
+   `ESCAPE '\\'` (or any escape char) comes back `{"code": 0, "data": null}` -
+   zero rows - while the identical query without it returns hundreds. An earlier
+   revision of this adapter added ESCAPE to neutralize LIKE wildcards and thereby
+   broke search() completely: every query returned no hits. The wildcards stay
+   live instead; `_escape` alone is the injection defense.
+
+2. `data: null` FROM THE SQL ENDPOINT IS AN ERROR, NOT AN EMPTY RESULT. That is
+   what made (1) silent. Callers used to do `result if isinstance(result, list)
+   else []`, so a query the kernel refused looked exactly like "no matches". A
+   genuinely empty result set is `[]`.
+
+The transport is stubbed - no network, no kernel.
 
 Run:
     python3 -m pytest chassis/second_brain/tests/test_siyuan_search_escaping.py -v
@@ -16,18 +24,21 @@ from __future__ import annotations
 
 import sys
 import unittest
+from datetime import datetime, timedelta
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT))
 
-from chassis.second_brain.siyuan import LIKE_ESCAPE_CHAR, SiYuanNotes  # noqa: E402
+from chassis.second_brain.siyuan import SiYuanError, SiYuanNotes  # noqa: E402
 
 
-class CapturingNotes(SiYuanNotes):
-    """SiYuanNotes with the HTTP call replaced by a recorder."""
+class StubNotes(SiYuanNotes):
+    """SiYuanNotes with the HTTP call replaced by a recorder + canned reply."""
 
-    def __init__(self) -> None:
+    _UNSET = object()
+
+    def __init__(self, reply=_UNSET) -> None:
         super().__init__(
             base_url="http://kernel.invalid:6806",
             token="fake-token",
@@ -35,10 +46,14 @@ class CapturingNotes(SiYuanNotes):
             deeplink_template="siyuan://blocks/",
         )
         self.statements: list[str] = []
+        # `reply=None` must mean "the kernel answered data: null", so the default
+        # needs a sentinel rather than None.
+        self._reply = [] if reply is self._UNSET else reply
 
     def _post(self, path: str, payload: dict):  # type: ignore[override]
-        self.statements.append(payload.get("stmt", ""))
-        return []
+        if path == "/api/query/sql":
+            self.statements.append(payload.get("stmt", ""))
+        return self._reply
 
     def sql_for(self, query: str) -> str:
         self.statements.clear()
@@ -47,48 +62,72 @@ class CapturingNotes(SiYuanNotes):
         return self.statements[0]
 
 
-class SearchEscapingTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.notes = CapturingNotes()
+class NoEscapeClauseTest(unittest.TestCase):
+    """SiYuan rejects ESCAPE. Emitting one silently zeroes out every search."""
 
-    def test_escape_clause_is_present(self) -> None:
+    def setUp(self) -> None:
+        self.notes = StubNotes()
+
+    def test_search_sql_contains_no_escape_token(self) -> None:
         sql = self.notes.sql_for("briefing")
-        self.assertIn(f"ESCAPE '{LIKE_ESCAPE_CHAR}'", sql)
+        self.assertNotIn("ESCAPE", sql.upper())
         self.assertIn("LIKE '%briefing%'", sql)
 
-    def test_percent_is_escaped_not_left_as_a_wildcard(self) -> None:
-        # "100% cotton" must match that literal string, not "100<anything>cotton".
-        sql = self.notes.sql_for("100% cotton")
-        self.assertIn(f"LIKE '%100{LIKE_ESCAPE_CHAR}% cotton%'", sql)
+    def test_no_escape_clause_even_when_the_query_holds_wildcards(self) -> None:
+        # The tempting-but-fatal case: wildcards present, so an implementation
+        # might reach for ESCAPE. It must not.
+        for query in ("100% cotton", "snake_case", "C:\\Users", "%_%"):
+            sql = self.notes.sql_for(query)
+            self.assertNotIn("ESCAPE", sql.upper(), f"ESCAPE emitted for {query!r}")
 
-    def test_underscore_is_escaped_not_left_as_a_single_char_wildcard(self) -> None:
-        sql = self.notes.sql_for("snake_case")
-        self.assertIn(f"LIKE '%snake{LIKE_ESCAPE_CHAR}_case%'", sql)
-
-    def test_escape_char_itself_is_doubled(self) -> None:
-        # A literal backslash in the query must not consume the next character.
-        sql = self.notes.sql_for("C:\\Users")
-        self.assertIn(f"LIKE '%C:{LIKE_ESCAPE_CHAR * 2}Users%'", sql)
+    def test_wildcards_pass_through_unescaped(self) -> None:
+        # Documented, accepted tradeoff: '%' and '_' stay live LIKE wildcards.
+        self.assertIn("LIKE '%100% cotton%'", self.notes.sql_for("100% cotton"))
+        self.assertIn("LIKE '%snake_case%'", self.notes.sql_for("snake_case"))
 
     def test_single_quote_cannot_break_out_of_the_literal(self) -> None:
-        sql = self.notes.sql_for("O'Brien")
-        self.assertIn("LIKE '%O''Brien%'", sql)
+        # Quote-doubling is the injection defense, and it survives.
+        self.assertIn("LIKE '%O''Brien%'", self.notes.sql_for("O'Brien"))
 
     def test_injection_attempt_stays_inside_the_literal(self) -> None:
         sql = self.notes.sql_for("' OR 1=1 --")
-        # The quote is doubled, so the payload never terminates the string.
         self.assertIn("LIKE '%'' OR 1=1 --%'", sql)
         self.assertEqual(sql.count("SELECT"), 1)
 
-    def test_wildcards_survive_the_round_trip_only_as_escaped_literals(self) -> None:
-        sql = self.notes.sql_for("%_%")
-        pattern = sql.split("LIKE '", 1)[1].split("'", 1)[0]
-        # Every wildcard inside the user's text is preceded by the escape char;
-        # the only bare wildcards are the two the adapter adds itself.
-        body = pattern[1:-1]
-        self.assertEqual(
-            body, f"{LIKE_ESCAPE_CHAR}%{LIKE_ESCAPE_CHAR}_{LIKE_ESCAPE_CHAR}%"
-        )
+
+class NullDataIsAnErrorTest(unittest.TestCase):
+    """`{"code": 0, "data": null}` means REFUSED, not "no rows"."""
+
+    def test_search_raises_on_null_data(self) -> None:
+        notes = StubNotes(reply=None)
+        with self.assertRaises(SiYuanError) as ctx:
+            notes.search("Vibecode")
+        message = str(ctx.exception)
+        self.assertIn("data=null", message)
+        self.assertIn("SELECT", message)  # the offending statement is surfaced
+
+    def test_list_recent_raises_on_null_data(self) -> None:
+        notes = StubNotes(reply=None)
+        now = datetime.now()
+        with self.assertRaises(SiYuanError):
+            notes.list_recent(now - timedelta(days=1), now)
+
+    def test_block_lookups_raise_on_null_data(self) -> None:
+        notes = StubNotes(reply=None)
+        with self.assertRaises(SiYuanError):
+            notes._block_to_hpath("20231101120000-abc123")
+        with self.assertRaises(SiYuanError):
+            notes._block_title("20231101120000-abc123")
+
+    def test_empty_list_is_still_a_legitimate_empty_result(self) -> None:
+        # The distinction the fix rests on: [] is "no matches", null is "refused".
+        notes = StubNotes(reply=[])
+        self.assertEqual(notes.search("nothing matches this"), [])
+
+    def test_non_list_payload_raises(self) -> None:
+        notes = StubNotes(reply={"unexpected": "shape"})
+        with self.assertRaises(SiYuanError):
+            notes.search("Vibecode")
 
 
 if __name__ == "__main__":

--- a/chassis/second_brain/tests/test_siyuan_search_escaping.py
+++ b/chassis/second_brain/tests/test_siyuan_search_escaping.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""test_siyuan_search_escaping.py - SiYuanNotes.search() escapes its LIKE pattern.
+
+search() is exposed as an MCP tool by second_brain/mcp_server.py, so `query` is
+arbitrary model-supplied or user-supplied text. It is interpolated into a sqlite
+`LIKE '%...%'` pattern, where a bare quote-escape leaves the wildcards live: a
+query containing `%` or `_` would silently match far more than the user asked
+for, and a `'` would break out of the literal.
+
+No network - _post is stubbed to capture the SQL the adapter would have sent.
+
+Run:
+    python3 -m pytest chassis/second_brain/tests/test_siyuan_search_escaping.py -v
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from chassis.second_brain.siyuan import LIKE_ESCAPE_CHAR, SiYuanNotes  # noqa: E402
+
+
+class CapturingNotes(SiYuanNotes):
+    """SiYuanNotes with the HTTP call replaced by a recorder."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            base_url="http://kernel.invalid:6806",
+            token="fake-token",
+            notebook_id="20231101120000-abc123",
+            deeplink_template="siyuan://blocks/",
+        )
+        self.statements: list[str] = []
+
+    def _post(self, path: str, payload: dict):  # type: ignore[override]
+        self.statements.append(payload.get("stmt", ""))
+        return []
+
+    def sql_for(self, query: str) -> str:
+        self.statements.clear()
+        self.search(query)
+        assert len(self.statements) == 1
+        return self.statements[0]
+
+
+class SearchEscapingTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.notes = CapturingNotes()
+
+    def test_escape_clause_is_present(self) -> None:
+        sql = self.notes.sql_for("briefing")
+        self.assertIn(f"ESCAPE '{LIKE_ESCAPE_CHAR}'", sql)
+        self.assertIn("LIKE '%briefing%'", sql)
+
+    def test_percent_is_escaped_not_left_as_a_wildcard(self) -> None:
+        # "100% cotton" must match that literal string, not "100<anything>cotton".
+        sql = self.notes.sql_for("100% cotton")
+        self.assertIn(f"LIKE '%100{LIKE_ESCAPE_CHAR}% cotton%'", sql)
+
+    def test_underscore_is_escaped_not_left_as_a_single_char_wildcard(self) -> None:
+        sql = self.notes.sql_for("snake_case")
+        self.assertIn(f"LIKE '%snake{LIKE_ESCAPE_CHAR}_case%'", sql)
+
+    def test_escape_char_itself_is_doubled(self) -> None:
+        # A literal backslash in the query must not consume the next character.
+        sql = self.notes.sql_for("C:\\Users")
+        self.assertIn(f"LIKE '%C:{LIKE_ESCAPE_CHAR * 2}Users%'", sql)
+
+    def test_single_quote_cannot_break_out_of_the_literal(self) -> None:
+        sql = self.notes.sql_for("O'Brien")
+        self.assertIn("LIKE '%O''Brien%'", sql)
+
+    def test_injection_attempt_stays_inside_the_literal(self) -> None:
+        sql = self.notes.sql_for("' OR 1=1 --")
+        # The quote is doubled, so the payload never terminates the string.
+        self.assertIn("LIKE '%'' OR 1=1 --%'", sql)
+        self.assertEqual(sql.count("SELECT"), 1)
+
+    def test_wildcards_survive_the_round_trip_only_as_escaped_literals(self) -> None:
+        sql = self.notes.sql_for("%_%")
+        pattern = sql.split("LIKE '", 1)[1].split("'", 1)[0]
+        # Every wildcard inside the user's text is preceded by the escape char;
+        # the only bare wildcards are the two the adapter adds itself.
+        body = pattern[1:-1]
+        self.assertEqual(
+            body, f"{LIKE_ESCAPE_CHAR}%{LIKE_ESCAPE_CHAR}_{LIKE_ESCAPE_CHAR}%"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -31,7 +31,7 @@ Once the file lands, restart Claude Code so it re-reads. The manual hydration wa
 |---|---|---|
 | **Always-on** (no auth) | `memory`, `playwright`, `context7` | Every install. Keep. |
 | **Always-on with config** | `github` | Every install touches GitHub. Provision agent-side PAT. |
-| **Pick one** (second-brain) | `siyuan` OR `notion` | Per `chassis.config.yaml.second_brain.backend`. Delete the other. |
+| **Pick one** (second-brain) | `siyuan` OR `notion` OR `secondbrain` | Per `chassis.config.yaml.second_brain.backend` + `second_brain.mode`. Mode `direct` (default): the backend's native server. Mode `adapter`: the chassis-owned `secondbrain` server INSTEAD, and the native server is not registered. Obsidian has no native server - obsidian installs need `mode: adapter` for any second-brain MCP surface. |
 | **Optional, opt-in** | `brave-search`, `tavily`, `turso`, `amplitude`, `n8n`, `loom`, `remarkable`, `oura`, `frame0` | Per `chassis.config.yaml.modules.*` flags. Delete entries you don't activate. |
 
 ---
@@ -71,7 +71,11 @@ Setup:
 
 Sanity check: `gh auth status` returns the agent-side identity (NOT your personal account).
 
-### siyuan OR notion (pick one)
+### secondbrain (adapter mode)
+
+If `chassis.config.yaml.second_brain.mode` is `adapter`, the hydrator registers the chassis-owned `secondbrain` server (`chassis/second_brain/mcp_server.py`) and OMITS the native backend server below. It needs no extra auth of its own - it reads the backend credentials from `chassis.config.yaml` / `.env` via the second-brain adapter factory. Tools: `create_doc`, `append_to_doc`, `read_doc`, `search`, `list_recent`, `get_deeplink` - identical on every backend. See docs/second-brain-adapters.md.
+
+### siyuan OR notion (pick one, direct mode)
 
 #### siyuan
 

--- a/docs/second-brain-adapters.md
+++ b/docs/second-brain-adapters.md
@@ -103,7 +103,51 @@ sb.database.update_property(hit, "last_outreach_at", "2026-05-07")
 hits = sb.notes.search("morning briefing", limit=5)
 for h in hits:
     print(h.title, h.deeplink)
+
+# Recent activity - docs created/modified in a time window, newest first
+from datetime import datetime, timedelta
+hits = sb.notes.list_recent(
+    since=datetime.now() - timedelta(days=1),
+    until=datetime.now(),
+    min_content_len=200,
+    limit=50,
+)
 ```
+
+## `list_recent` per-backend divergences
+
+All three backends implement `list_recent(since, until, min_content_len, limit)` - docs created or modified in `[since, until)`, newest first. The implementations are honest but the underlying signals are NOT equivalent. Naive datetimes are interpreted as local time.
+
+| | Timestamp source | Granularity | `min_content_len` measure | Caveats |
+|---|---|---|---|---|
+| SiYuan | `blocks.updated` (kernel-local clock) | second | `SUM(LENGTH(content))` over the doc's child blocks via correlated subquery - the doc row's own `content` column holds only the TITLE (verified against a live kernel: max 81 chars over 283 docs), so it cannot be used for length filtering | cleanest of the three; block timestamps reflect actual edits |
+| Obsidian | filesystem mtime of `*.md` | filesystem-dependent | file size in bytes (frontmatter and markdown syntax count toward it; multi-byte characters count per byte) | NOISIEST: a git pull, iCloud resync, or any sync tool that rewrites files produces false "activity". Treat hits as candidates, not facts |
+| Notion | `last_edited_time` via `/search`, descending scan with client-side windowing (the endpoint has no timestamp filter) | MINUTE - Notion truncates seconds, so edits at a window boundary can fall on either side | reconstructed-markdown length of the first 100 blocks; costs one extra API call per candidate page, so leave at 0 unless needed | only pages shared with the integration are visible; scan is capped at 500 pages per call |
+
+## `second_brain.mode` and the `secondbrain` MCP server
+
+`chassis.config.yaml` carries a `mode` key next to `backend`:
+
+```yaml
+second_brain:
+  backend: siyuan     # siyuan | notion | obsidian
+  mode: direct        # direct | adapter (direct is the default, and what a missing key means)
+```
+
+- **`direct`** (default): today's behavior. The backend's own MCP server (`siyuan` / `notion`) is registered in `.mcp.json`; chassis scripts talk to the backend natively. Installs whose config predates the key see zero change.
+- **`adapter`**: the chassis-owned `secondbrain` MCP server (`chassis/second_brain/mcp_server.py`) is registered INSTEAD, exposing one fixed tool namespace over `get_adapter()`: `create_doc`, `append_to_doc`, `read_doc`, `search`, `list_recent`, `get_deeplink`. The native backend server is deliberately NOT registered - tool availability is the guardrail that keeps prompts backend-neutral. One server over N adapter classes, not one server per backend: MCP tool names are namespaced by server name, so per-backend servers would mean per-backend prompt text, which defeats the abstraction.
+
+Registration is driven by `_enable_when` predicates in `chassis/.mcp.json.template`, evaluated by `chassis/scripts/hydrate-mcp-json.py` (which supports `==`, `!=`, and `&&`; a missing `mode` key satisfies `mode != 'adapter'`, keeping legacy configs on the direct path).
+
+Backend support per mode:
+
+| backend | direct | adapter |
+|---|---|---|
+| siyuan | `siyuan` MCP server (`siyuan-mcp@1.0.4`) | `secondbrain` |
+| notion | `notion` MCP server (`@suekou/mcp-notion-server`) | `secondbrain` |
+| obsidian | NO second-brain MCP surface - no suitable native server exists (community options require the Obsidian desktop app + Local REST API plugin, which headless container installs do not run) | `secondbrain` |
+
+Obsidian installs are therefore adapter-mode-only if they want a second-brain MCP surface at all.
 
 ## Contract
 

--- a/docs/second-brain-adapters.md
+++ b/docs/second-brain-adapters.md
@@ -160,6 +160,32 @@ This is **not a write failure** - the write persists correctly and `read_doc` on
 
 Callers that write-then-read-back must tolerate the lag: keep the id `create_doc` returned rather than searching for the doc by title, or poll. Obsidian (direct filesystem IO) and Notion (API-backed) have no equivalent lag - a write is visible to the next read. This divergence is SiYuan-only, and it is the one place where the adapters' shared interface hides genuinely different semantics.
 
+### SiYuan `search()`: LIKE wildcards pass through, and cannot be escaped
+
+`SiYuanNotes.search(query)` interpolates `query` into a SQL `LIKE '%...%'` pattern. **`%` and `_` in a query stay live as LIKE wildcards.** A search for `50%` also matches `50 percent`; `a_b` also matches `axb`.
+
+This is a known tradeoff, not an oversight. **SiYuan's `/api/query/sql` does not accept an `ESCAPE` clause**, so the wildcards cannot be neutralized. Measured against a live kernel:
+
+| Statement | Result |
+|---|---|
+| `... content LIKE '%Vibecode%'` | `code 0`, 397 rows |
+| `... content LIKE '%Vibecode%' ESCAPE '\'` | `code 0`, `data: null` - **zero rows** |
+| same with `ESCAPE '!'` or `ESCAPE '#'` | `code 0`, `data: null` - **zero rows** |
+
+Any escape character makes the kernel refuse the query. An earlier revision of the adapter added `ESCAPE '\'` to tame the wildcards and thereby broke `search()` outright: every query returned no hits, against a kernel holding hundreds of matches. Do not re-add it.
+
+Wildcard pass-through is safe. The single-quote doubling in `_escape()` is the injection defense - a query can never break out of the string literal it sits in - and results are `LIMIT`-capped. The only cost is that a query containing a wildcard matches more broadly than the caller may have intended.
+
+### SiYuan `data: null` means the query was REFUSED, not "no matches"
+
+Related, and the reason the above was silent for so long. SiYuan answers a SQL statement it will not run with a **success-shaped null**:
+
+```json
+{"code": 0, "msg": "", "data": null}
+```
+
+A genuinely empty result set comes back as `[]`. The adapter's `_query_sql()` therefore raises `SiYuanError` (naming the offending statement) on a null payload rather than coercing it to an empty list. Treating null as "no rows" is what turned a rejected query into a plausible-looking "nothing found". Only the `/api/query/sql` path is hardened this way - other endpoints (`appendBlock`) return null legitimately.
+
 ## `second_brain.mode` and the `secondbrain` MCP server
 
 `chassis.config.yaml` carries a `mode` key next to `backend`:

--- a/docs/second-brain-adapters.md
+++ b/docs/second-brain-adapters.md
@@ -36,7 +36,7 @@ Pick the backend in `chassis.config.yaml`.
 | siyuan | `SIYUAN_TOKEN` | `second_brain.siyuan.token` | none - **empty token raises `ValueError` at startup** |
 | siyuan | `SIYUAN_URL` | `second_brain.siyuan.base_url` | `http://127.0.0.1:6806` |
 | siyuan | - | `second_brain.siyuan.notebook_id` | `second_brain.databases.notes_root`; empty raises `ValueError` |
-| siyuan | - | `second_brain.siyuan.deeplink_template` | `siyuan://blocks/` |
+| siyuan | `SIYUAN_DEEPLINK_BASE` | `second_brain.siyuan.deeplink_template` | `siyuan://blocks/` - **desktop-app URI, does not open on a phone** (see below) |
 | notion | `NOTION_API_TOKEN` | `second_brain.notion.token` | none |
 | notion | - | `second_brain.notion.notes_root` | `second_brain.databases.notes_root` |
 | obsidian | - (no credential) | `second_brain.obsidian.vault_path` | none - required |
@@ -46,6 +46,24 @@ Resolution is: **YAML key if set, else env var, else the documented default.** A
 The SiYuan adapter refuses to construct with an empty token or an empty `notebook_id`. Both used to be silently tolerated, which produced an adapter that answered every call with `Auth failed [session]`. Failing loudly at server startup is deliberate - `mcp_server.main()` resolves the adapter eagerly so a broken config shows up in `claude mcp list` and the server log, not mid-task.
 
 > **Container gotcha:** from inside the chassis container, `127.0.0.1` is the container itself. A SiYuan kernel running on the host is reachable at `http://host.docker.internal:6806`. Set `SIYUAN_URL` accordingly.
+
+### SiYuan deeplinks: the default does not open on a phone
+
+`get_deeplink(doc_id)` returns `deeplink_template + doc_id` - the template is a prefix a block id is appended to verbatim, so it must keep its trailing separator (`/` or `=`).
+
+Resolution is three-level, same shape as the credentials:
+
+1. `second_brain.siyuan.deeplink_template` in `chassis.config.yaml` (explicit per-install override)
+2. env `SIYUAN_DEEPLINK_BASE`
+3. the chassis default, `siyuan://blocks/`
+
+**The default is a desktop-app URI. It does NOT open on mobile.** `siyuan://blocks/<id>` hands off to the SiYuan desktop application; tapping it on an iPhone does nothing. Any install that wants links a human can actually tap from a phone (briefings, Pacman proposals, anything delivered over Discord or email) must set `SIYUAN_DEEPLINK_BASE` to its SiYuan **web UI** prefix:
+
+```
+SIYUAN_DEEPLINK_BASE=https://<your-siyuan-host>:6806/stage/build/desktop/?id=
+```
+
+Substitute a hostname that is actually reachable from the phone - public DNS, a Tailnet address, or a reverse proxy. **The chassis ships no hostname**: it is per-install, and in practice it moves (a public host today, a Tailnet address while DNS is broken, back again later). That is exactly why it is a parameter and not a constant. Set it in `.env`, in one place, and nothing in the code or the committed config has to change when it moves.
 
 ### SiYuan
 

--- a/docs/second-brain-adapters.md
+++ b/docs/second-brain-adapters.md
@@ -25,18 +25,42 @@ Notion implements both natively. SiYuan and Obsidian implement `notes` natively 
 
 ## Configuration
 
-Pick the backend in `chassis.config.yaml`:
+Pick the backend in `chassis.config.yaml`.
+
+### Credential resolution order
+
+**Credentials live in `.env`, not in `chassis.config.yaml`.** Adapter mode and direct mode read the same vars from the same place, so a secret is never duplicated and flipping `mode` cannot strand one of them. `chassis.config.yaml` is committed; a token must never be pasted into it.
+
+| Backend | Env var (source of truth) | YAML override (optional) | Fallback |
+|---|---|---|---|
+| siyuan | `SIYUAN_TOKEN` | `second_brain.siyuan.token` | none - **empty token raises `ValueError` at startup** |
+| siyuan | `SIYUAN_URL` | `second_brain.siyuan.base_url` | `http://127.0.0.1:6806` |
+| siyuan | - | `second_brain.siyuan.notebook_id` | `second_brain.databases.notes_root`; empty raises `ValueError` |
+| siyuan | - | `second_brain.siyuan.deeplink_template` | `siyuan://blocks/` |
+| notion | `NOTION_API_TOKEN` | `second_brain.notion.token` | none |
+| notion | - | `second_brain.notion.notes_root` | `second_brain.databases.notes_root` |
+| obsidian | - (no credential) | `second_brain.obsidian.vault_path` | none - required |
+
+Resolution is: **YAML key if set, else env var, else the documented default.** A YAML value of `${SIYUAN_TOKEN}` that expands to nothing counts as unset and falls through rather than shadowing the env var.
+
+The SiYuan adapter refuses to construct with an empty token or an empty `notebook_id`. Both used to be silently tolerated, which produced an adapter that answered every call with `Auth failed [session]`. Failing loudly at server startup is deliberate - `mcp_server.main()` resolves the adapter eagerly so a broken config shows up in `claude mcp list` and the server log, not mid-task.
+
+> **Container gotcha:** from inside the chassis container, `127.0.0.1` is the container itself. A SiYuan kernel running on the host is reachable at `http://host.docker.internal:6806`. Set `SIYUAN_URL` accordingly.
 
 ### SiYuan
+
+Every key below is an optional override. With `SIYUAN_URL` / `SIYUAN_TOKEN` in `.env` and `second_brain.databases.notes_root` set, the block can be omitted entirely.
 
 ```yaml
 second_brain:
   backend: siyuan
   siyuan:
-    base_url: http://127.0.0.1:6806             # local kernel
-    token: ${SIYUAN_TOKEN}                       # from .env (or VW)
-    notebook_id: 20231101120000-abc123            # default notebook for create_doc
-    deeplink_template: https://s.grid7.com/?id=  # for iPhone-clickable links
+    base_url: http://127.0.0.1:6806              # default; env SIYUAN_URL wins over this default
+    token: ${SIYUAN_TOKEN}                        # default: env SIYUAN_TOKEN
+    notebook_id: 20231101120000-abc123            # default: second_brain.databases.notes_root
+    deeplink_template: siyuan://blocks/           # default; point at a reverse proxy
+                                                  # (https://siyuan.example.com/?id=) for
+                                                  # phone-clickable links
 ```
 
 ### Notion
@@ -123,6 +147,18 @@ All three backends implement `list_recent(since, until, min_content_len, limit)`
 | SiYuan | `blocks.updated` (kernel-local clock) | second | `SUM(LENGTH(content))` over the doc's child blocks via correlated subquery - the doc row's own `content` column holds only the TITLE (verified against a live kernel: max 81 chars over 283 docs), so it cannot be used for length filtering | cleanest of the three; block timestamps reflect actual edits |
 | Obsidian | filesystem mtime of `*.md` | filesystem-dependent | file size in bytes (frontmatter and markdown syntax count toward it; multi-byte characters count per byte) | NOISIEST: a git pull, iCloud resync, or any sync tool that rewrites files produces false "activity". Treat hits as candidates, not facts |
 | Notion | `last_edited_time` via `/search`, descending scan with client-side windowing (the endpoint has no timestamp filter) | MINUTE - Notion truncates seconds, so edits at a window boundary can fall on either side | reconstructed-markdown length of the first 100 blocks; costs one extra API call per candidate page, so leave at 0 unless needed | only pages shared with the integration are visible; scan is capped at 500 pages per call |
+
+### SiYuan's SQL index is eventually consistent
+
+`search()` and `list_recent()` read SiYuan's SQL index (`SELECT ... FROM blocks`), which the kernel populates **asynchronously** after a write commits.
+
+Verified against a live kernel: immediately after `appendBlock` returned success, the new block was absent from the `blocks` table for several seconds, then appeared once the kernel flushed its transaction.
+
+This is **not a write failure** - the write persists correctly and `read_doc` on the returned id reflects it right away. Only the index lags. The consequence:
+
+> A caller that writes with `create_doc` / `append_to_doc` and then immediately reads back via `search()` or `list_recent()` will NOT see the doc it just wrote.
+
+Callers that write-then-read-back must tolerate the lag: keep the id `create_doc` returned rather than searching for the doc by title, or poll. Obsidian (direct filesystem IO) and Notion (API-backed) have no equivalent lag - a write is visible to the next read. This divergence is SiYuan-only, and it is the one place where the adapters' shared interface hides genuinely different semantics.
 
 ## `second_brain.mode` and the `secondbrain` MCP server
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,8 @@
 #   - tzdata         IANA tz DB on Debian-slim (slim base ships minimal locales)
 #   - pillow         BFL photo ingest + image preprocessing for vision extract
 #   - openai         OpenAI fallback path (TTS, occasional non-Claude calls)
+#   - mcp            official MCP Python SDK - runs the chassis-owned
+#                    `secondbrain` server (chassis/second_brain/mcp_server.py)
 
 pyyaml==6.0.2
 requests==2.32.3
@@ -28,3 +30,4 @@ python-dateutil==2.9.0.post0
 tzdata==2024.2
 pillow==11.0.0
 openai==1.54.5
+mcp==1.28.1


### PR DESCRIPTION
Stage 1 of the second-brain cutover, per the ratified plan (one chassis-owned `secondbrain` MCP server over `get_adapter()`, `second_brain.mode: direct | adapter` defaulting to `direct`, native backend MCP not registered in adapter mode). Later stages (Pacman queue to Postgres, daily-log migration, prompt rewrites) are deliberately NOT in this PR.

**Inert for existing installs.** A config with no `mode` key renders `.mcp.json` exactly as today - verified by test (`test_missing_mode_means_direct`) and by a CLI dry-run of `hydrate-mcp-json.py` against a legacy fixture config (output servers: `context7, github, memory, playwright, siyuan` - identical to main).

## What changed

- `chassis.config.yaml`: `second_brain.mode` key, documented default `direct`.
- `chassis/second_brain/factory.py`: `get_mode()` - missing key means `direct`, invalid values raise.
- `chassis/second_brain/mcp_server.py` (new): the `secondbrain` MCP server. Six tools mirroring the `NotesAdapter` protocol: `create_doc`, `append_to_doc`, `read_doc`, `search`, `list_recent`, `get_deeplink`. Resolves its backend via `get_adapter()` at startup, so identical tool names work against SiYuan, Notion, or Obsidian. **There was no MCP server precedent in this repo, so it uses the official Python MCP SDK** (`mcp==1.28.1`, added to `requirements.txt`) over stdio, as the task allows.
- `chassis/second_brain/base.py`: `list_recent(since, until, min_content_len, limit)` added to the `NotesAdapter` protocol, implemented on all three adapters (SiYuan SQL, Obsidian mtime scan, Notion `last_edited_time`). Callers are NOT migrated in this stage.
- `chassis/.mcp.json.template`: new `secondbrain` entry gated on `mode == 'adapter'`; `siyuan` and `notion` entries additionally gated on `mode != 'adapter'` so the native backend server is omitted entirely in adapter mode (tool availability is the guardrail).
- `chassis/scripts/hydrate-mcp-json.py`: `_enable_when` grammar grows `!=` and `&&`. Missing-key semantics are deliberate: `==` on a missing path is False, `!=` on a missing path is True - that is what keeps configs that predate the `mode` key on the direct path.
- `docs/second-brain-adapters.md`, `docs/mcp-setup.md`: mode semantics, the server, and the `list_recent` divergence table.
- `.github/workflows/python-tests.yml` (new): first pytest workflow in the repo (previously NO CI ran the Python suites), scoped to the second-brain paths.

## (backend, mode) matrix

| backend | direct | adapter |
|---|---|---|
| siyuan | `siyuan` server (as today) | `secondbrain` only |
| notion | `notion` server (as today) | `secondbrain` only |
| obsidian | **no second-brain MCP server - effectively invalid** | `secondbrain` only |

`(obsidian, direct)` gets no entry because no suitable Obsidian MCP server exists to register: the community options require the Obsidian desktop app plus its Local REST API plugin, which a headless container install does not run. I did not fabricate one. Obsidian installs are adapter-mode-only, stated in the template divider, `chassis.config.yaml` comments, and both docs. This matches the status quo (the template had no obsidian option before this PR either).

## `list_recent` parity, honestly

Per Sean's instruction, all three backends implement it with the closest honest approximation; divergences are in the protocol docstring and `docs/second-brain-adapters.md`:

- **SiYuan**: SQL over `blocks.updated` (second granularity, kernel-local clock). Cleanest signal.
- **Obsidian**: filesystem mtime scan. Noisier than SiYuan - a git pull or iCloud resync produces false "activity". `min_content_len` is approximated by file size in bytes.
- **Notion**: `/search` sorted by `last_edited_time` descending with client-side windowing, because the endpoint has no timestamp filter. Minute granularity (Notion truncates seconds). Only pages shared with the integration are visible. `min_content_len > 0` costs one extra API call per candidate page. Scan capped at 500 pages per call.

## Where the plan did not survive contact with the code

1. **The plan's "SiYuan: the existing SQL, verbatim" is wrong.** `daily-log-gather.py:326-336` filters doc rows with `LENGTH(content) > 200`, but `blocks.content` for `type='d'` rows holds the TITLE, not the body. Verified against Sean's live kernel: `MAX(LENGTH(content))` over all 283 `type='d'` rows is 81, so that filter can never match and the production `siyuan_activity` gather is very likely returning an empty list every night. The adapter's `list_recent` instead filters on `SUM(LENGTH(content))` over child blocks via a correlated subquery (also verified against the live kernel, read-only). The `daily-log-gather.py` fix itself is a later stage per scope; flagging it now so it does not get ported verbatim.
2. **`bootstrap-mcp-config.sh` has a pre-existing gap the plan does not mention**: it strips `_enable_when` keys without evaluating them (`chassis/scripts/bootstrap-mcp-config.sh:154`), so its sed-based render emits EVERY server regardless of backend or mode. The bootstrap path that matters (`bootstrap.sh:314` calling `hydrate-mcp-json.py`) is mode-aware after this PR; the recovery script was already backend-unaware before it. I left it untouched to keep Stage 1 inert - it should be taught to delegate to `hydrate-mcp-json.py` in the stage that makes the mode flip operational.
3. **Smoke-test rework**: the plan's Stage 1 bullet includes reworking `smoke-test.sh:209-225` per backend, but the task instructions explicitly scope it out of this PR. Task instructions win; not touched.
4. **Server path in the template**: the entry uses `${CHASSIS_ROOT:-/app/chassis}/second_brain/mcp_server.py`. `CHASSIS_ROOT` is baked into the container image (`Dockerfile:74`, chassis tree copied to `/app/chassis` at `Dockerfile:317`) and Claude Code expands `${VAR:-default}` in `.mcp.json` at load time. Host-side (non-container) layouts need the vendored path instead - stated in the entry's `_install_note`. Mild uncertainty flag: I verified the expansion syntax against Claude Code's documented `.mcp.json` env-expansion behavior, not against a live container; the e2e test drives the server by absolute path, which is layout-independent.

## Test plan

- [x] Suite before: 30 passed. Suite after: 68 passed (30 existing untouched + 38 new). `python3 -m pytest chassis/second_brain/tests/ -q`
- [x] `list_recent` unit tests on all three adapters against throwaway fixtures (temp vault with controlled mtimes for Obsidian; stubbed `_post` / `_request` transports for SiYuan and Notion - window filtering, half-open interval, ordering, `min_content_len`, limit, pagination)
- [x] `.mcp.json` render matrix: all six (backend, mode) combinations plus the missing-mode compatibility case, driven through the REAL template and REAL hydrator (`test_mcp_json_render.py`)
- [x] End-to-end: spawned `mcp_server.py` as a subprocess over stdio against a throwaway Obsidian vault, exactly as Claude Code launches it. Observed: initialize handshake returns `serverInfo.name == "secondbrain"`; `tools/list` returns exactly the six tools; `create_doc` wrote `Briefings/manual-drill.md` into the vault and returned `{id, deeplink}`; `read_doc` round-tripped the body; `append_to_doc` content visible in the next read; `search` found seeded content; `list_recent` returned the just-created doc in a 2-hour window and nothing in a future window; `get_deeplink` returned `obsidian://open?vault=...`; a malformed `since` datetime surfaced as a tool error (`isError: true`) with the server still answering afterwards (`test_mcp_server.py` runs this same drill in CI)
- [x] Legacy-config CLI dry-run: `hydrate-mcp-json.py --dry-run` with a mode-less siyuan config renders the same server set as main
- [x] MCP e2e tests skip cleanly (not fail) on an interpreter without the `mcp` package
- [x] Secret scan of the diff: clean. No em dashes in added lines. `chassis/VERSION` untouched per policy.

Stage 2 and beyond (Pacman queue to Postgres, `daily-log-gather.py` adapter branch, prompt rewrites, smoke-test backend dispatch) land as separate PRs per the staged plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
