### PR TITLE
fix(daily-log): siyuan_activity scan has always returned zero rows

### DIFF
--- a/chassis/scripts/daily-log-gather.py
+++ b/chassis/scripts/daily-log-gather.py
@@ -324,14 +324,21 @@ def gather_siyuan(url: str, token: str | None, since: datetime, until: datetime,
     activity: list[dict] = []
     since_stamp = since.strftime("%Y%m%d%H%M%S")
     until_stamp = until.strftime("%Y%m%d%H%M%S")
+    # A type='d' row's `content` holds the document TITLE, not its body, so the
+    # old `LENGTH(content) > MIN` filter could never match and this scan always
+    # returned zero rows. Document size lives in the child blocks.
+    doc_len = (
+        "(SELECT COALESCE(SUM(LENGTH(c.content)), 0) FROM blocks c "
+        "WHERE c.root_id = d.id AND c.type != 'd')"
+    )
     sql = (
-        "SELECT id, hpath, LENGTH(content) as len, updated, created "
-        "FROM blocks "
-        "WHERE type='d' "
-        f"AND updated >= '{since_stamp}' "
-        f"AND updated < '{until_stamp}' "
-        f"AND LENGTH(content) > {DEFAULT_SIYUAN_MIN_CONTENT_LEN} "
-        "ORDER BY updated DESC "
+        f"SELECT d.id, d.hpath, {doc_len} as len, d.updated, d.created "
+        "FROM blocks d "
+        "WHERE d.type='d' "
+        f"AND d.updated >= '{since_stamp}' "
+        f"AND d.updated < '{until_stamp}' "
+        f"AND {doc_len} > {DEFAULT_SIYUAN_MIN_CONTENT_LEN} "
+        "ORDER BY d.updated DESC "
         f"LIMIT {DEFAULT_SIYUAN_LIMIT}"
     )
     resp = siyuan_post(url, "/api/query/sql", token, {"stmt": sql}, verbose=verbose)


### PR DESCRIPTION
## The bug

`chassis/scripts/daily-log-gather.py:333` filtered document rows with:

```sql
WHERE type='d' AND LENGTH(content) > 200
```

A `type='d'` row's `content` column holds the document **title**, not its body. So the filter can never match.

Verified against Sean's live SiYuan kernel, read-only:

```
SELECT COUNT(*), MAX(LENGTH(content)), SUM(LENGTH(content) > 200)
FROM blocks WHERE type='d'
-> 283 docs, longest title 81 chars, docs over 200 chars: 0
```

**The nightly `siyuan_activity` gather has returned an empty list for its entire existence.** No error. No warning. The briefing faithfully reports nothing about which documents were touched, because it is handed nothing. Every install with a SiYuan backend is affected.

## The fix

Document size lives in the child blocks, not the doc row. Compute it with a correlated subquery and filter on that.

Verified against the live kernel, read-only. Where the old query returned nothing for the last two days, the fixed one returns the four docs actually touched, with sensible lengths (3.8k to 11.8k chars).

## Testing

`chassis/scripts/test-daily-log-gather.sh`: 6 passed, 0 failed.

## Scope

Deliberately minimal. This repairs the existing direct-SiYuan gather path. It does not touch the second-brain adapter migration (#55, PR #58), which replaces this code path entirely at a later stage. Fixing it now rather than waiting means Sean's, Ben's, and Toby's daily logs start working tonight instead of whenever the cutover lands.

Found by Fable while implementing `list_recent` for PR #58. Confirmed independently against the live kernel before filing.

Sean asked for this as a standalone PR, 2026-07-09.