### PR TITLE
feat(mcp): ship Gmail + Google Calendar MCP servers for headless installs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,28 @@ VAULTWARDEN_DOMAIN=http://localhost:8222
 
 # Obsidian needs no credential - set second_brain.obsidian.vault_path in
 # chassis.config.yaml instead.
+
+# --- Google (Gmail + Calendar, headless installs) ---------------------------
+# Only needed when chassis.config.yaml sets modules.google.gmail and/or
+# modules.google.calendar to true. Leave unset otherwise - the hydrator drops
+# both MCP entries when the flags are off and never looks for these.
+#
+# These are PATHS, not secrets. The secrets are the two files they point at,
+# and those files never enter git: secrets/ is gitignored. Chmod both 0600.
+#
+# gcp-oauth.keys.json is the OAuth CLIENT (type: Desktop app), downloaded from
+# the Google Cloud Console. ONE client covers both servers - do not create two.
+# A service account is not usable here: reading a mailbox with one requires
+# domain-wide delegation, which a personal Gmail account cannot grant.
+#
+# The *-token / credentials files are the CONSENTED TOKENS, produced by running
+# each server's one-time auth command. That step needs a browser, which a VPS
+# does not have - run it on your laptop and copy the tokens up. Exact procedure:
+# docs/installer-homework.md.
+#
+# Paths are as seen from INSIDE the chassis container, where the customer dir is
+# mounted at /app/customer. On a bare-metal install, use the host paths instead.
+# GMAIL_OAUTH_PATH=/app/customer/secrets/google/gcp-oauth.keys.json
+# GMAIL_CREDENTIALS_PATH=/app/customer/secrets/google/gmail-token.json
+# GOOGLE_OAUTH_CREDENTIALS=/app/customer/secrets/google/gcp-oauth.keys.json
+# GOOGLE_CALENDAR_MCP_TOKEN_PATH=/app/customer/secrets/google/calendar-token.json

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -253,7 +253,13 @@ hydrate_env() {
     log "  - Manual: prompt installer to paste each credential"
     log ""
     log "Required credentials (per docs/installer-homework.md):"
-    log "  GITHUB_PAT, GOOGLE_OAUTH_*, DISCORD_BOT_TOKEN, OPENAI_API_KEY"
+    log "  GITHUB_PAT, DISCORD_BOT_TOKEN, OPENAI_API_KEY"
+    log "  + if modules.google.gmail / .calendar are on (headless installs need this,"
+    log "    Claude's hosted Google connectors never complete over SSH):"
+    log "    GMAIL_OAUTH_PATH, GMAIL_CREDENTIALS_PATH, GOOGLE_OAUTH_CREDENTIALS,"
+    log "    GOOGLE_CALENDAR_MCP_TOKEN_PATH - paths to the OAuth client + consented"
+    log "    tokens staged under \$CUSTOMER_HOME/secrets/google/."
+    log "    Consent needs a browser: docs/installer-homework.md section 4."
     log "  + per-plugin: NOTION_API_TOKEN (if siyuan/notion=notion),"
     log "    BRAVE_API_KEY (if research enabled), STRAVA_*, OURA_TOKEN (if BFL),"
     log "    TURSO_* (if turso), etc."
@@ -270,6 +276,14 @@ hydrate_env() {
 # GITHUB_PAT=<from password manager>
 # OPENAI_API_KEY=<from password manager>
 # DISCORD_BOT_TOKEN=<from password manager>
+
+# === GOOGLE (only if modules.google.gmail / .calendar are true) ===
+# Paths, not secrets. The secrets are the files they point at - chmod 600.
+# Consent needs a browser: see docs/installer-homework.md section 4.
+# GMAIL_OAUTH_PATH=/app/customer/secrets/google/gcp-oauth.keys.json
+# GMAIL_CREDENTIALS_PATH=/app/customer/secrets/google/gmail-token.json
+# GOOGLE_OAUTH_CREDENTIALS=/app/customer/secrets/google/gcp-oauth.keys.json
+# GOOGLE_CALENDAR_MCP_TOKEN_PATH=/app/customer/secrets/google/calendar-token.json
 
 # === PER-PLUGIN (only the ones enabled in chassis.config.yaml) ===
 # NOTION_API_TOKEN=...

--- a/chassis.config.yaml
+++ b/chassis.config.yaml
@@ -213,6 +213,15 @@ modules:
     telegram_trigger_user_id: null          # Optional - telegram user_id whose 👀 fires Mode B
                                             # (queue-from-telegram-reaction). Leave null to disable Mode B.
     telegram_admin_chat_ids: null           # Optional - comma-separated chat_ids where Mode B is active
+  google:                                   # Gmail + Calendar over on-disk OAuth, for HEADLESS installs
+    gmail: false                            # Claude's hosted Google connectors need a browser and a human,
+    calendar: false                         # so they never complete over SSH. A Linux/VPS install has no
+                                            # other path to Google; a desktop install that already has the
+                                            # connectors working can leave both false.
+                                            # Both flags default false, so an install that never sets them
+                                            # renders .mcp.json exactly as it did before these keys existed.
+                                            # Pre-flight (OAuth client, scopes, headless consent):
+                                            #   docs/installer-homework.md
   dealflow: false
   health_general: false
   banking: false                            # Hard opt-in - trust line requires explicit installer decision
@@ -220,7 +229,11 @@ modules:
 
 trust_line:
   email: read_and_draft                     # Never auto-send
-  calendar: read_write
+  calendar: read_only                       # LOAD-BEARING as of the Google MCP servers: read_only registers
+                                            # google-calendar with the read tools only. Raise to read_write to
+                                            # add create/update/delete/respond. Read-only is the default because
+                                            # a mistake an agent can make on its own is one you find out about
+                                            # from someone else's calendar.
   github: collaborator                      # Agent-side account separate from installer-personal
   google_drive: read_primary_write_on_ask
   notion: read_write

--- a/chassis/.mcp.json.template
+++ b/chassis/.mcp.json.template
@@ -74,6 +74,46 @@
       }
     },
 
+    "_google-headless": {
+      "_role": "Gmail + Google Calendar for HEADLESS installs. Claude's hosted Google connectors need a browser and a human, so they never complete over SSH - a Linux/VPS install has no other path to Google. These two servers hold OAuth credentials on disk and run unattended. A desktop install that already has the hosted connectors working can leave both flags false. Setup + the one-time consent procedure: docs/installer-homework.md.",
+      "_credential_note": "Both servers share ONE Google Cloud OAuth client of type 'Desktop app' (gcp-oauth.keys.json). A service account is NOT an option for Gmail: reading a user's mailbox with one needs domain-wide delegation, which needs a Workspace admin and is impossible on a personal Gmail account. Calendar could use a service account; it deliberately does not, so the installer creates one client and follows one procedure."
+    },
+
+    "gmail": {
+      "_role": "optional - Gmail over an on-disk OAuth token. Unattended, no desktop, no hosted connector. Full API surface including attachment download, which the hosted connector does not expose (#39, #40).",
+      "_enable_when": "chassis.config.yaml.modules.google.gmail == true",
+      "_install_note": "npm @gongrzhe/server-gmail-autoauth-mcp. The server Ben's Debian install has been running in production; the only Gmail MCP we have headless evidence for. GMAIL_OAUTH_PATH is the OAuth CLIENT (gcp-oauth.keys.json, same file the calendar server reads); GMAIL_CREDENTIALS_PATH is the TOKEN this install consented to. The token is a live credential - it belongs under a gitignored secrets/ dir, 0600.",
+      "_scope_note": "Gmail scopes are fixed by the server and include send. The chassis policy that email is drafted and never auto-sent is a prompt-layer rule (trust_line.email: read_and_draft), not an OAuth-layer one. Do not read this entry as a technical guarantee that nothing can send.",
+      "command": "npx",
+      "args": ["-y", "@gongrzhe/server-gmail-autoauth-mcp"],
+      "env": {
+        "GMAIL_OAUTH_PATH": "<GMAIL_OAUTH_PATH>",
+        "GMAIL_CREDENTIALS_PATH": "<GMAIL_CREDENTIALS_PATH>"
+      }
+    },
+
+    "google-calendar": {
+      "_role": "optional - Google Calendar over an on-disk OAuth token. Ben's install has never had Calendar at all; this is the first time the chassis ships one.",
+      "_enable_when": "chassis.config.yaml.modules.google.calendar == true",
+      "_install_note": "npm @cocal/google-calendar-mcp (nspady/google-calendar-mcp). GOOGLE_OAUTH_CREDENTIALS is the same gcp-oauth.keys.json the gmail entry reads; GOOGLE_CALENDAR_MCP_TOKEN_PATH is this install's calendar token. Each server keeps its own token, so the installer consents once per server against the one shared client.",
+      "_trust_line_note": "ENABLED_TOOLS inline is the READ-ONLY toolset - the floor every install lands on. _override_when widens it to read-write ONLY when chassis.config.yaml sets trust_line.calendar: read_write. This is TOOL-GATING, not scope-gating: the server requests Google's read-write calendar scope either way, so the token on disk can always technically write. Removing the write tools removes the agent's means, not the token's power. If you need scope-level read-only, issue the token against a narrower scope by hand.",
+      "command": "npx",
+      "args": ["-y", "@cocal/google-calendar-mcp"],
+      "env": {
+        "GOOGLE_OAUTH_CREDENTIALS": "<GOOGLE_OAUTH_CREDENTIALS>",
+        "GOOGLE_CALENDAR_MCP_TOKEN_PATH": "<GOOGLE_CALENDAR_MCP_TOKEN_PATH>",
+        "ENABLED_TOOLS": "list-calendars,list-events,search-events,get-event,get-freebusy,get-current-time,list-colors"
+      },
+      "_override_when": [
+        {
+          "predicate": "chassis.config.yaml.trust_line.calendar == 'read_write'",
+          "set": {
+            "env.ENABLED_TOOLS": "list-calendars,list-events,search-events,get-event,get-freebusy,get-current-time,list-colors,create-event,update-event,delete-event,respond-to-event"
+          }
+        }
+      ]
+    },
+
     "_optional-feature-gated": {
       "_role": "Below: opt-in per chassis.config.yaml flags. Delete entries you don't enable."
     },

--- a/chassis/scripts/bootstrap-mcp-config.sh
+++ b/chassis/scripts/bootstrap-mcp-config.sh
@@ -98,6 +98,55 @@ if [[ ! -f "$TEMPLATE" ]]; then
     exit 2
 fi
 
+# ---------------------------------------------------------------------------
+# Delegate to hydrate-mcp-json.py when we can.
+#
+# The sed+jq path below cannot evaluate `_enable_when`: it strips the key and
+# registers the server anyway. That was survivable while the gated servers were
+# things like brave-search, where the worst case is a server nobody calls. It
+# stopped being survivable with the Google entries (#57), which would otherwise
+# get registered on every install that recovers through this script - including
+# installs that never enabled Google and have no OAuth token on disk.
+#
+# hydrate-mcp-json.py is the renderer bootstrap.sh already uses and the one the
+# test suite covers. Use it here too, so both paths honor one grammar. The sed
+# path stays as the fallback for the case it was written for: a broken install
+# where chassis.config.yaml is missing and .mcp.json must be reconstructed.
+# ---------------------------------------------------------------------------
+HYDRATOR="$SCRIPT_DIR/hydrate-mcp-json.py"
+CONFIG="$CUSTOMER_HOME/chassis.config.yaml"
+
+if [[ -f "$HYDRATOR" && -f "$CONFIG" ]] && command -v python3 >/dev/null 2>&1 \
+   && python3 -c 'import yaml' 2>/dev/null; then
+    hydrator_args=(--config "$CONFIG" --template "$TEMPLATE")
+    [[ -f "$ENV_FILE" ]] && hydrator_args+=(--env "$ENV_FILE")
+
+    if [[ $DRY_RUN -eq 1 ]]; then
+        python3 "$HYDRATOR" "${hydrator_args[@]}" --output "$TARGET" --dry-run
+        exit 0
+    fi
+
+    if [[ -f "$TARGET" && $FORCE -eq 0 ]]; then
+        echo "skip: $TARGET already exists; pass --force to overwrite" >&2
+        exit 0
+    fi
+
+    rc=0
+    ( umask 077; python3 "$HYDRATOR" "${hydrator_args[@]}" --output "$TARGET" ) || rc=$?
+    # Exit 2 means the file was written with <PLACEHOLDER> tokens still in it.
+    # Loud, not fatal - same contract bootstrap.sh applies.
+    if [[ $rc -eq 0 || $rc -eq 2 ]]; then
+        chmod 600 "$TARGET" 2>/dev/null || true
+        exit "$rc"
+    fi
+    echo "ERROR: hydrate-mcp-json.py exited $rc" >&2
+    exit "$rc"
+fi
+
+echo "WARN: falling back to the sed+jq renderer (no chassis.config.yaml, or no" >&2
+echo "      python3+PyYAML). It cannot evaluate _enable_when, so feature-gated" >&2
+echo "      servers are registered unconditionally. Review $TARGET before use." >&2
+
 if [[ -f "$TARGET" && $FORCE -eq 0 && $DRY_RUN -eq 0 ]]; then
     echo "skip: $TARGET already exists; pass --force to overwrite" >&2
     exit 0
@@ -147,11 +196,18 @@ done
 # template so the file is self-documenting). Only substitute the exact tokens.
 OUTPUT=$(printf '%s' "$OUTPUT" | sed -e "s|\${CHASSIS_HOME}|$CHASSIS_HOME|g" -e "s|\${CUSTOMER_HOME}|$CUSTOMER_HOME|g")
 
-# Drop the `_README` key from the top-level object and any `_role` / `_enable_when`
-# / `_install_note` keys from servers. They're documentation, not config — jq
-# treats them as noise.
+# Strip template-only metadata: the top-level `_README`, every `_*` key inside a
+# server entry, and the `_*` divider entries that are section headers rather than
+# servers. Match on the underscore prefix, not on a hand-maintained list of names -
+# the old `del(._role) | del(._enable_when) | del(._install_note)` form silently
+# leaked every key nobody remembered to add to it.
 if command -v jq >/dev/null 2>&1; then
-    OUTPUT=$(printf '%s' "$OUTPUT" | jq 'del(._README) | .mcpServers |= with_entries(.value |= (del(._role) | del(._enable_when) | del(._install_note)))')
+    OUTPUT=$(printf '%s' "$OUTPUT" | jq '
+        del(._README)
+        | .mcpServers |= (
+            with_entries(select(.key | startswith("_") | not))
+            | map_values(with_entries(select(.key | startswith("_") | not)))
+        )')
 fi
 
 # Validate the result is parseable JSON before writing.

--- a/chassis/scripts/hydrate-mcp-json.py
+++ b/chassis/scripts/hydrate-mcp-json.py
@@ -11,6 +11,8 @@ Algorithm:
    - Skip entries whose key starts with '_' (template-only dividers).
    - If entry has `_enable_when`, evaluate the predicate against the config;
      drop the entry if false.
+   - If entry has `_override_when`, apply each clause whose predicate holds,
+     rewriting individual keys inside the kept entry (see apply_overrides).
    - Strip all keys starting with '_' from the kept entry.
    - Substitute <PLACEHOLDER> tokens in string values from .env (or env vars).
      Tokens whose substitution value is missing are LEFT IN PLACE - bootstrap
@@ -169,6 +171,58 @@ def evaluate_enable_when(predicate, config):
     return all(evaluate_clause(clause, config) for clause in clauses)
 
 
+def apply_overrides(entry, config):
+    """Apply an entry's `_override_when` clauses against the config.
+
+    `_enable_when` decides whether a server is registered at all. It cannot
+    vary a value *inside* a registered server, which is what a capability tier
+    needs: one `google-calendar` server whose exposed toolset widens when the
+    installer raises `trust_line.calendar` to `read_write`. Splitting that into
+    two differently-named servers would change the MCP tool prefix and break
+    every prompt written against the read-only one, so the value moves instead
+    of the server.
+
+    Shape:
+
+        "_override_when": [
+          {
+            "predicate": "chassis.config.yaml.trust_line.calendar == 'read_write'",
+            "set": {"env.ENABLED_TOOLS": "list-events,create-event,..."}
+          }
+        ]
+
+    `set` keys are dotted paths *within the entry*. Clauses apply in order, so
+    a later clause wins over an earlier one. A clause whose predicate is false,
+    unparsable, or whose config path is missing is skipped - the entry keeps
+    the value it declares inline, which is why the template's inline value must
+    always be the safe floor (read-only), never the privileged tier.
+    """
+    clauses = entry.get('_override_when')
+    if not isinstance(clauses, list):
+        return entry
+    out = json.loads(json.dumps(entry))  # deep copy - never mutate the template
+    for clause in clauses:
+        if not isinstance(clause, dict):
+            continue
+        predicate = clause.get('predicate')
+        assignments = clause.get('set')
+        if not isinstance(predicate, str) or not isinstance(assignments, dict):
+            continue
+        if not evaluate_enable_when(predicate, config):
+            continue
+        for dotted, value in assignments.items():
+            segments = dotted.split('.')
+            cur = out
+            for segment in segments[:-1]:
+                nxt = cur.get(segment)
+                if not isinstance(nxt, dict):
+                    nxt = {}
+                    cur[segment] = nxt
+                cur = nxt
+            cur[segments[-1]] = value
+    return out
+
+
 _PLACEHOLDER_PAT = re.compile(r'<([A-Z_][A-Z0-9_]*)>')
 
 
@@ -211,7 +265,8 @@ def hydrate(config, template, env):
         if predicate is not None:
             if not evaluate_enable_when(predicate, config):
                 continue
-        stripped = strip_meta_keys(entry)
+        overridden = apply_overrides(entry, config)
+        stripped = strip_meta_keys(overridden)
         substituted = substitute_placeholders(stripped, env, unresolved)
         out[name] = substituted
     return {'mcpServers': out}, unresolved

--- a/chassis/second_brain/tests/test_mcp_json_render.py
+++ b/chassis/second_brain/tests/test_mcp_json_render.py
@@ -102,6 +102,148 @@ class McpJsonRenderMatrixTest(unittest.TestCase):
         self.assertFalse([k for k in entry if k.startswith("_")])
 
 
+CALENDAR_WRITE_TOOLS = {"create-event", "update-event", "delete-event", "respond-to-event"}
+
+
+def _render_config(config: dict) -> dict:
+    template = hydrator.load_json(str(TEMPLATE_PATH))
+    hydrated, _unresolved = hydrator.hydrate(config, template, env={})
+    return hydrated["mcpServers"]
+
+
+def _calendar_tools(servers: dict) -> set[str]:
+    return set(servers["google-calendar"]["env"]["ENABLED_TOOLS"].split(","))
+
+
+class GoogleMcpRenderTest(unittest.TestCase):
+    """Gmail + Calendar MCP servers (issue #57).
+
+    The load-bearing case is the FIRST one: an existing install whose config
+    predates modules.google must render byte-identically to before. Everything
+    else here is downstream of that.
+    """
+
+    def test_config_without_google_keys_renders_no_google_servers(self) -> None:
+        for config in (
+            {},
+            {"second_brain": {"backend": "siyuan"}},
+            {"modules": {"admin": True}},  # modules exists, google does not
+        ):
+            servers = _render_config(config)
+            self.assertNotIn("gmail", servers)
+            self.assertNotIn("google-calendar", servers)
+
+    def test_existing_install_server_set_is_unchanged(self) -> None:
+        # The exact server set a pre-#57 config rendered. If adding a Google
+        # entry ever leaks into an install that did not ask for it, this fails.
+        servers = _render_config({"second_brain": {"backend": "siyuan"}})
+        self.assertEqual(
+            set(servers), {"memory", "playwright", "context7", "github", "siyuan"}
+        )
+
+    def test_gmail_registers_when_flag_set(self) -> None:
+        servers = _render_config({"modules": {"google": {"gmail": True}}})
+        entry = servers["gmail"]
+        self.assertEqual(entry["command"], "npx")
+        self.assertIn("@gongrzhe/server-gmail-autoauth-mcp", entry["args"])
+        self.assertEqual(
+            set(entry["env"]), {"GMAIL_OAUTH_PATH", "GMAIL_CREDENTIALS_PATH"}
+        )
+        self.assertFalse([k for k in entry if k.startswith("_")])
+        # Enabling Gmail must not drag Calendar in with it.
+        self.assertNotIn("google-calendar", servers)
+
+    def test_calendar_defaults_to_read_only_when_trust_line_absent(self) -> None:
+        # A config that enables Calendar but never mentions trust_line lands on
+        # the read floor. `==` on a missing path is False, so the override skips.
+        servers = _render_config({"modules": {"google": {"calendar": True}}})
+        tools = _calendar_tools(servers)
+        self.assertIn("list-events", tools)
+        self.assertEqual(tools & CALENDAR_WRITE_TOOLS, set())
+
+    def test_calendar_read_only_trust_line_withholds_write_tools(self) -> None:
+        servers = _render_config(
+            {
+                "modules": {"google": {"calendar": True}},
+                "trust_line": {"calendar": "read_only"},
+            }
+        )
+        self.assertEqual(_calendar_tools(servers) & CALENDAR_WRITE_TOOLS, set())
+
+    def test_calendar_read_write_trust_line_grants_write_tools(self) -> None:
+        servers = _render_config(
+            {
+                "modules": {"google": {"calendar": True}},
+                "trust_line": {"calendar": "read_write"},
+            }
+        )
+        tools = _calendar_tools(servers)
+        self.assertEqual(tools & CALENDAR_WRITE_TOOLS, CALENDAR_WRITE_TOOLS)
+        self.assertIn("list-events", tools)  # widened, not swapped
+
+    def test_calendar_entry_shape(self) -> None:
+        entry = _render_config({"modules": {"google": {"calendar": True}}})[
+            "google-calendar"
+        ]
+        self.assertIn("@cocal/google-calendar-mcp", entry["args"])
+        # _override_when and friends are template-only and must not ship.
+        self.assertFalse([k for k in entry if k.startswith("_")])
+
+    def test_shipped_config_defaults_calendar_to_read_only(self) -> None:
+        # Guards the chassis.config.yaml default itself: if someone raises
+        # trust_line.calendar back to read_write, every install that turns
+        # Calendar on silently gets delete-event. Make that a failing test,
+        # not a surprise.
+        import yaml  # noqa: PLC0415 - test-only dependency
+
+        with open(REPO_ROOT / "chassis.config.yaml") as f:
+            shipped = yaml.safe_load(f)
+        self.assertEqual(shipped["trust_line"]["calendar"], "read_only")
+        self.assertIs(shipped["modules"]["google"]["gmail"], False)
+        self.assertIs(shipped["modules"]["google"]["calendar"], False)
+
+
+class OverrideWhenTest(unittest.TestCase):
+    ENTRY = {
+        "_enable_when": "chassis.config.yaml.modules.x == true",
+        "env": {"TOOLS": "read"},
+        "_override_when": [
+            {
+                "predicate": "chassis.config.yaml.trust_line.x == 'read_write'",
+                "set": {"env.TOOLS": "read,write"},
+            }
+        ],
+    }
+
+    def test_override_applies_when_predicate_holds(self) -> None:
+        out = hydrator.apply_overrides(self.ENTRY, {"trust_line": {"x": "read_write"}})
+        self.assertEqual(out["env"]["TOOLS"], "read,write")
+
+    def test_override_skipped_when_predicate_fails(self) -> None:
+        out = hydrator.apply_overrides(self.ENTRY, {"trust_line": {"x": "read_only"}})
+        self.assertEqual(out["env"]["TOOLS"], "read")
+
+    def test_override_skipped_on_missing_config_path(self) -> None:
+        out = hydrator.apply_overrides(self.ENTRY, {})
+        self.assertEqual(out["env"]["TOOLS"], "read")
+
+    def test_template_entry_is_not_mutated(self) -> None:
+        # apply_overrides deep-copies. A shared template dict must survive being
+        # rendered against a permissive config and then a restrictive one.
+        hydrator.apply_overrides(self.ENTRY, {"trust_line": {"x": "read_write"}})
+        self.assertEqual(self.ENTRY["env"]["TOOLS"], "read")
+
+    def test_entry_without_override_when_is_returned_unchanged(self) -> None:
+        entry = {"command": "npx"}
+        self.assertEqual(hydrator.apply_overrides(entry, {}), entry)
+
+    def test_malformed_clauses_are_ignored(self) -> None:
+        for clauses in ("not-a-list", ["not-a-dict"], [{"predicate": "x == 'y'"}], [{}]):
+            entry = {"env": {"TOOLS": "read"}, "_override_when": clauses}
+            out = hydrator.apply_overrides(entry, {"trust_line": {"x": "read_write"}})
+            self.assertEqual(out["env"]["TOOLS"], "read")
+
+
 class EnableWhenEvaluatorTest(unittest.TestCase):
     CONFIG = {"second_brain": {"backend": "siyuan", "mode": "adapter"}}
 

--- a/docs/installer-homework.md
+++ b/docs/installer-homework.md
@@ -1,0 +1,235 @@
+# Installer homework
+
+> Audience: the human installing a chassis instance, before `bootstrap.sh` runs.
+> Companion to `docs/hydration.md` (what bootstrap does with what you stage here)
+> and `docs/mcp-setup.md` (per-MCP wiring).
+
+Everything here is work `bootstrap.sh` deliberately does NOT do, because it needs
+a human with a browser, a credit card, or an account you own. Do it before install
+day and the install is 30-45 minutes. Do it during, and it is an afternoon.
+
+---
+
+## 1. Machine
+
+- A Linux box (Ubuntu 22.04+ recommended) or a Mac. 8GB RAM is the realistic floor.
+- Docker + Docker Compose installed and working as your user, not just as root.
+- Tailscale installed, node joined, shared with whoever is helping you install.
+- SSH key handoff done, if someone else is driving the install.
+
+## 2. Agent-side accounts
+
+The chassis runs as an agent that is NOT you. That separation is the whole security
+model: when you fire the agent, you revoke its accounts, not yours.
+
+Provision a separate account for each surface you plan to enable - GitHub, Google,
+Discord, and your second brain (Notion or SiYuan). Do not hand the chassis your
+personal credentials.
+
+## 3. Credentials to stage
+
+Stage these in Vaultwarden (or the password manager of your choice) before install.
+The item names below are matched as exact strings by
+`chassis/scripts/hydrate-env-from-vw.sh` - a single typo is a silent hydration
+failure, so copy them literally.
+
+| Vaultwarden item | Needed when |
+|---|---|
+| `Behalf.bot - GitHub PAT` | Always. Scopes: `repo`, `workflow`, `read:org`. |
+| `Behalf.bot - chassis OpenAI key` | Always. |
+| `Behalf.bot - Postgres password` | Always. `openssl rand -base64 32`. |
+| `Behalf.bot - Vaultwarden API token` | Always. |
+| `Behalf.bot - Google OAuth client` | Gmail or Calendar. See section 4. |
+| `Behalf.bot - Notion integration token` | Second brain = Notion. |
+| `Behalf.bot - Telegram bot token` | Telegram surface. |
+| `Behalf.bot - Slack bot token` | Slack surface. |
+| `Behalf.bot - Tailscale auth key` | Headless / unattended Tailscale join. |
+
+The Discord bot token is wired through Claude Code's plugin layer, not `.env` -
+run `claude /discord:configure` after install.
+
+---
+
+## 4. Google: Gmail and Calendar
+
+**Read this section in full before you start clicking. The consent step is where
+every installer gets stuck, and the fix is to know about it in advance.**
+
+### Do you need this at all?
+
+Only if `chassis.config.yaml` sets `modules.google.gmail` or
+`modules.google.calendar` to `true`.
+
+| Your install | What to do |
+|---|---|
+| **Headless** (Linux box, VPS, anything you only reach over SSH) | You need this. It is the only path by which Google ever works on your box. |
+| **Desktop** (a Mac you sit in front of) | Optional. Claude's hosted Google connectors are easier - click through them instead. Come back here only if you want Gmail attachment downloads, which the hosted connector cannot do. |
+
+Claude's hosted connectors need a browser and a human at the keyboard. They do not
+complete over SSH. That is the entire reason these two MCP servers exist.
+
+### Why not a service account?
+
+Because it cannot read Gmail. A Google service account reads a normal user's mailbox
+only with **domain-wide delegation**, which requires a Google Workspace admin and is
+flatly impossible on a personal `@gmail.com` account. Calendar alone would work with
+one, but then you would run two different credential mechanisms for two Google
+services. You create one OAuth client instead, and consent once per server.
+
+### 4a. In the Google Cloud Console (browser, any machine)
+
+1. Create a project, or pick an existing one.
+2. **APIs & Services > Library**: enable **Gmail API** and **Google Calendar API**.
+   Enable only the one you actually plan to turn on if you are only doing one.
+3. **APIs & Services > OAuth consent screen**:
+   - User type **External** is correct for a personal Gmail account.
+   - Add the agent's Google address as a **Test user**. This is not optional. Consent
+     will refuse to proceed until it propagates, which takes a few minutes.
+4. **APIs & Services > Credentials > Create Credentials > OAuth client ID**:
+   - Application type: **Desktop app**. Not "Web application" - Desktop gets you a
+     loopback redirect, which is what makes the consent step below work.
+   - Download the JSON. Rename it `gcp-oauth.keys.json`.
+
+That one file is the OAuth **client**. Both servers read it. Do not create two.
+
+### 4b. Scopes
+
+You do not type these in anywhere - each MCP server requests its own. Listed so you
+know what you are consenting to when the screen appears:
+
+- Gmail: full mailbox access, **including send**. The server exposes `send_email`.
+  The chassis policy that email is drafted and never auto-sent (`trust_line.email:
+  read_and_draft`) is a rule in the agent's prompt, not a limit on the token. If
+  that distinction matters to you, use a dedicated agent-side Gmail account.
+- Calendar: read-write. `trust_line.calendar` controls which calendar *tools* the
+  agent is handed, not which scope the token holds - see section 4d.
+
+### 4c. Consent, on a headless box
+
+The consent flow opens a browser and redirects to `localhost`. Your VPS has neither.
+Two ways out. **The first one is the recommended path.**
+
+#### Path A - consent on your laptop, copy the tokens up (recommended)
+
+Run the auth flow where a browser already exists, then move the resulting token files
+to the server. The tokens are portable; nothing in them is machine-specific.
+
+On your **laptop**, with `gcp-oauth.keys.json` in the current directory:
+
+```bash
+mkdir -p ~/bb-google && cd ~/bb-google
+# put gcp-oauth.keys.json here first
+
+# Gmail. Writes the token to GMAIL_CREDENTIALS_PATH.
+GMAIL_OAUTH_PATH="$PWD/gcp-oauth.keys.json" \
+GMAIL_CREDENTIALS_PATH="$PWD/gmail-token.json" \
+  npx @gongrzhe/server-gmail-autoauth-mcp auth
+
+# Calendar. Writes the token to GOOGLE_CALENDAR_MCP_TOKEN_PATH.
+GOOGLE_OAUTH_CREDENTIALS="$PWD/gcp-oauth.keys.json" \
+GOOGLE_CALENDAR_MCP_TOKEN_PATH="$PWD/calendar-token.json" \
+  npx @cocal/google-calendar-mcp auth
+```
+
+Each command opens your browser. Sign in **as the agent's Google account**, not your
+personal one, and accept. You consent twice - once per server - against the one client.
+
+Then copy all three files to the server and lock them down:
+
+```bash
+ssh you@your-box 'mkdir -p ~/.behalfbot/secrets/google'
+scp gcp-oauth.keys.json gmail-token.json calendar-token.json \
+    you@your-box:~/.behalfbot/secrets/google/
+ssh you@your-box 'chmod 600 ~/.behalfbot/secrets/google/*'
+```
+
+`secrets/` is gitignored. These files are live credentials - treat the two token
+files exactly like passwords, because that is what they are.
+
+#### Path B - SSH tunnel, consent stays on the server
+
+If you would rather the tokens never touch your laptop. Both servers redirect to a
+loopback port; forward that port from your laptop and the browser round-trip closes
+through the tunnel.
+
+Run the auth command on the server first and **read the port off the URL it prints**
+(the Gmail server uses `3000`; do not assume the Calendar server matches). Then, from
+your laptop:
+
+```bash
+ssh -L 3000:localhost:3000 you@your-box   # swap 3000 for the port it printed
+```
+
+Re-run the auth command inside that SSH session, and open the printed URL in your
+laptop's browser. The redirect lands back on the server through the tunnel.
+
+Path B is fiddlier and the port is the part people get wrong. If it fights you, use
+Path A.
+
+### 4d. Read-only by default
+
+`trust_line.calendar` in `chassis.config.yaml`:
+
+| Value | Calendar tools the agent gets |
+|---|---|
+| `read_only` (default) | `list-calendars`, `list-events`, `search-events`, `get-event`, `get-freebusy`, `get-current-time`, `list-colors` |
+| `read_write` | the above, plus `create-event`, `update-event`, `delete-event`, `respond-to-event` |
+
+Raise it to `read_write` only when you actually want the agent booking things. An
+agent that cannot write a calendar cannot double-book you in front of a client.
+
+Two honest caveats:
+
+- This is **tool-gating, not scope-gating**. The token on disk holds a read-write
+  scope either way. Withholding the write tools removes the agent's means, not the
+  token's power. For a scope-level guarantee, mint the token by hand against a
+  read-only scope.
+- The `manage-accounts` tool is exposed regardless of this setting - the calendar
+  server always ships it, because it is how re-authentication happens. It manages
+  which Google accounts are connected. It cannot touch an event.
+
+Gmail has no equivalent tool filter. It is all-or-nothing: `modules.google.gmail:
+true` hands the agent the full mailbox surface, send included.
+
+### 4e. Wire it up
+
+`chassis.config.yaml`:
+
+```yaml
+modules:
+  google:
+    gmail: true
+    calendar: true
+trust_line:
+  calendar: read_only
+```
+
+`$CUSTOMER_HOME/.env` - paths as seen from **inside** the container, where the
+customer dir is mounted at `/app/customer`:
+
+```
+GMAIL_OAUTH_PATH=/app/customer/secrets/google/gcp-oauth.keys.json
+GMAIL_CREDENTIALS_PATH=/app/customer/secrets/google/gmail-token.json
+GOOGLE_OAUTH_CREDENTIALS=/app/customer/secrets/google/gcp-oauth.keys.json
+GOOGLE_CALENDAR_MCP_TOKEN_PATH=/app/customer/secrets/google/calendar-token.json
+```
+
+Both servers read the same `gcp-oauth.keys.json`. Each keeps its own token.
+
+### 4f. Test-mode tokens expire in 7 days
+
+While your OAuth consent screen is in **Testing**, Google expires refresh tokens after
+one week and Google will not tell you - the agent just quietly stops seeing your mail.
+
+Fix it once, properly: **OAuth consent screen > Publish app**. You do not need Google
+verification for this; an unverified app still works for accounts you listed as test
+users, and publishing stops the 7-day clock. If you leave it in Testing, expect to
+re-run the auth commands from 4c every week.
+
+---
+
+## Cross-references
+
+- `docs/hydration.md` - what bootstrap does with what you staged
+- `docs/mcp-setup.md` - per-MCP wiring, including the two Google servers
+- `docs/security.md` - the guardrail model these credentials sit behind

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -32,6 +32,7 @@ Once the file lands, restart Claude Code so it re-reads. The manual hydration wa
 | **Always-on** (no auth) | `memory`, `playwright`, `context7` | Every install. Keep. |
 | **Always-on with config** | `github` | Every install touches GitHub. Provision agent-side PAT. |
 | **Pick one** (second-brain) | `siyuan` OR `notion` OR `secondbrain` | Per `chassis.config.yaml.second_brain.backend` + `second_brain.mode`. Mode `direct` (default): the backend's native server. Mode `adapter`: the chassis-owned `secondbrain` server INSTEAD, and the native server is not registered. Obsidian has no native server - obsidian installs need `mode: adapter` for any second-brain MCP surface. |
+| **Google** (headless installs) | `gmail`, `google-calendar` | Per `chassis.config.yaml.modules.google.*`. Both default off. The only path to Google on a box you reach over SSH - Claude's hosted connectors need a browser and never complete remotely. |
 | **Optional, opt-in** | `brave-search`, `tavily`, `turso`, `amplitude`, `n8n`, `loom`, `remarkable`, `oura`, `frame0` | Per `chassis.config.yaml.modules.*` flags. Delete entries you don't activate. |
 
 ---
@@ -95,6 +96,42 @@ If you're running Notion (cloud, page+block model):
 3. Copy the Internal Integration Token. Save labeled `<INSTANCE>-notion-token`.
 4. Share the relevant pages/databases with the integration (pages won't be visible to the integration until shared).
 5. Hydrate into `.mcp.json`.
+
+---
+
+## Google MCPs (gmail, google-calendar)
+
+Off by default. Turn them on with `modules.google.gmail` / `modules.google.calendar`
+in `chassis.config.yaml`.
+
+**Who needs them:** every headless install. Claude's hosted Google connectors need a
+browser and a human at the keyboard, so they do not complete over SSH - on a Linux box
+or VPS there is no other way to reach Google. A desktop install that already has the
+hosted connectors working can leave both flags false, unless it wants Gmail attachment
+downloads, which the hosted connector does not expose (#39, #40).
+
+**Packages:**
+
+| Server | Package | Notes |
+|---|---|---|
+| `gmail` | [`@gongrzhe/server-gmail-autoauth-mcp`](https://github.com/gongrzhe/server-gmail-autoauth-mcp) | The server the first headless install has been running in production. Exposes `download_attachment`. |
+| `google-calendar` | [`@cocal/google-calendar-mcp`](https://github.com/nspady/google-calendar-mcp) | Supports `ENABLED_TOOLS` filtering, which is how `trust_line.calendar` is enforced. |
+
+**Credentials:** both read ONE OAuth client of type *Desktop app*
+(`gcp-oauth.keys.json`), and each keeps its own consented token. A service account is
+not an option: reading a mailbox with one needs domain-wide delegation, which needs a
+Workspace admin and cannot be granted on a personal Gmail account.
+
+**The consent step needs a browser, and your server does not have one.** Run the auth
+flow on your laptop and copy the token files up. Full procedure, plus the Google Cloud
+Console setup and the 7-day test-mode token expiry that bites everyone:
+[`docs/installer-homework.md`](installer-homework.md) section 4.
+
+**Calendar write access** is gated on `trust_line.calendar`. `read_only` (the default)
+registers the server with read tools only; `read_write` adds `create-event`,
+`update-event`, `delete-event`, `respond-to-event`. This is tool-gating, not
+scope-gating - the token holds a read-write scope either way. Gmail has no equivalent
+filter and is all-or-nothing, send included.
 
 ---
 


### PR DESCRIPTION
Closes #39, closes #40. Implements #57.

## What changed

Claude's hosted Google connectors need a browser and a human at the keyboard. They do not complete over SSH, so on every customer VPS there has been no path by which Google ever works. `bootstrap.sh` even told installers to have `GOOGLE_OAUTH_*` ready, and nothing read it.

Two MCP servers that hold OAuth credentials on disk and run unattended, both gated on config and both default off:

| Server | Package | Gate |
|---|---|---|
| `gmail` | [`@gongrzhe/server-gmail-autoauth-mcp`](https://github.com/gongrzhe/server-gmail-autoauth-mcp) | `modules.google.gmail` |
| `google-calendar` | [`@cocal/google-calendar-mcp`](https://github.com/nspady/google-calendar-mcp) | `modules.google.calendar` |

## Which servers, and why

Both are existing, maintained packages. Neither is written here.

**Gmail:** `@gongrzhe/server-gmail-autoauth-mcp` (v1.1.11). This is the server the first headless install has been running in production, so it is the only Gmail MCP we have headless evidence for, and its `GMAIL_OAUTH_PATH` / `GMAIL_CREDENTIALS_PATH` contract is what that box already proves out. It advertises `download_attachment`, which is the exact capability #39 and #40 were filed for and which the hosted connector does not expose. `@shinzolabs/gmail-mcp` was the alternative named in #39; it is a reasonable package, but there was no reason to prefer an unproven one over the one already surviving contact with a real install.

**Calendar:** `@cocal/google-calendar-mcp` (v2.6.2, published last month). The chassis has never shipped a Calendar server at all. This one was chosen over the alternatives specifically because it supports `ENABLED_TOOLS` filtering, which is the mechanism that makes `trust_line.calendar` enforceable. Without tool filtering there is no way to hand the agent a read-only calendar short of writing our own server.

## The headless consent problem

This is the actual hard part, and it is solved in docs, not code - it cannot be solved in code, because it needs a human and a browser.

The OAuth consent flow redirects to `localhost`. A VPS has no browser and no localhost worth redirecting to. `docs/installer-homework.md` section 4 spells out both ways through, for a non-expert:

- **Path A (recommended):** run each server's one-time `auth` command on the installer's laptop, with the env vars set so the token files land at known paths, then `scp` the three files up to `$CUSTOMER_HOME/secrets/google/` and `chmod 600`. The tokens are portable and nothing in them is machine-specific.
- **Path B:** `ssh -L` port-forward, consent stays on the server, tokens never touch the laptop. Fiddlier - the port is the part people get wrong, so the doc says to read it off the printed URL rather than assume.

The doc also covers the trap that will otherwise eat an installer's week: **while the OAuth consent screen is in Testing, Google silently expires refresh tokens after 7 days.** Fix is one click (Publish app), no Google verification needed.

## One OAuth client, not a service account

A service account works for Calendar and Drive. It **does not work for Gmail** - reading a normal user's mailbox with one requires domain-wide delegation, which requires a Workspace admin and is impossible on a personal `@gmail.com` account.

So Gmail must use an installed-app OAuth client. Calendar could have used a service account, and deliberately does not: running two credential mechanisms for two Google services means two procedures for the installer to get wrong. One "Desktop app" OAuth client (`gcp-oauth.keys.json`), read by both servers, consented once per server.

## trust_line.calendar is now load-bearing

Nothing in the repo consumed `trust_line` before this PR - it was config that described an intention. `trust_line.calendar` now actually drives what the agent can do:

| Value | Calendar tools |
|---|---|
| `read_only` (new default) | list-calendars, list-events, search-events, get-event, get-freebusy, get-current-time, list-colors |
| `read_write` | the above, plus create-event, update-event, delete-event, respond-to-event |

**This changes a shipped default:** `trust_line.calendar` was `read_write`. Leaving it there would have meant "read-only by default" was false the moment anyone turned Calendar on. Flagging it explicitly because it is a policy change, not just a code change.

Two caveats stated plainly in the template, the config, and the docs, because they would otherwise be mistaken for guarantees:

- **This is tool-gating, not scope-gating.** The server requests a read-write calendar scope either way. Withholding the write tools removes the agent's means, not the token's power.
- **Gmail has no equivalent filter.** It is all-or-nothing, `send_email` included. The chassis rule that email is drafted and never auto-sent is a prompt-layer rule, not an OAuth-layer one.

## Two things the spec did not anticipate

**1. The hydrator needed a new primitive.** `_enable_when` gates a whole server. It cannot vary a value *inside* one, which is exactly what a capability tier is. The obvious workaround - two differently-named calendar servers - changes the MCP tool prefix, so every prompt written against `google-calendar` breaks the day someone opts into read-write. So the value moves instead of the server: `_override_when` is a list of `{predicate, set}` clauses reusing the existing predicate evaluator, applied to keys within a kept entry. The template's inline value is always the safe floor.

**2. `bootstrap-mcp-config.sh` would have shipped this as a footgun.** `bootstrap.sh` renders `.mcp.json` with `hydrate-mcp-json.py`, but `bootstrap-mcp-config.sh` - the recovery path, used when `.mcp.json` goes missing after a clone or cutover - is a sed+jq renderer that **strips `_enable_when` and registers the server anyway**. On that path both Google servers would have landed on installs that never enabled them, pointing at OAuth tokens that do not exist.

It now delegates to `hydrate-mcp-json.py` when `chassis.config.yaml` and python3+PyYAML are present, falling back to sed+jq (loudly) only in the broken-install case it was written for. Its jq filter also now strips meta keys by underscore prefix instead of by a hand-maintained list of three names, which had already fallen behind the template - `_env_note` and the `_*` divider entries were leaking into rendered `.mcp.json` files today.

## Verification

- **Existing installs cannot break.** Rendered `.mcp.json` with the pre-change renderer and the post-change renderer, for both an empty config and the shipped `chassis.config.yaml`. `diff` is empty in both cases - byte-identical. Locked in as a test (`test_existing_install_server_set_is_unchanged`) asserting the exact pre-#57 server set.
- **Both servers actually launch.** Started each over stdio and drove a real MCP `initialize` + `tools/list` handshake:
  - `gmail` advertises 19 tools including `download_attachment`.
  - `google-calendar` under the read-only `ENABLED_TOOLS` list advertises **zero** write tools; under the read-write list it advertises all four. The server refuses to start on an invalid tool name, so this also proves the tool names in the template are correct rather than plausible.
- **Recovery path.** Exercised `bootstrap-mcp-config.sh` in a scratch install tree: delegation with no Google keys renders the same 5 servers as before; delegation with Google on renders both with the read-only toolset; the fallback path leaks zero meta keys and zero divider entries.
- 101 tests pass (`pytest chassis/second_brain/tests/`), `shellcheck` clean on both shell files, `chassis/VERSION` untouched.

## Not verified

**Nobody has completed a real Google OAuth consent against these servers yet.** The credential paths, env var names, tool surfaces, and tool-filtering behavior are all confirmed against the running servers with a syntactically valid but fake OAuth client. The consent flow itself, and the resulting token actually fetching mail or events, needs a real Google Cloud project - which needs an installer. The homework doc is written to be followed cold; the first person to follow it will find out whether it is right.