### PR TITLE
feat(mcp): ship a Google Sheets MCP server for headless installs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,22 +73,22 @@ VAULTWARDEN_DOMAIN=http://localhost:8222
 # Obsidian needs no credential - set second_brain.obsidian.vault_path in
 # chassis.config.yaml instead.
 
-# --- Google (Gmail + Calendar, headless installs) ---------------------------
-# Only needed when chassis.config.yaml sets modules.google.gmail and/or
-# modules.google.calendar to true. Leave unset otherwise - the hydrator drops
-# both MCP entries when the flags are off and never looks for these.
+# --- Google (Gmail + Calendar + Sheets, headless installs) ------------------
+# Only needed when chassis.config.yaml sets modules.google.gmail, .calendar
+# and/or .sheets to true. Leave unset otherwise - the hydrator drops the MCP
+# entries when the flags are off and never looks for these.
 #
-# These are PATHS, not secrets. The secrets are the two files they point at,
-# and those files never enter git: secrets/ is gitignored. Chmod both 0600.
+# These are PATHS, not secrets. The secrets are the files they point at,
+# and those files never enter git: secrets/ is gitignored. Chmod them 0600.
 #
 # gcp-oauth.keys.json is the OAuth CLIENT (type: Desktop app), downloaded from
-# the Google Cloud Console. ONE client covers both servers - do not create two.
-# A service account is not usable here: reading a mailbox with one requires
-# domain-wide delegation, which a personal Gmail account cannot grant.
+# the Google Cloud Console. ONE client covers all three servers - do not create
+# three. A service account is not usable here: reading a mailbox with one
+# requires domain-wide delegation, which a personal Gmail account cannot grant.
 #
-# The *-token / credentials files are the CONSENTED TOKENS, produced by running
-# each server's one-time auth command. That step needs a browser, which a VPS
-# does not have - run it on your laptop and copy the tokens up. Exact procedure:
+# The *-token files are the CONSENTED TOKENS, produced by running each server's
+# one-time auth step. That step needs a browser, which a VPS does not have - run
+# it on your laptop and copy the tokens up. Exact procedure:
 # docs/installer-homework.md.
 #
 # Paths are as seen from INSIDE the chassis container, where the customer dir is
@@ -97,3 +97,14 @@ VAULTWARDEN_DOMAIN=http://localhost:8222
 # GMAIL_CREDENTIALS_PATH=/app/customer/secrets/google/gmail-token.json
 # GOOGLE_OAUTH_CREDENTIALS=/app/customer/secrets/google/gcp-oauth.keys.json
 # GOOGLE_CALENDAR_MCP_TOKEN_PATH=/app/customer/secrets/google/calendar-token.json
+#
+# Sheets. GOOGLE_SHEETS_TOKEN_PATH is this install's sheets token - the server
+# reads it as GOOGLE_OAUTH_TOKENS, but it is named for Sheets here because it is
+# NOT shared with the other two servers, and a generic name invites that mistake.
+# GOOGLE_SHEETS_TOKEN_PATH=/app/customer/secrets/google/sheets-token.json
+#
+# GOOGLE_SHEETS_ALLOWLIST is only read when trust_line.sheets is read_write. It
+# names, by spreadsheet id, the sheets the agent may WRITE. Without it the server
+# refuses every write. It is not itself a credential, but it lives beside them.
+# The server appends to this file when it creates a sheet, so it must be writable.
+# GOOGLE_SHEETS_ALLOWLIST=/app/customer/secrets/google/sheets-allowlist.json

--- a/chassis.config.yaml
+++ b/chassis.config.yaml
@@ -213,12 +213,15 @@ modules:
     telegram_trigger_user_id: null          # Optional - telegram user_id whose 👀 fires Mode B
                                             # (queue-from-telegram-reaction). Leave null to disable Mode B.
     telegram_admin_chat_ids: null           # Optional - comma-separated chat_ids where Mode B is active
-  google:                                   # Gmail + Calendar over on-disk OAuth, for HEADLESS installs
+  google:                                   # Gmail + Calendar + Sheets over on-disk OAuth, for HEADLESS installs
     gmail: false                            # Claude's hosted Google connectors need a browser and a human,
     calendar: false                         # so they never complete over SSH. A Linux/VPS install has no
-                                            # other path to Google; a desktop install that already has the
-                                            # connectors working can leave both false.
-                                            # Both flags default false, so an install that never sets them
+    sheets: false                           # other path to Google; a desktop install that already has the
+                                            # connectors working can leave all three false.
+                                            # sheets is the CELL-level surface: Drive read access lets an
+                                            # agent open a spreadsheet as a file, which is not the same as
+                                            # writing a row, and writing rows is what people ask for (#63).
+                                            # All flags default false, so an install that never sets them
                                             # renders .mcp.json exactly as it did before these keys existed.
                                             # Pre-flight (OAuth client, scopes, headless consent):
                                             #   docs/installer-homework.md
@@ -234,6 +237,13 @@ trust_line:
                                             # add create/update/delete/respond. Read-only is the default because
                                             # a mistake an agent can make on its own is one you find out about
                                             # from someone else's calendar.
+  sheets: read_only                         # LOAD-BEARING when modules.google.sheets is on. read_only leaves
+                                            # the allowlist file unset, and the SERVER then refuses every
+                                            # update-values / append-values call - the refusal is server-side,
+                                            # not a tool we hid from the agent. read_write points the server at
+                                            # an allowlist naming the spreadsheets it may write, by id: there
+                                            # is no blanket write tier, on purpose. See docs/installer-homework.md
+                                            # section 4g for the one gap (create-from-template can still copy).
   github: collaborator                      # Agent-side account separate from installer-personal
   google_drive: read_primary_write_on_ask
   notion: read_write

--- a/chassis/.mcp.json.template
+++ b/chassis/.mcp.json.template
@@ -75,8 +75,9 @@
     },
 
     "_google-headless": {
-      "_role": "Gmail + Google Calendar for HEADLESS installs. Claude's hosted Google connectors need a browser and a human, so they never complete over SSH - a Linux/VPS install has no other path to Google. These two servers hold OAuth credentials on disk and run unattended. A desktop install that already has the hosted connectors working can leave both flags false. Setup + the one-time consent procedure: docs/installer-homework.md.",
-      "_credential_note": "Both servers share ONE Google Cloud OAuth client of type 'Desktop app' (gcp-oauth.keys.json). A service account is NOT an option for Gmail: reading a user's mailbox with one needs domain-wide delegation, which needs a Workspace admin and is impossible on a personal Gmail account. Calendar could use a service account; it deliberately does not, so the installer creates one client and follows one procedure."
+      "_role": "Gmail + Google Calendar + Google Sheets for HEADLESS installs. Claude's hosted Google connectors need a browser and a human, so they never complete over SSH - a Linux/VPS install has no other path to Google. These servers hold OAuth credentials on disk and run unattended. A desktop install that already has the hosted connectors working can leave all three flags false. Setup + the one-time consent procedure: docs/installer-homework.md.",
+      "_credential_note": "All three servers share ONE Google Cloud OAuth client of type 'Desktop app' (gcp-oauth.keys.json). A service account is NOT an option for Gmail: reading a user's mailbox with one needs domain-wide delegation, which needs a Workspace admin and is impossible on a personal Gmail account. Calendar and Sheets could each use a service account; they deliberately do not, so the installer creates one client and follows one procedure. Each server keeps its OWN consented token - one client, one procedure, one consent per server.",
+      "_sharing_note": "Scope is not access. A consented token carries the SCOPE to touch Sheets, but it still only reaches spreadsheets the credentialed identity can already open. The agent's Google account is not you. A spreadsheet you own is invisible to it until you share that spreadsheet with the agent's address (Editor, for writes). This is the single most common reason a correctly-configured Sheets server still cannot read a sheet."
     },
 
     "gmail": {
@@ -109,6 +110,28 @@
           "predicate": "chassis.config.yaml.trust_line.calendar == 'read_write'",
           "set": {
             "env.ENABLED_TOOLS": "list-calendars,list-events,search-events,get-event,get-freebusy,get-current-time,list-colors,create-event,update-event,delete-event,respond-to-event"
+          }
+        }
+      ]
+    },
+
+    "google-sheets": {
+      "_role": "optional - Google Sheets over an on-disk OAuth token. Reading a spreadsheet as a Drive FILE is not the same as writing a CELL, and writing cells is the thing people actually want (#63). Advertised tools, verified against the running server: list-spreadsheets, get-spreadsheet, get-values, update-values, append-values, create-from-template.",
+      "_enable_when": "chassis.config.yaml.modules.google.sheets == true",
+      "_install_note": "npm @shivaduke28/google-sheets-mcp. Chosen over mcp-google-sheets, google-sheets-mcp and mcp-google-sheets-full because it is the only candidate that (a) reads GOOGLE_OAUTH_CREDENTIALS - the SAME gcp-oauth.keys.json the google-calendar entry already reads, so it adds no second credential mechanism - and (b) enforces a write allowlist server-side. The server's own token env var is GOOGLE_OAUTH_TOKENS; the chassis feeds it from a .env key named GOOGLE_SHEETS_TOKEN_PATH so that a file holding ONLY the sheets token is not misread as the token for every Google server.",
+      "_scope_note": "The server requests TWO scopes: .../auth/spreadsheets AND .../auth/drive - full Drive, not Drive-readonly. The drive scope is how it resolves a spreadsheet's parent folder for the allowlist check. Consenting this server therefore hands its token more reach than 'Sheets' suggests. Stated plainly rather than buried: if that is too much, do not enable this module.",
+      "_trust_line_note": "NOT tool-gating. Unlike google-calendar, this server has no ENABLED_TOOLS filter - every tool above is always advertised. It instead REFUSES writes at call time unless the target spreadsheet is allowlisted 'readwrite' in the GOOGLE_MCP_CONFIG file. So the inline entry (no GOOGLE_MCP_CONFIG) is the read floor: update-values and append-values are rejected by the SERVER, not merely hidden from the agent. _override_when adds GOOGLE_MCP_CONFIG only when trust_line.sheets is read_write, and even then writes reach only the spreadsheets the installer listed by id. One honest gap: create-from-template checks READ access on its template, so on the read floor it can still COPY a readable sheet into a new file. It cannot alter an existing one.",
+      "command": "npx",
+      "args": ["-y", "@shivaduke28/google-sheets-mcp"],
+      "env": {
+        "GOOGLE_OAUTH_CREDENTIALS": "<GOOGLE_OAUTH_CREDENTIALS>",
+        "GOOGLE_OAUTH_TOKENS": "<GOOGLE_SHEETS_TOKEN_PATH>"
+      },
+      "_override_when": [
+        {
+          "predicate": "chassis.config.yaml.trust_line.sheets == 'read_write'",
+          "set": {
+            "env.GOOGLE_MCP_CONFIG": "<GOOGLE_SHEETS_ALLOWLIST>"
           }
         }
       ]

--- a/chassis/second_brain/tests/test_mcp_json_render.py
+++ b/chassis/second_brain/tests/test_mcp_json_render.py
@@ -132,6 +132,7 @@ class GoogleMcpRenderTest(unittest.TestCase):
             servers = _render_config(config)
             self.assertNotIn("gmail", servers)
             self.assertNotIn("google-calendar", servers)
+            self.assertNotIn("google-sheets", servers)
 
     def test_existing_install_server_set_is_unchanged(self) -> None:
         # The exact server set a pre-#57 config rendered. If adding a Google
@@ -201,6 +202,90 @@ class GoogleMcpRenderTest(unittest.TestCase):
         self.assertEqual(shipped["trust_line"]["calendar"], "read_only")
         self.assertIs(shipped["modules"]["google"]["gmail"], False)
         self.assertIs(shipped["modules"]["google"]["calendar"], False)
+
+
+class GoogleSheetsMcpRenderTest(unittest.TestCase):
+    """Google Sheets MCP server (issue #63).
+
+    Same shape as the Gmail/Calendar tests above, with one difference worth
+    stating: `trust_line.sheets` does not gate a TOOL LIST, because
+    @shivaduke28/google-sheets-mcp has no tool filter. It gates whether the
+    server is handed a write allowlist at all. With no allowlist the server
+    refuses every write itself, so the absence of GOOGLE_MCP_CONFIG *is* the
+    read-only floor - which is why these tests assert on that key's presence
+    rather than on a set of tool names.
+    """
+
+    def test_sheets_absent_unless_flag_set(self) -> None:
+        # Gmail/Calendar on must not drag Sheets in with them.
+        servers = _render_config(
+            {"modules": {"google": {"gmail": True, "calendar": True}}}
+        )
+        self.assertNotIn("google-sheets", servers)
+
+    def test_sheets_registers_when_flag_set(self) -> None:
+        servers = _render_config({"modules": {"google": {"sheets": True}}})
+        entry = servers["google-sheets"]
+        self.assertEqual(entry["command"], "npx")
+        self.assertIn("@shivaduke28/google-sheets-mcp", entry["args"])
+        self.assertFalse([k for k in entry if k.startswith("_")])
+        # Enabling Sheets must not drag Gmail or Calendar in with it.
+        self.assertNotIn("gmail", servers)
+        self.assertNotIn("google-calendar", servers)
+
+    def test_sheets_reuses_the_shared_oauth_client(self) -> None:
+        # The whole point of #63: one OAuth client, not a second credential
+        # mechanism. The Sheets server must read the SAME placeholder the
+        # calendar entry reads.
+        sheets = _render_config({"modules": {"google": {"sheets": True}}})[
+            "google-sheets"
+        ]
+        calendar = _render_config({"modules": {"google": {"calendar": True}}})[
+            "google-calendar"
+        ]
+        self.assertEqual(
+            sheets["env"]["GOOGLE_OAUTH_CREDENTIALS"],
+            calendar["env"]["GOOGLE_OAUTH_CREDENTIALS"],
+        )
+
+    def test_sheets_defaults_to_read_floor_when_trust_line_absent(self) -> None:
+        # No trust_line at all: no allowlist, so the server denies every write.
+        entry = _render_config({"modules": {"google": {"sheets": True}}})[
+            "google-sheets"
+        ]
+        self.assertNotIn("GOOGLE_MCP_CONFIG", entry["env"])
+        self.assertEqual(
+            set(entry["env"]), {"GOOGLE_OAUTH_CREDENTIALS", "GOOGLE_OAUTH_TOKENS"}
+        )
+
+    def test_sheets_read_only_trust_line_withholds_the_allowlist(self) -> None:
+        entry = _render_config(
+            {
+                "modules": {"google": {"sheets": True}},
+                "trust_line": {"sheets": "read_only"},
+            }
+        )["google-sheets"]
+        self.assertNotIn("GOOGLE_MCP_CONFIG", entry["env"])
+
+    def test_sheets_read_write_trust_line_grants_the_allowlist(self) -> None:
+        entry = _render_config(
+            {
+                "modules": {"google": {"sheets": True}},
+                "trust_line": {"sheets": "read_write"},
+            }
+        )["google-sheets"]
+        self.assertEqual(entry["env"]["GOOGLE_MCP_CONFIG"], "<GOOGLE_SHEETS_ALLOWLIST>")
+        # Widened, not swapped - the credentials must survive the override.
+        self.assertIn("GOOGLE_OAUTH_CREDENTIALS", entry["env"])
+        self.assertIn("GOOGLE_OAUTH_TOKENS", entry["env"])
+
+    def test_shipped_config_defaults_sheets_off_and_read_only(self) -> None:
+        import yaml  # noqa: PLC0415 - test-only dependency
+
+        with open(REPO_ROOT / "chassis.config.yaml") as f:
+            shipped = yaml.safe_load(f)
+        self.assertIs(shipped["modules"]["google"]["sheets"], False)
+        self.assertEqual(shipped["trust_line"]["sheets"], "read_only")
 
 
 class OverrideWhenTest(unittest.TestCase):

--- a/docs/installer-homework.md
+++ b/docs/installer-homework.md
@@ -50,37 +50,68 @@ run `claude /discord:configure` after install.
 
 ---
 
-## 4. Google: Gmail and Calendar
+## 4. Google: Gmail, Calendar and Sheets
 
 **Read this section in full before you start clicking. The consent step is where
 every installer gets stuck, and the fix is to know about it in advance.**
 
+> ### Scope is not access. Share the file.
+>
+> The one that wastes an afternoon, so it is at the top rather than at the bottom.
+>
+> Getting Google working takes **two** independent things, and having one does not
+> get you the other:
+>
+> 1. **Scope** - the token must be allowed to touch Sheets at all. Comes from the
+>    OAuth client and the consent screen. Sections 4a to 4c.
+> 2. **Access to the specific file** - the spreadsheet must be **shared with the
+>    agent's Google account**, the same way you would share it with a colleague.
+>    Editor if you want the agent to write to it. Section 4g.
+>
+> The agent is not you. It has its own Google account (section 2). A spreadsheet
+> sitting in *your* Drive is invisible to it until you share that spreadsheet with
+> *its* address - scope or no scope. Equally, sharing the file with the agent does
+> nothing if the token never held the Sheets scope.
+>
+> If a spreadsheet reads as "not found" when you can plainly see it in your own
+> browser, it is almost always this: you have not shared it. "Not found" is what
+> Google returns for "exists, but not for you".
+
 ### Do you need this at all?
 
-Only if `chassis.config.yaml` sets `modules.google.gmail` or
-`modules.google.calendar` to `true`.
+Only if `chassis.config.yaml` sets `modules.google.gmail`, `modules.google.calendar`
+or `modules.google.sheets` to `true`.
 
 | Your install | What to do |
 |---|---|
 | **Headless** (Linux box, VPS, anything you only reach over SSH) | You need this. It is the only path by which Google ever works on your box. |
-| **Desktop** (a Mac you sit in front of) | Optional. Claude's hosted Google connectors are easier - click through them instead. Come back here only if you want Gmail attachment downloads, which the hosted connector cannot do. |
+| **Desktop** (a Mac you sit in front of) | Optional. Claude's hosted Google connectors are easier - click through them instead. Come back here only if you want Gmail attachment downloads or Sheets cell writes, neither of which the hosted connectors do. |
 
 Claude's hosted connectors need a browser and a human at the keyboard. They do not
-complete over SSH. That is the entire reason these two MCP servers exist.
+complete over SSH. That is the entire reason these MCP servers exist.
+
+On Sheets specifically: the hosted Drive connector can *read a spreadsheet as a file*.
+That is not the same as *writing a cell*, and writing cells is the thing people
+actually ask for. Enable `modules.google.sheets` when you want the agent to update
+rows, not just read them.
 
 ### Why not a service account?
 
 Because it cannot read Gmail. A Google service account reads a normal user's mailbox
 only with **domain-wide delegation**, which requires a Google Workspace admin and is
-flatly impossible on a personal `@gmail.com` account. Calendar alone would work with
-one, but then you would run two different credential mechanisms for two Google
-services. You create one OAuth client instead, and consent once per server.
+flatly impossible on a personal `@gmail.com` account. Calendar and Sheets would each
+work with one, but then you would run two different credential mechanisms for three
+Google services. You create one OAuth client instead, and consent once per server.
 
 ### 4a. In the Google Cloud Console (browser, any machine)
 
 1. Create a project, or pick an existing one.
-2. **APIs & Services > Library**: enable **Gmail API** and **Google Calendar API**.
-   Enable only the one you actually plan to turn on if you are only doing one.
+2. **APIs & Services > Library**: enable the API for each server you plan to turn on.
+   - Gmail: **Gmail API**
+   - Calendar: **Google Calendar API**
+   - Sheets: **Google Sheets API** *and* **Google Drive API**. Both. The Sheets
+     server uses Drive to look up which folder a spreadsheet lives in, and it fails
+     confusingly if the Drive API is off.
 3. **APIs & Services > OAuth consent screen**:
    - User type **External** is correct for a personal Gmail account.
    - Add the agent's Google address as a **Test user**. This is not optional. Consent
@@ -90,7 +121,7 @@ services. You create one OAuth client instead, and consent once per server.
      loopback redirect, which is what makes the consent step below work.
    - Download the JSON. Rename it `gcp-oauth.keys.json`.
 
-That one file is the OAuth **client**. Both servers read it. Do not create two.
+That one file is the OAuth **client**. All three servers read it. Do not create three.
 
 ### 4b. Scopes
 
@@ -103,6 +134,14 @@ know what you are consenting to when the screen appears:
   that distinction matters to you, use a dedicated agent-side Gmail account.
 - Calendar: read-write. `trust_line.calendar` controls which calendar *tools* the
   agent is handed, not which scope the token holds - see section 4d.
+- Sheets: `.../auth/spreadsheets` **and `.../auth/drive`**. Note the second one. It
+  is full Drive, not Drive-readonly, and the Sheets server needs it to resolve a
+  spreadsheet's parent folder. So consenting the Sheets server hands its token more
+  reach than the word "Sheets" suggests. That is stated here rather than buried: if
+  it is more than you want to grant, leave `modules.google.sheets` off.
+
+**And none of these scopes gets you access to a specific spreadsheet.** That takes
+sharing the file. Section 4g.
 
 ### 4c. Consent, on a headless box
 
@@ -129,32 +168,46 @@ GMAIL_CREDENTIALS_PATH="$PWD/gmail-token.json" \
 GOOGLE_OAUTH_CREDENTIALS="$PWD/gcp-oauth.keys.json" \
 GOOGLE_CALENDAR_MCP_TOKEN_PATH="$PWD/calendar-token.json" \
   npx @cocal/google-calendar-mcp auth
+
+# Sheets. No `auth` subcommand - this server consents on first use instead.
+# Start it, and it opens the browser and writes the token to GOOGLE_OAUTH_TOKENS.
+# It prints nothing on success and keeps running: once your browser says
+# "authenticated", press Ctrl-C. The token file is already on disk.
+GOOGLE_OAUTH_CREDENTIALS="$PWD/gcp-oauth.keys.json" \
+GOOGLE_OAUTH_TOKENS="$PWD/sheets-token.json" \
+  npx @shivaduke28/google-sheets-mcp
 ```
 
 Each command opens your browser. Sign in **as the agent's Google account**, not your
-personal one, and accept. You consent twice - once per server - against the one client.
+personal one, and accept. You consent once per server - three times, if you are
+enabling all three - against the one client.
 
-Then copy all three files to the server and lock them down:
+The Sheets server is the odd one out: it authenticates lazily, on the first tool call
+rather than at startup. If the browser does not open when you run it, invoke a tool
+against it, or simply check that `sheets-token.json` exists after you have completed
+the consent screen. That file existing is the success condition.
+
+Then copy the files to the server and lock them down:
 
 ```bash
 ssh you@your-box 'mkdir -p ~/.behalfbot/secrets/google'
-scp gcp-oauth.keys.json gmail-token.json calendar-token.json \
+scp gcp-oauth.keys.json gmail-token.json calendar-token.json sheets-token.json \
     you@your-box:~/.behalfbot/secrets/google/
 ssh you@your-box 'chmod 600 ~/.behalfbot/secrets/google/*'
 ```
 
-`secrets/` is gitignored. These files are live credentials - treat the two token
-files exactly like passwords, because that is what they are.
+`secrets/` is gitignored. These files are live credentials - treat every token
+file exactly like a password, because that is what it is.
 
 #### Path B - SSH tunnel, consent stays on the server
 
-If you would rather the tokens never touch your laptop. Both servers redirect to a
+If you would rather the tokens never touch your laptop. Each server redirects to a
 loopback port; forward that port from your laptop and the browser round-trip closes
 through the tunnel.
 
 Run the auth command on the server first and **read the port off the URL it prints**
-(the Gmail server uses `3000`; do not assume the Calendar server matches). Then, from
-your laptop:
+(Gmail and Sheets both use `3000`, so consent them one at a time, not in two shells
+at once; do not assume the Calendar server matches either). Then, from your laptop:
 
 ```bash
 ssh -L 3000:localhost:3000 you@your-box   # swap 3000 for the port it printed
@@ -200,8 +253,10 @@ modules:
   google:
     gmail: true
     calendar: true
+    sheets: true
 trust_line:
   calendar: read_only
+  sheets: read_only
 ```
 
 `$CUSTOMER_HOME/.env` - paths as seen from **inside** the container, where the
@@ -212,9 +267,17 @@ GMAIL_OAUTH_PATH=/app/customer/secrets/google/gcp-oauth.keys.json
 GMAIL_CREDENTIALS_PATH=/app/customer/secrets/google/gmail-token.json
 GOOGLE_OAUTH_CREDENTIALS=/app/customer/secrets/google/gcp-oauth.keys.json
 GOOGLE_CALENDAR_MCP_TOKEN_PATH=/app/customer/secrets/google/calendar-token.json
+GOOGLE_SHEETS_TOKEN_PATH=/app/customer/secrets/google/sheets-token.json
 ```
 
-Both servers read the same `gcp-oauth.keys.json`. Each keeps its own token.
+All three servers read the same `gcp-oauth.keys.json`. Each keeps its own token.
+
+Only if you set `trust_line.sheets: read_write`, one more - the write allowlist from
+section 4g:
+
+```
+GOOGLE_SHEETS_ALLOWLIST=/app/customer/secrets/google/sheets-allowlist.json
+```
 
 ### 4f. Test-mode tokens expire in 7 days
 
@@ -226,10 +289,93 @@ verification for this; an unverified app still works for accounts you listed as 
 users, and publishing stops the 7-day clock. If you leave it in Testing, expect to
 re-run the auth commands from 4c every week.
 
+### 4g. Sheets: share the file, then decide about writes
+
+#### Share the spreadsheet with the agent. This is the step everyone misses.
+
+Everything in 4a to 4f gets the agent a token with the **scope** to use Sheets. It
+does not get the agent into **your spreadsheet**. Those are different things, and a
+correctly-scoped token still returns "not found" on a spreadsheet nobody shared.
+
+For each spreadsheet you want the agent to touch:
+
+1. Open it in Google Sheets.
+2. **Share**.
+3. Add the **agent's Google address** - the account you consented with in 4c, not
+   your own.
+4. Role:
+   - **Viewer** if the agent only needs to read it.
+   - **Editor** if the agent needs to write to it. Viewer plus a write scope still
+     cannot write. Google checks the file permission too.
+5. Send. Sharing is effective immediately - no propagation wait, unlike the test-user
+   step in 4a.
+
+If you would rather not share sheet by sheet, share a whole **folder** with the agent
+and move the spreadsheets into it. Folder permissions are inherited.
+
+A diagnosis you may be offered and should not believe: *"adding an editor will not
+help, the problem is the API scope, not file permissions."* It is both, and they are
+independent. Scope without sharing fails. Sharing without scope fails. You need the
+two together, and if the agent cannot see a sheet you are looking at right now, the
+missing half is nearly always the sharing.
+
+#### Tools the agent gets
+
+Verified against the running server, not copied from a README:
+
+`list-spreadsheets`, `get-spreadsheet`, `get-values`, `update-values`,
+`append-values`, `create-from-template`.
+
+#### `trust_line.sheets`
+
+| Value | What the agent can do |
+|---|---|
+| `read_only` (default) | Read any spreadsheet that has been shared with it. **Every write is refused by the server.** |
+| `read_write` | The above, plus write - but only to spreadsheets you name by id in the allowlist below. There is no blanket write tier. |
+
+This works differently from `trust_line.calendar`, and the difference is in your
+favour. Calendar hides its write tools from the agent while the token underneath
+stays fully capable. The Sheets server instead **refuses the write itself**, at call
+time, when the target spreadsheet is not allowlisted for writing. The write tools stay
+visible and simply come back denied. Enforcement, rather than concealment.
+
+To allow writes, set `trust_line.sheets: read_write` and create the allowlist file at
+the `GOOGLE_SHEETS_ALLOWLIST` path from 4e:
+
+```json
+{
+  "sheets": {
+    "allowedSpreadsheets": [
+      {
+        "id": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
+        "name": "LP prospects",
+        "access": "readwrite"
+      },
+      {
+        "id": "1AbCdEfGhIjKlMnOpQrStUvWxYz",
+        "name": "Board reporting",
+        "access": "readonly"
+      }
+    ]
+  }
+}
+```
+
+The `id` is the long string in the spreadsheet's URL, between `/d/` and `/edit`. The
+file must be writable by the agent: `create-from-template` appends to it. And it is
+not a substitute for step 1 of this section - a spreadsheet allowlisted here but never
+shared with the agent is still invisible to it.
+
+One honest gap, so you hear it from us rather than discover it: on the `read_only`
+floor, `create-from-template` can still **copy** a spreadsheet the agent can read into
+a new file in its own Drive. It cannot modify an existing spreadsheet, which is the
+thing `read_only` is there to prevent. But "read_only" is not literally zero writes to
+Drive, and the server offers no tool filter with which we could make it so.
+
 ---
 
 ## Cross-references
 
 - `docs/hydration.md` - what bootstrap does with what you staged
-- `docs/mcp-setup.md` - per-MCP wiring, including the two Google servers
+- `docs/mcp-setup.md` - per-MCP wiring, including the three Google servers
 - `docs/security.md` - the guardrail model these credentials sit behind

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -32,7 +32,7 @@ Once the file lands, restart Claude Code so it re-reads. The manual hydration wa
 | **Always-on** (no auth) | `memory`, `playwright`, `context7` | Every install. Keep. |
 | **Always-on with config** | `github` | Every install touches GitHub. Provision agent-side PAT. |
 | **Pick one** (second-brain) | `siyuan` OR `notion` OR `secondbrain` | Per `chassis.config.yaml.second_brain.backend` + `second_brain.mode`. Mode `direct` (default): the backend's native server. Mode `adapter`: the chassis-owned `secondbrain` server INSTEAD, and the native server is not registered. Obsidian has no native server - obsidian installs need `mode: adapter` for any second-brain MCP surface. |
-| **Google** (headless installs) | `gmail`, `google-calendar` | Per `chassis.config.yaml.modules.google.*`. Both default off. The only path to Google on a box you reach over SSH - Claude's hosted connectors need a browser and never complete remotely. |
+| **Google** (headless installs) | `gmail`, `google-calendar`, `google-sheets` | Per `chassis.config.yaml.modules.google.*`. All default off. The only path to Google on a box you reach over SSH - Claude's hosted connectors need a browser and never complete remotely. |
 | **Optional, opt-in** | `brave-search`, `tavily`, `turso`, `amplitude`, `n8n`, `loom`, `remarkable`, `oura`, `frame0` | Per `chassis.config.yaml.modules.*` flags. Delete entries you don't activate. |
 
 ---
@@ -99,16 +99,17 @@ If you're running Notion (cloud, page+block model):
 
 ---
 
-## Google MCPs (gmail, google-calendar)
+## Google MCPs (gmail, google-calendar, google-sheets)
 
-Off by default. Turn them on with `modules.google.gmail` / `modules.google.calendar`
-in `chassis.config.yaml`.
+Off by default. Turn them on with `modules.google.gmail` / `modules.google.calendar` /
+`modules.google.sheets` in `chassis.config.yaml`.
 
 **Who needs them:** every headless install. Claude's hosted Google connectors need a
 browser and a human at the keyboard, so they do not complete over SSH - on a Linux box
 or VPS there is no other way to reach Google. A desktop install that already has the
-hosted connectors working can leave both flags false, unless it wants Gmail attachment
-downloads, which the hosted connector does not expose (#39, #40).
+hosted connectors working can leave all three flags false, unless it wants Gmail
+attachment downloads (#39, #40) or Sheets cell writes (#63), neither of which the
+hosted connectors expose. Reading a spreadsheet as a Drive file is not writing a cell.
 
 **Packages:**
 
@@ -116,8 +117,9 @@ downloads, which the hosted connector does not expose (#39, #40).
 |---|---|---|
 | `gmail` | [`@gongrzhe/server-gmail-autoauth-mcp`](https://github.com/gongrzhe/server-gmail-autoauth-mcp) | The server the first headless install has been running in production. Exposes `download_attachment`. |
 | `google-calendar` | [`@cocal/google-calendar-mcp`](https://github.com/nspady/google-calendar-mcp) | Supports `ENABLED_TOOLS` filtering, which is how `trust_line.calendar` is enforced. |
+| `google-sheets` | [`@shivaduke28/google-sheets-mcp`](https://github.com/shivaduke28/google-mcp) | Reads the same `GOOGLE_OAUTH_CREDENTIALS` client as Calendar. Enforces a per-spreadsheet write allowlist server-side. Tools: `list-spreadsheets`, `get-spreadsheet`, `get-values`, `update-values`, `append-values`, `create-from-template`. |
 
-**Credentials:** both read ONE OAuth client of type *Desktop app*
+**Credentials:** all three read ONE OAuth client of type *Desktop app*
 (`gcp-oauth.keys.json`), and each keeps its own consented token. A service account is
 not an option: reading a mailbox with one needs domain-wide delegation, which needs a
 Workspace admin and cannot be granted on a personal Gmail account.
@@ -127,11 +129,28 @@ flow on your laptop and copy the token files up. Full procedure, plus the Google
 Console setup and the 7-day test-mode token expiry that bites everyone:
 [`docs/installer-homework.md`](installer-homework.md) section 4.
 
+**Scope is not access.** A Sheets token can only reach spreadsheets that have been
+**shared with the agent's Google account** - Editor, if it is to write. This is the
+single most common reason a correctly-configured Sheets server still cannot open a
+sheet, and it is independent of scope: neither one substitutes for the other.
+[`installer-homework.md`](installer-homework.md) section 4g.
+
 **Calendar write access** is gated on `trust_line.calendar`. `read_only` (the default)
 registers the server with read tools only; `read_write` adds `create-event`,
 `update-event`, `delete-event`, `respond-to-event`. This is tool-gating, not
 scope-gating - the token holds a read-write scope either way. Gmail has no equivalent
 filter and is all-or-nothing, send included.
+
+**Sheets write access** is gated on `trust_line.sheets`, by a different and stronger
+mechanism. The server has no tool filter, so its write tools are always advertised;
+it instead **refuses the write at call time** unless the target spreadsheet is listed
+`readwrite` in the `GOOGLE_MCP_CONFIG` allowlist. `read_only` (the default) leaves that
+file unset, so every write is denied by the server. `read_write` points at an allowlist
+naming the writable spreadsheets by id - there is deliberately no blanket write tier.
+Caveat, stated rather than hidden: `create-from-template` checks only read access, so
+on the read floor it can still copy a readable sheet into a new file. It cannot alter
+an existing one. The Sheets server also requests a full `drive` scope alongside
+`spreadsheets`, which is broader than the module name suggests.
 
 ---
 


### PR DESCRIPTION
Closes #63. Follow-on to #57 / PR #62, whose pattern this copies.

## What changed

One new gated server. No new credential mechanism, no second consent flow, no new gating grammar.

| Server | Package | Gate |
|---|---|---|
| `google-sheets` | [`@shivaduke28/google-sheets-mcp`](https://github.com/shivaduke28/google-mcp) v1.3.0 | `modules.google.sheets` |

Ben asked his assistant to update 16 rows in a Google Sheet and it could not. Drive read access is not Sheets write access: reading a spreadsheet as a *file* is not writing a *cell*, and writing cells is the operation people actually want.

## Which package, and why

I drove all four candidates from #63 rather than trusting their READMEs.

| Package | Verdict |
|---|---|
| `google-sheets-mcp` (1.2.1) | **Out.** Only reads `GOOGLE_ACCESS_TOKEN` - a bare access token, no refresh. Expires in an hour. Unusable unattended, which is the entire use case. |
| `mcp-google-sheets-full` (0.2.0) | **Out.** Ships `run_sheets_script`, which executes arbitrary Node with pre-authenticated Google clients. Not going anywhere near a chassis. Also service-account/ADC shaped, which fragments the credential story. |
| `mcp-google-sheets` (2.0.1) | **Out.** Launches fine, 8 tools, but no permission mechanism of any kind and it ships `share_spreadsheet` - an agent could grant a third party access to a sheet. That is an exfiltration path nobody asked for. |
| `@shivaduke28/google-sheets-mcp` (1.3.0) | **Chosen.** |

Two reasons it wins:

1. **It reads `GOOGLE_OAUTH_CREDENTIALS`** - byte-for-byte the same env var, and the same `gcp-oauth.keys.json`, that `@cocal/google-calendar-mcp` already reads. One OAuth client, one procedure. This is exactly the constraint #63 set.
2. **It is the only candidate with server-side permission enforcement.** Writes are deny-by-default.

## Real advertised tools

Not from the README - from a live MCP `initialize` + `tools/list` over stdio:

```
INITIALIZE OK -> {"name": "google-sheets-mcp", "version": "2.0.0"}
TOOLS (6):
  - list-spreadsheets    - get-spreadsheet    - get-values
  - update-values        - append-values      - create-from-template
```

The README documents only 5. `create-from-template` is undocumented and real. This is why the issue said to verify.

## Tool filtering: there is none, and the tier is still enforced

**Stated plainly, per #63:** this server has **no `ENABLED_TOOLS` equivalent.** All six tools are always advertised. I am not going to pretend otherwise.

What it has instead is better. It **refuses the write at call time** when the target spreadsheet is not allowlisted `readwrite` in `GOOGLE_MCP_CONFIG`. So `trust_line.sheets: read_only` (the default) simply withholds the allowlist file, and the server denies every write itself.

Contrast with Calendar, where #62 was careful to say `ENABLED_TOOLS` is tool-gating, not scope-gating - the token underneath stays fully capable and we merely hide the tools. Here the server is the one saying no. Enforcement rather than concealment.

Verified empirically against the package's own `checkAccess`, not inferred from source:

```
read  @ read-floor  -> {"allowed":true}
WRITE @ read-floor  -> {"allowed":false, reason: "allowlist ... required"}
WRITE @ allowlisted -> {"allowed":true}
WRITE @ off-list    -> {"allowed":false}
WRITE @ ro-entry    -> {"allowed":false}
```

`read_write` is not a blanket grant either - it names writable spreadsheets by id.

## The step that wastes the afternoon

`docs/installer-homework.md` gets a callout at the **top** of section 4, not buried at the bottom, plus a full section 4g:

> **Scope is not access. Share the file.**

Getting Sheets working takes two independent things: the token needs the **scope**, and the spreadsheet needs to be **shared with the agent's Google account** (Editor, for writes). The agent is not you. A sheet in your Drive is invisible to it until you share it, scope or no scope.

#63 records the wrong diagnosis Ben was given - *"adding an editor won't unblock me, the issue is API scope, not file permissions."* It is both, and they are independent. The doc says so in as many words.

## Three things I want reviewed rather than glossed

1. **The Sheets server requests a full `.../auth/drive` scope** alongside `.../auth/spreadsheets`. Not `drive.readonly` - full Drive. It needs it to resolve a spreadsheet's parent folder for the folder-allowlist check. Consenting this server hands its token more reach than "Sheets" implies. Documented in 4b and in the template's `_scope_note`, and it is a real reason someone might decline the module.
2. **`read_only` is not literally zero writes.** `create-from-template` checks only *read* access on its template, so on the read floor it can still copy a readable sheet into a new file. It cannot alter an existing spreadsheet - which is what the tier exists to prevent - but the honest statement is "cannot modify existing sheets", not "cannot write to Drive". Called out in 4g and in `_trust_line_note`.
3. **The package's README and its runtime denial messages are in Japanese.** The code is clean and the behaviour is verified, but an agent hitting a refused write gets a Japanese string back. Cosmetic, and worth knowing before merge.

## Test plan

- [x] **Existing installs render byte-identically.** Rendered 4 pre-#63 config shapes (`{}`, siyuan, `modules.admin`, gmail+calendar+`trust_line.calendar: read_write`) against the template before and after. `diff -r` is **empty**; sha256 matches on all four. This is proven, not asserted.
- [x] Entry renders correctly when `modules.google.sheets: true` - both tiers. `GOOGLE_MCP_CONFIG` appears only at `read_write`. All `_`-prefixed meta keys stripped.
- [x] Server launches over stdio; real tool list captured above.
- [x] Write-refusal model verified by driving `checkAccess` across five cases.
- [x] Full chassis suite: `108 passed, 10 skipped` (the 2 initial failures were `No module named yaml` in a bare 3.14 interpreter and hit #62's pre-existing test too - clean on an interpreter with PyYAML).
- [x] No shell files touched, so no shellcheck surface. `chassis/VERSION` not bumped. No em dashes. No credentials, hostnames, or customer-specific paths in the diff.

**Not verified:** no live Google API call. I had no consented Sheets token, so the end-to-end "agent writes 16 rows" path is unexercised against Google itself. Everything up to the API boundary - registration, gating, credential wiring, stdio handshake, the permission decision - is verified. The token-to-Google leg is not, and I am flagging that rather than implying otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
