### PR TITLE
fix(loom-vision): convert loom-dl transcript JSON to WebVTT so the transcript half works

### DIFF
--- a/plugins/loom-vision/README.md
+++ b/plugins/loom-vision/README.md
@@ -4,20 +4,20 @@
 
 ## What it does
 
-Loom's auto-transcript captures only what was said aloud. For most technical Loom videos — code walkthroughs, design reviews, bug repros — the screen contents matter more than the audio. Loom Vision closes that gap:
+Loom's auto-transcript captures only what was said aloud. For most technical Loom videos - code walkthroughs, design reviews, bug repros - the screen contents matter more than the audio. Loom Vision closes that gap:
 
 1. Downloads the source video and Loom's auto-transcript.
 2. Samples frames at 1 frame per 5 seconds (configurable).
 3. Hands both to Claude as multimodal context.
 
-The agent then reads the transcript to anchor timing and browses the frames that fall in the relevant window — IDE state, error popups, on-screen code, design mockups, and UI transitions that the audio narration skipped.
+The agent then reads the transcript to anchor timing and browses the frames that fall in the relevant window - IDE state, error popups, on-screen code, design mockups, and UI transitions that the audio narration skipped.
 
 ## Example uses
 
-- "Here's a 7-minute Loom of the bug — what did I click on at minute 4 that triggered the 500?"
+- "Here's a 7-minute Loom of the bug - what did I click on at minute 4 that triggered the 500?"
 - "Walk me through this design review and pull out every comment about contrast ratios."
-- "Loom of my PR walkthrough — summarize the diff strategy I described."
-- "I recorded my onboarding flow — where does the UX get confusing?"
+- "Loom of my PR walkthrough - summarize the diff strategy I described."
+- "I recorded my onboarding flow - where does the UX get confusing?"
 
 ## Install
 
@@ -27,43 +27,50 @@ The agent then reads the transcript to anchor timing and browses the frames that
 #   modules:
 #     loom-vision:
 #       enabled: true
-# Then re-run chassis/bootstrap.sh — setup.sh runs automatically.
+# Then re-run chassis/bootstrap.sh - setup.sh runs automatically.
 
 # Standalone (no chassis)
 bash plugins/loom-vision/setup.sh
 ```
 
-Setup installs two CLI dependencies:
+Setup installs three CLI dependencies:
 
-- `loom-dl` — `npm install -g loom-dl` (Node-based; not on Homebrew)
-- `ffmpeg` — `brew install ffmpeg`
+- `node` - `brew install node`. Runs the transcript JSON to VTT conversion, and is required by loom-dl anyway (loom-dl is an npm CLI), so a working loom-dl implies node is present.
+- `loom-dl` - `npm install -g loom-dl` (Node-based; not on Homebrew)
+- `ffmpeg` - `brew install ffmpeg`. Frame sampling, plus ffprobe for reading duration.
 
-Both are idempotent. Re-running setup.sh on an already-installed system is a no-op.
+All are idempotent. Re-running setup.sh on an already-installed system is a no-op.
 
 ## Usage
 
-The skill triggers automatically when the user pastes a Loom share URL or asks the agent to process Loom video content. The skill definition is in `skills/loom-vision.md`.
+The skill triggers automatically when the user pastes a Loom share URL or asks the agent to process Loom video content. The skill definition is in `skills/loom-vision/SKILL.md`.
 
 You can also invoke the underlying script directly:
 
 ```bash
-bash plugins/loom-vision/scripts/process-loom.sh "https://www.loom.com/share/<32-hex-id>/..."
+bash plugins/loom-vision/skills/loom-vision/process-loom.sh "https://www.loom.com/share/<32-hex-id>/..."
 ```
 
 The script prints the output directory path to stdout. The directory contains:
 
-- `video.mp4` — original video (kept for re-sampling at different intervals)
-- `transcript.vtt` — Loom's auto-transcript with timestamps
-- `frame_NNN.jpg` — sampled frames
+- `video.mp4` - original video (kept for re-sampling at different intervals)
+- `transcript.vtt` - Loom's auto-transcript as WebVTT with timestamps
+- `transcript.txt` - the same transcript as plaintext
+- `transcript.json` - the raw loom-dl transcript JSON, kept verbatim
+- `frame_NNN.jpg` - sampled frames
 
 Frame N corresponds to timestamp `(N - 1) * FRAME_INTERVAL_SECONDS` from the start.
+
+loom-dl writes its transcript as `<basename>.transcript.json`, not VTT. The script
+converts that into `transcript.vtt` + `transcript.txt` so the agent always has a
+transcript file to read.
 
 ## Configuration
 
 | Knob | Default | Purpose |
 |---|---|---|
 | `enabled` | `true` | Master toggle for the skill. |
-| `frame_interval_seconds` | `5` | Lower for fast-changing UI, higher for slow walkthroughs. |
+| `frame_interval_seconds` | `5` | Lower for fast-changing UI, higher for slow walkthroughs. Try 2-3 for fast bug repros. |
 | `frame_max_width_px` | `1280` | Bump up if code fonts get too small to read. |
 | `frame_quality` | `3` | ffmpeg `-q:v` scale (1-31, lower = better quality). |
 | `output_root` | `${CHASSIS_HOME}/temp` | Where per-video output folders are written. |
@@ -72,13 +79,13 @@ All knobs honored via environment variables. See `openclaw.plugin.json` for the 
 
 ## Why this is interesting
 
-Plain Loom transcripts miss the visual narrative entirely. Sampling at 1 frame per 5 seconds is the sweet spot for code and UI content — dense enough to catch transient errors and UI transitions, sparse enough that a 10-minute video yields ~120 frames (a manageable batch size for multimodal review).
+Plain Loom transcripts miss the visual narrative entirely. Sampling at 1 frame per 5 seconds is the sweet spot for code and UI content - dense enough to catch transient errors and UI transitions, sparse enough that a 10-minute video yields ~120 frames (a manageable batch size for multimodal review).
 
-The token cost of the frames themselves is negligible compared to the value of having the agent see what was actually on screen during a walkthrough. For Claude Code in particular, this lets you treat Loom recordings as first-class context for code review and debugging — drop a URL into your session and continue working with full visual awareness.
+The token cost of the frames themselves is negligible compared to the value of having the agent see what was actually on screen during a walkthrough. For Claude Code in particular, this lets you treat Loom recordings as first-class context for code review and debugging - drop a URL into your session and continue working with full visual awareness.
 
 ## Built by
 
-This plugin ships standard with [Behalf.bot](https://behalf.bot) — battery-included Claude Code installs for operators and Build School students. The full Behalf.bot stack bundles Loom Vision alongside dating-app automation, body-for-life journaling, restaurant booking, reMarkable tablet sync, and more, with a single `bootstrap.sh` that wires everything to your local infrastructure.
+This plugin ships standard with [Behalf.bot](https://behalf.bot) - battery-included Claude Code installs for operators and Build School students. The full Behalf.bot stack bundles Loom Vision alongside dating-app automation, body-for-life journaling, restaurant booking, reMarkable tablet sync, and more, with a single `bootstrap.sh` that wires everything to your local infrastructure.
 
 If Loom Vision is useful to you on its own, the rest of the Behalf.bot plugin catalog is probably interesting too.
 

--- a/plugins/loom-vision/openclaw.plugin.json
+++ b/plugins/loom-vision/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "behalfbot-loom-vision",
-  "name": "Behalf.bot — Loom Vision",
-  "description": "Process a Loom share URL into multimodal context: downloads the video, samples key frames at 1 frame per 5 seconds, and pairs them with the auto-generated transcript. Lets Claude see what's happening on screen during a walkthrough, code review, or bug repro — not just what was said. Token-cheap visual context for any Loom link.",
+  "name": "Behalf.bot - Loom Vision",
+  "description": "Process a Loom share URL into multimodal context: downloads the video, samples key frames at 1 frame per 5 seconds, and pairs them with the auto-generated transcript. Lets Claude see what's happening on screen during a walkthrough, code review, or bug repro - not just what was said. Token-cheap visual context for any Loom link.",
   "version": "0.1.0",
   "configSchema": {
     "type": "object",
@@ -35,7 +35,7 @@
       },
       "output_root": {
         "type": "string",
-        "description": "Directory where per-video output folders are written. Each Loom video gets a subdir named loom-<video_id> containing video.mp4, transcript.vtt, and frame_NNN.jpg files.",
+        "description": "Directory where per-video output folders are written. Each Loom video gets a subdir named loom-<video_id> containing video.mp4, transcript.vtt, transcript.txt, transcript.json, and frame_NNN.jpg files.",
         "default": "${CHASSIS_HOME}/temp"
       }
     },
@@ -53,14 +53,19 @@
   "dependencies": {
     "system": [
       {
+        "name": "node",
+        "install": "brew install node",
+        "_explanation": "Runs the transcript JSON to VTT/plaintext conversion embedded in process-loom.sh. Also required transitively by loom-dl (it is an npm CLI), so a working loom-dl implies node is present. Listed explicitly so a chassis that ships loom-dl as a prebuilt binary still installs node."
+      },
+      {
         "name": "loom-dl",
         "install": "npm install -g loom-dl",
-        "_explanation": "loom-dl is a small Node CLI that handles the Loom share URL → mp4 + transcript download. Not on Homebrew, ships via npm. Verified against loom-dl 1.1.1."
+        "_explanation": "loom-dl is a small Node CLI that handles the Loom share URL to mp4 + transcript download. Not on Homebrew, ships via npm. Verified against loom-dl 1.1.1, which writes the transcript as <basename>.transcript.json (schemaVersion 1.1.x)."
       },
       {
         "name": "ffmpeg",
         "install": "brew install ffmpeg",
-        "_explanation": "Frame sampling. Any recent ffmpeg works."
+        "_explanation": "Frame sampling, plus ffprobe (bundled) to read video duration for bounding the final transcript cue. Any recent ffmpeg works."
       }
     ]
   },

--- a/plugins/loom-vision/setup.sh
+++ b/plugins/loom-vision/setup.sh
@@ -10,6 +10,21 @@ set -euo pipefail
 
 echo "[loom-vision] checking deps..."
 
+# node - runs the transcript JSON -> VTT conversion in process-loom.sh, and is
+# required by loom-dl anyway. Installing loom-dl below needs npm (hence node),
+# so this is mostly a clear, early failure message.
+if command -v node >/dev/null 2>&1; then
+  echo "[loom-vision] node present ($(node --version 2>/dev/null || echo 'unknown version'))"
+else
+  if command -v brew >/dev/null 2>&1; then
+    echo "[loom-vision] installing node via Homebrew..."
+    brew install node
+  else
+    echo "[loom-vision] ERROR: node not found and Homebrew unavailable. Install Node manually." >&2
+    exit 1
+  fi
+fi
+
 # loom-dl - Node CLI, not on Homebrew
 if command -v loom-dl >/dev/null 2>&1; then
   echo "[loom-vision] loom-dl present ($(loom-dl --version 2>/dev/null || echo 'unknown version'))"

--- a/plugins/loom-vision/skills/loom-vision/SKILL.md
+++ b/plugins/loom-vision/skills/loom-vision/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: loom-vision
-description: Process a Loom share URL into multimodal context — downloaded video, sampled frames at one frame per 5 seconds, and the auto-generated transcript. Triggers when the user shares a Loom URL, asks "what is happening in this Loom video", or wants visual context beyond the transcript.
+description: Process a Loom share URL into multimodal context - downloaded video, sampled frames at one frame per 5 seconds, and the auto-generated transcript. Triggers when the user shares a Loom URL, asks "what is happening in this Loom video", or wants visual context beyond the transcript.
 plugin: behalfbot-loom-vision
 enabled_when: "chassis.config.yaml modules.loom-vision.enabled == true"
-metadata: { "openclaw": { "emoji": "🎥", "homepage": "https://behalf.bot", "requires": { "bins": ["loom-dl", "ffmpeg"] }, "install": [ { "id": "node-loom-dl", "kind": "node", "package": "loom-dl", "bins": ["loom-dl"], "label": "Install loom-dl (npm)" }, { "id": "brew-ffmpeg", "kind": "brew", "formula": "ffmpeg", "bins": ["ffmpeg"], "label": "Install ffmpeg (brew)" } ] } }
+metadata: { "openclaw": { "emoji": "🎥", "homepage": "https://behalf.bot", "requires": { "bins": ["node", "loom-dl", "ffmpeg"] }, "install": [ { "id": "node-loom-dl", "kind": "node", "package": "loom-dl", "bins": ["loom-dl"], "label": "Install loom-dl (npm)" }, { "id": "brew-ffmpeg", "kind": "brew", "formula": "ffmpeg", "bins": ["ffmpeg"], "label": "Install ffmpeg (brew)" } ] } }
 ---
 
 # Loom Vision
@@ -14,7 +14,7 @@ Use this skill whenever:
 - The user asks you to "watch", "review", "summarize", or "explain" a Loom video.
 - The user references a Loom video they recorded and asks a question that needs visual context (e.g. "what was the error on screen at minute 3", "did I click the right button", "what's the diff in that PR walkthrough").
 
-The skill exists because Loom's auto-transcript captures only what was said aloud — not what was on screen. For code walkthroughs, design reviews, and bug repros, the screen contents are often more important than the audio.
+The skill exists because Loom's auto-transcript captures only what was said aloud - not what was on screen. For code walkthroughs, design reviews, and bug repros, the screen contents are often more important than the audio.
 
 ## How to invoke
 
@@ -24,17 +24,23 @@ Run the processor script with the Loom share URL. It downloads the mp4, samples 
 bash {baseDir}/process-loom.sh "<loom-share-url>"
 ```
 
-`{baseDir}` expands to the directory containing this `SKILL.md` at runtime — both `process-loom.sh` and `SKILL.md` ship in the same bundle so the script is always co-located with the skill.
+`{baseDir}` expands to the directory containing this `SKILL.md` at runtime - both `process-loom.sh` and `SKILL.md` ship in the same bundle so the script is always co-located with the skill.
 
 The script prints the output directory path to stdout. Inside that directory:
 
-- `video.mp4` — the original video (kept in case you want to re-process at a different frame interval)
-- `transcript.vtt` — Loom's auto-transcript with timestamps
-- `frame_001.jpg`, `frame_002.jpg`, ... — sampled frames at 1 frame per N seconds (default 5)
+- `video.mp4` - the original video (kept in case you want to re-process at a different frame interval)
+- `transcript.vtt` - Loom's auto-transcript as WebVTT with timestamps (read this one)
+- `transcript.txt` - the same transcript as plaintext, no timestamps
+- `transcript.json` - the raw loom-dl transcript JSON, kept verbatim
+- `frame_001.jpg`, `frame_002.jpg`, ... - sampled frames at 1 frame per N seconds (default 5)
+
+Note: loom-dl writes its transcript as `<basename>.transcript.json`, not VTT. The
+script converts that JSON into `transcript.vtt` + `transcript.txt` for you, so the
+"read the transcript" step below always has a file to read.
 
 ## What to do with the output
 
-Read the transcript first to anchor timing, then browse the frames that fall in the relevant time window. For a 10-minute video at 5-second sampling that's 120 frames — review them in batches or jump to the specific window the user asked about.
+Read the transcript first to anchor timing, then browse the frames that fall in the relevant time window. For a 10-minute video at 5-second sampling that's 120 frames - review them in batches or jump to the specific window the user asked about.
 
 Frame N corresponds to timestamp `(N - 1) * frame_interval_seconds` from the start of the video. Default interval is 5 seconds, so frame_007.jpg is at the 30-second mark.
 
@@ -44,30 +50,31 @@ Common patterns:
 
 - **Summarize the whole video.** Read the full transcript, then sample every 6th frame (one per 30 seconds) for the visual narrative. Combine.
 - **Answer a specific question.** Search the transcript for the relevant keyword, find the timestamp, look at the frame(s) within ±10 seconds.
-- **Spot what's missing from the transcript.** Errors, popup dialogs, UI states, and on-screen code rarely make it into the spoken audio — go directly to the frames.
+- **Spot what's missing from the transcript.** Errors, popup dialogs, UI states, and on-screen code rarely make it into the spoken audio - go directly to the frames.
 
 ## Configuration
 
 The plugin manifest's `configSchema` controls:
 
-- `frame_interval_seconds` — default 5. Lower for densely visual content (animations, fast UI changes), higher for slow walkthroughs.
-- `frame_max_width_px` — default 1280. Bump up for tiny-font code review videos.
-- `frame_quality` — default 3 (ffmpeg `-q:v` scale, 1-31, lower = better).
-- `output_root` — default `${CHASSIS_HOME}/temp/`.
+- `frame_interval_seconds` - default 5. Lower for densely visual content (animations, fast UI changes), higher for slow walkthroughs. For fast bug repros where you need to catch a transient error, 2-3 seconds is a good tighter setting.
+- `frame_max_width_px` - default 1280. Bump up for tiny-font code review videos.
+- `frame_quality` - default 3 (ffmpeg `-q:v` scale, 1-31, lower = better).
+- `output_root` - default `${CHASSIS_HOME}/temp/`.
 
 These are read at run time from chassis.config.yaml (chassis installs) or set via environment variables before invoking the script (standalone installs). See `{baseDir}/process-loom.sh` for the env var contract.
 
 ## Dependencies
 
-Two system CLIs are required:
+Three system CLIs are required:
 
-- `loom-dl` — install with `npm install -g loom-dl` (Node CLI, not on Homebrew)
-- `ffmpeg` — install with `brew install ffmpeg` (macOS) or your distro's package manager (Linux)
+- `node` - runs the transcript JSON to VTT conversion. It is also required by loom-dl, so if loom-dl works, node is already present. Install with `brew install node` if missing.
+- `loom-dl` - install with `npm install -g loom-dl` (Node CLI, not on Homebrew)
+- `ffmpeg` - install with `brew install ffmpeg` (macOS) or your distro's package manager (Linux). Supplies `ffprobe`, used to bound the final transcript cue.
 
-Chassis installs run `plugins/loom-vision/setup.sh` automatically during bootstrap. Standalone / ClawHub installs need to run the two install commands once manually; both are idempotent.
+Chassis installs run `plugins/loom-vision/setup.sh` automatically during bootstrap. Standalone / ClawHub installs need to run the install commands once manually; all are idempotent.
 
 ## Why this exists
 
-Most Loom-style integrations treat the video as audio-with-pictures: they ingest the transcript and stop. That loses the entire visual half of a walkthrough — IDE state, error popups, on-screen code, design mockups, the actual change in a PR review.
+Most Loom-style integrations treat the video as audio-with-pictures: they ingest the transcript and stop. That loses the entire visual half of a walkthrough - IDE state, error popups, on-screen code, design mockups, the actual change in a PR review.
 
 Sampling at 1 frame per 5 seconds is the sweet spot for code/UI content: dense enough to catch transient errors and UI transitions, sparse enough that a 10-minute video yields 120 frames (manageable batch size for multimodal review). The transcript provides the audio narrative; the frames provide everything else.

--- a/plugins/loom-vision/skills/loom-vision/process-loom.sh
+++ b/plugins/loom-vision/skills/loom-vision/process-loom.sh
@@ -2,24 +2,27 @@
 # process-loom.sh - Download a Loom video, extract key frames + transcript.
 #
 # Usage:
-#   bash plugins/loom-vision/scripts/process-loom.sh <loom-share-url>
+#   bash plugins/loom-vision/skills/loom-vision/process-loom.sh <loom-share-url>
 #
 # Output:
 #   Creates ${OUTPUT_ROOT}/loom-<video_id>/ containing:
 #     - video.mp4         (full source video, kept for re-sampling)
-#     - transcript.vtt    (Loom auto-transcript with timestamps)
+#     - transcript.json   (raw loom-dl transcript, kept verbatim)
+#     - transcript.vtt    (WebVTT built from the JSON - what the agent reads)
+#     - transcript.txt    (plaintext transcript, no timestamps)
 #     - frame_NNN.jpg     (sampled frames at FRAME_INTERVAL_SECONDS cadence)
 #   Prints the output directory path to stdout. Progress messages go to stderr.
 #
 # Configuration (env vars; defaults match plugin configSchema):
 #   OUTPUT_ROOT               default ${CHASSIS_HOME}/temp
-#   FRAME_INTERVAL_SECONDS    default 5
+#   FRAME_INTERVAL_SECONDS    default 5 (try 2-3 for fast bug repros)
 #   FRAME_MAX_WIDTH_PX        default 1280
 #   FRAME_QUALITY             default 3 (ffmpeg -q:v, 1-31, lower = better)
 #
 # Dependencies (installed via plugins/loom-vision/setup.sh):
+#   - node    (transcript JSON -> VTT conversion; also required by loom-dl)
 #   - loom-dl (npm install -g loom-dl)
-#   - ffmpeg  (brew install ffmpeg)
+#   - ffmpeg  (brew install ffmpeg; supplies ffprobe for duration bounding)
 
 set -euo pipefail
 
@@ -38,15 +41,19 @@ FRAME_QUALITY="${FRAME_QUALITY:-3}"
 # of midway through the pipeline.
 if ! command -v loom-dl >/dev/null 2>&1; then
   echo "ERROR: loom-dl not found in PATH. Install with: npm install -g loom-dl" >&2
-  echo "       (Or run plugins/loom-vision/setup.sh to install both deps.)" >&2
+  echo "       (Or run plugins/loom-vision/setup.sh to install all deps.)" >&2
   exit 2
 fi
 if ! command -v ffmpeg >/dev/null 2>&1; then
   echo "ERROR: ffmpeg not found in PATH. Install with: brew install ffmpeg" >&2
   exit 2
 fi
+if ! command -v node >/dev/null 2>&1; then
+  echo "ERROR: node not found in PATH. Install with: brew install node" >&2
+  exit 2
+fi
 
-# Extract video ID from URL — Loom share URLs are .../share/<32-hex>/...
+# Extract video ID from URL - Loom share URLs are .../share/<32-hex>/...
 VIDEO_ID=$(echo "$URL" | grep -oE '[a-f0-9]{32}' | head -1)
 if [[ -z "$VIDEO_ID" ]]; then
   echo "ERROR: Could not extract a 32-hex video ID from URL: $URL" >&2
@@ -57,8 +64,179 @@ fi
 OUTPUT_DIR="$OUTPUT_ROOT/loom-$VIDEO_ID"
 mkdir -p "$OUTPUT_DIR"
 
+# Download the video + transcript. The .mp4 extension on --out is load-bearing:
+# loom-dl treats a path ending in .mp4 as an explicit file. Do NOT change it to
+# a bare directory - loom-dl would then misinterpret the target and break.
 echo "Downloading Loom video $VIDEO_ID..." >&2
 loom-dl --url "$URL" --out "$OUTPUT_DIR/video.mp4" --transcript 2>&2
+
+# --- transcript JSON -> VTT + plaintext ------------------------------------
+# transcript JSON->VTT conversion added per beta feedback from Bart Boughton,
+# 2026-07-15. loom-dl --transcript writes "<out-basename>.transcript.json"
+# (schemaVersion 1.1.x: { "phrases": [ { "ts": <seconds>, "value": <text> } ] }),
+# NOT a transcript.vtt. Older docs told the agent to read transcript.vtt, which
+# never existed, so the transcript half of the skill silently did nothing. The
+# embedded converter is defensive about field names and always emits a valid VTT
+# (even timing-less) so the agent's "read the transcript" step never dead-ends.
+echo "Converting transcript to VTT + plaintext..." >&2
+
+# loom-dl derives the transcript name from the --out basename: video.mp4 -> video.transcript.json
+TRANSCRIPT_JSON="$OUTPUT_DIR/video.transcript.json"
+if [[ ! -f "$TRANSCRIPT_JSON" ]]; then
+  TRANSCRIPT_JSON=$(ls -1 "$OUTPUT_DIR"/*.transcript.json 2>/dev/null | head -1 || true)
+  if [[ -z "${TRANSCRIPT_JSON:-}" ]]; then
+    TRANSCRIPT_JSON=$(ls -1 "$OUTPUT_DIR"/*.json 2>/dev/null | grep -v '/transcript\.json$' | head -1 || true)
+  fi
+fi
+
+VTT="$OUTPUT_DIR/transcript.vtt"
+TXT="$OUTPUT_DIR/transcript.txt"
+
+# Best-effort video duration (seconds) to bound the final cue.
+DURATION_SECONDS=""
+if command -v ffprobe >/dev/null 2>&1; then
+  DURATION_SECONDS=$(ffprobe -v error -show_entries format=duration -of default=nk=1:nw=1 "$OUTPUT_DIR/video.mp4" 2>/dev/null || true)
+fi
+
+if [[ -n "${TRANSCRIPT_JSON:-}" && -f "$TRANSCRIPT_JSON" ]]; then
+  # Keep the raw JSON under a predictable name alongside the converted files.
+  if [[ "$TRANSCRIPT_JSON" != "$OUTPUT_DIR/transcript.json" ]]; then
+    cp -f "$TRANSCRIPT_JSON" "$OUTPUT_DIR/transcript.json"
+  fi
+  node - "$TRANSCRIPT_JSON" "$VTT" "$TXT" "${DURATION_SECONDS:-0}" <<'LOOMVTT'
+const fs = require("fs");
+const args = process.argv.slice(2);
+const jsonPath = args[0], vttPath = args[1], txtPath = args[2];
+const duration = parseFloat(args[3]) || 0;
+
+function writeStub(msg) {
+  fs.writeFileSync(vttPath, "WEBVTT\n\nNOTE " + msg + "\n");
+  fs.writeFileSync(txtPath, "");
+  console.error("WARN: " + msg);
+}
+
+let root;
+try { root = JSON.parse(fs.readFileSync(jsonPath, "utf8")); }
+catch (e) { writeStub("transcript JSON could not be parsed: " + e.message); process.exit(0); }
+
+function firstArray() {
+  for (let i = 0; i < arguments.length; i++) {
+    const c = arguments[i];
+    if (Array.isArray(c) && c.length) return c;
+  }
+  return null;
+}
+let segs = firstArray(
+  root && root.phrases,
+  Array.isArray(root) ? root : null,
+  root && root.transcript,
+  root && root.segments,
+  root && root.cues,
+  root && root.captions,
+  root && root.results
+);
+let wordLevel = false;
+if (!segs) {
+  const words = firstArray(root && root.words, root && root.tokens);
+  if (words) { segs = words; wordLevel = true; }
+}
+if (!segs) {
+  const blob = root && (root.text || root.transcript || root.value);
+  segs = (typeof blob === "string" && blob.trim()) ? [{ value: blob }] : [];
+}
+
+const START_KEYS = ["start_ts", "startTime", "start", "ts", "tsStart", "begin", "offset", "from", "startTimeMs", "startMs"];
+const END_KEYS = ["end_ts", "endTime", "end", "tsEnd", "stop", "to", "endTimeMs", "endMs"];
+const TEXT_KEYS = ["value", "text", "content", "phrase", "caption", "transcript", "word", "token"];
+
+function parseClock(s) {
+  const parts = String(s).trim().split(":").map(Number);
+  if (!parts.length || parts.some(n => !isFinite(n))) return null;
+  let sec = 0;
+  for (const p of parts) sec = sec * 60 + p;
+  return sec;
+}
+function num(v) {
+  if (typeof v === "number" && isFinite(v)) return v;
+  if (typeof v === "string" && v.trim() !== "") {
+    if (isFinite(+v)) return +v;
+    return parseClock(v);
+  }
+  return null;
+}
+function pickKV(o, keys) {
+  for (const k of keys) if (o && o[k] !== undefined && o[k] !== null && o[k] !== "") return [k, o[k]];
+  return [null, undefined];
+}
+function toSec(k, raw) { let v = num(raw); if (v === null) return null; if (/ms$/i.test(k || "")) v /= 1000; return v; }
+function pick(o, keys) { return pickKV(o, keys)[1]; }
+function startOf(o) { const kv = pickKV(o, START_KEYS); return toSec(kv[0], kv[1]); }
+function endOf(o) { const kv = pickKV(o, END_KEYS); return toSec(kv[0], kv[1]); }
+function textOf(o) { if (typeof o === "string") return o; const t = pick(o, TEXT_KEYS); return t == null ? "" : String(t); }
+
+let cues;
+if (wordLevel) {
+  cues = [];
+  const CHUNK = 12;
+  for (let i = 0; i < segs.length; i += CHUNK) {
+    const grp = segs.slice(i, i + CHUNK);
+    const text = grp.map(textOf).join(" ").replace(/\s+/g, " ").trim();
+    const starts = grp.map(startOf).filter(v => v != null);
+    const ends = grp.map(endOf).filter(v => v != null);
+    cues.push({ start: starts.length ? starts[0] : null, end: ends.length ? ends[ends.length - 1] : null, text });
+  }
+} else {
+  cues = segs.map(s => ({ start: startOf(s), end: endOf(s), text: textOf(s).replace(/\s+/g, " ").trim() }))
+             .filter(c => c.text.length || c.start != null);
+}
+
+const anyStart = cues.some(c => c.start != null);
+
+for (let i = 0; i < cues.length; i++) {
+  if (cues[i].start == null) continue;
+  if (cues[i].end == null) {
+    let ns = null;
+    for (let j = i + 1; j < cues.length; j++) if (cues[j].start != null) { ns = cues[j].start; break; }
+    cues[i].end = ns != null ? ns : (duration > cues[i].start ? duration : cues[i].start + 4);
+  }
+  if (cues[i].end <= cues[i].start) cues[i].end = cues[i].start + 0.5;
+}
+
+function fmt(t) {
+  if (!(t > 0)) t = 0;
+  const h = Math.floor(t / 3600), m = Math.floor((t % 3600) / 60), s = Math.floor(t % 60);
+  const ms = Math.round((t - Math.floor(t)) * 1000);
+  const p = (n, w) => String(n).padStart(w, "0");
+  return p(h, 2) + ":" + p(m, 2) + ":" + p(s, 2) + "." + p(ms, 3);
+}
+
+let out = "WEBVTT\n\n";
+if (anyStart) {
+  let n = 0;
+  for (const c of cues) {
+    if (!c.text || c.start == null) continue;
+    n++;
+    out += n + "\n" + fmt(c.start) + " --> " + fmt(c.end) + "\n" + c.text + "\n\n";
+  }
+} else {
+  const whole = cues.map(c => c.text).filter(Boolean).join(" ").replace(/\s+/g, " ").trim();
+  const end = duration > 0 ? duration : Math.max(1, whole.split(/\s+/).length * 0.4);
+  out += "NOTE No per-cue timings were present in the source transcript JSON; emitting an untimed transcript.\n\n";
+  out += "1\n" + fmt(0) + " --> " + fmt(end) + "\n" + (whole || "(empty transcript)") + "\n\n";
+}
+fs.writeFileSync(vttPath, out);
+
+let txt = cues.map(c => c.text).filter(Boolean).join("\n").trim();
+if (!txt && root && typeof root.text === "string") txt = root.text.trim();
+fs.writeFileSync(txtPath, txt + (txt ? "\n" : ""));
+
+console.error("Transcript converted: " + cues.filter(c => c.text).length + " segments -> " + vttPath + (anyStart ? " (timed)" : " (untimed fallback)"));
+LOOMVTT
+else
+  echo "WARN: no transcript JSON found - loom-dl may not have a transcript for this video." >&2
+  printf 'WEBVTT\n\nNOTE No transcript was produced by loom-dl for this video.\n' > "$VTT"
+  : > "$TXT"
+fi
 
 echo "Sampling frames (1 per ${FRAME_INTERVAL_SECONDS}s, max width ${FRAME_MAX_WIDTH_PX}px)..." >&2
 ffmpeg -y -i "$OUTPUT_DIR/video.mp4" \
@@ -67,7 +245,10 @@ ffmpeg -y -i "$OUTPUT_DIR/video.mp4" \
   "$OUTPUT_DIR/frame_%03d.jpg" 2>/dev/null
 
 FRAME_COUNT=$(ls "$OUTPUT_DIR"/frame_*.jpg 2>/dev/null | wc -l | tr -d ' ')
-DURATION=$(ffmpeg -i "$OUTPUT_DIR/video.mp4" 2>&1 | grep Duration | awk '{print $2}' | tr -d ',' || echo "unknown")
+# `|| true` keeps ffmpeg's nonzero exit (it has no output file) from tripping
+# pipefail; the empty-check supplies the fallback without a stray extra line.
+DURATION=$(ffmpeg -i "$OUTPUT_DIR/video.mp4" 2>&1 | grep -m1 Duration | awk '{print $2}' | tr -d ',' || true)
+[[ -z "$DURATION" ]] && DURATION="unknown"
 
 echo "Processed: $FRAME_COUNT frames, duration $DURATION" >&2
 echo "$OUTPUT_DIR"


### PR DESCRIPTION
## What

Fix the Loom Vision plugin's transcript bug found by beta tester Bart Boughton, so the transcript half of the skill works for external users, not just the internal chassis.

## The bug

`process-loom.sh` and the docs told the agent to read **`transcript.vtt`**, but the published `loom-dl` (npm, v1.1.1) with `--transcript` writes a JSON file named **`<basename>.transcript.json`**, not VTT. So `transcript.vtt` never existed and the entire transcript half of the skill silently did nothing for anyone off the internal version.

Observed real shape (loom-dl 1.1.1, schemaVersion 1.1.3):

```json
{ "schemaVersion": "1.1.3",
  "phrases": [ { "ts": 0.011, "value": "phrase text", "ranges": [ ... ] }, ... ] }
```

Timing is `ts` (float seconds, start only) - no per-phrase end field and no per-word timing. End of a cue is the next cue's start; the last cue is bounded by video duration.

## The fix

- After the download step, locate the produced `*.transcript.json` and convert it to real WebVTT at `transcript.vtt` plus plaintext at `transcript.txt`; keep the raw JSON as `transcript.json`.
- The converter is defensive about field names (`start_ts` / `startTime` / `start` / `ts`, and end equivalents), fills missing end times from the next cue, falls back to word-level data, and **always** emits a valid VTT (even timing-less) so the read-transcript step never dead-ends.
- The working **video-download path is untouched** - the `.mp4` extension on `--out` is load-bearing (loom-dl treats it as an explicit file path).
- Add `node` to the stated deps (setup.sh, manifest, SKILL.md, README) - it runs the conversion and is required by loom-dl anyway.
- Fix README's wrong script path and stale `skills/loom-vision.md` reference; document the new outputs; recommend a 2-3s frame interval for fast bug repros (5s stays default).
- Fix a latent `set -o pipefail` bug that appended a stray line to the duration readout.

Header comment credits: "transcript JSON->VTT conversion added per beta feedback from Bart Boughton, 2026-07-15."

## How it was verified

Ran the fixed script end-to-end against a real 20-minute Loom (`a2f5cb5c...`):

- video.mp4 downloaded (305 MB)
- 41 frames sampled at 30s interval
- `transcript.vtt` emitted: valid `WEBVTT` header, **81 timed cues**, last cue ends at 00:20:23.633 matching video duration
- `transcript.txt`: 81 lines of plaintext
- `transcript.json`: raw JSON kept

Defensive paths unit-tested with synthetic inputs: array + `startTime/endTime`, `segments` + `start_ts` (missing end filled), word-level start-only (grouped), timing-less phrases (valid untimed fallback), and malformed JSON (valid stub with NOTE). All produce valid VTT.

## Test plan

- [x] Real Loom processed end-to-end (video + frames + transcript.vtt + transcript.txt)
- [x] transcript.vtt is valid WebVTT, non-empty, timestamps correct
- [x] Defensive fallbacks produce valid VTT for 5 malformed/variant inputs
- [x] Video-download path unchanged
- [x] bash + JSON syntax checks pass; no em dashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
