### PR TITLE
docs(loom-vision): note ffmpeg-static npm route lacks ffprobe

### DIFF
--- a/plugins/loom-vision/README.md
+++ b/plugins/loom-vision/README.md
@@ -41,6 +41,8 @@ Setup installs three CLI dependencies:
 
 All are idempotent. Re-running setup.sh on an already-installed system is a no-op.
 
+> **Installing ffmpeg without Homebrew?** Use a full ffmpeg package - Homebrew, your distro's package manager (`apt install ffmpeg`), or the official static builds from ffmpeg.org. Avoid the `ffmpeg-static` npm module: it ships the `ffmpeg` binary alone and does not include `ffprobe`. The script still runs fine without `ffprobe` - it just can't read the exact video duration, so the last transcript cue gets an estimated end time instead of the real one. Frames, transcript text, and every earlier cue timing are unaffected.
+
 ## Usage
 
 The skill triggers automatically when the user pastes a Loom share URL or asks the agent to process Loom video content. The skill definition is in `skills/loom-vision/SKILL.md`.

--- a/plugins/loom-vision/skills/loom-vision/SKILL.md
+++ b/plugins/loom-vision/skills/loom-vision/SKILL.md
@@ -71,6 +71,8 @@ Three system CLIs are required:
 - `loom-dl` - install with `npm install -g loom-dl` (Node CLI, not on Homebrew)
 - `ffmpeg` - install with `brew install ffmpeg` (macOS) or your distro's package manager (Linux). Supplies `ffprobe`, used to bound the final transcript cue.
 
+If you install ffmpeg from something other than a full package - notably the `ffmpeg-static` npm module - you may get the `ffmpeg` binary without `ffprobe`. That is not fatal: the script detects the missing `ffprobe` and degrades gracefully, estimating the end time of the last transcript cue instead of reading the true video duration. Frames, transcript text, and all earlier cue timings are unaffected. To get exact bounding, install ffmpeg via Homebrew, your distro package manager, or the official static builds from ffmpeg.org, all of which bundle `ffprobe`.
+
 Chassis installs run `plugins/loom-vision/setup.sh` automatically during bootstrap. Standalone / ClawHub installs need to run the install commands once manually; all are idempotent.
 
 ## Why this exists


### PR DESCRIPTION
## What

Adds a note to the Loom Vision plugin docs (README + SKILL) that installing ffmpeg via the `ffmpeg-static` npm package supplies `ffmpeg` but not `ffprobe`, and steers non-Homebrew installers to a full ffmpeg package (Homebrew, distro package manager, or official static builds from ffmpeg.org).

## Why

Beta tester Bart Boughton confirmed the transcript-bug fix (PR #67) works end to end, and flagged this gap: his machine got ffmpeg through `ffmpeg-static` (no `ffprobe`). The script already degrades gracefully - without `ffprobe` it can't read exact video duration, so only the final transcript cue gets an estimated end time. Frames, transcript text, and all earlier cue timings are unaffected. Not blocking, but worth a line in the docs so the next non-Homebrew installer knows what to expect.

## Changes

- `README.md` - callout after the dependency list
- `skills/loom-vision/SKILL.md` - note in the Dependencies section

Docs only. No code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)