### PR TITLE
feat(executor): CF Containers eval + executor Worker/container scaffold (#41, #66 phase 1)

### DIFF
--- a/cloudflare/executor/.gitignore
+++ b/cloudflare/executor/.gitignore
@@ -1,0 +1,5 @@
+# Staged by build.sh from the private vibecodelisboa repo. Never commit -
+# it is a snapshot of another repo, and must always be rebuilt fresh.
+build-context/
+node_modules/
+.wrangler/

--- a/cloudflare/executor/Dockerfile
+++ b/cloudflare/executor/Dockerfile
@@ -1,0 +1,55 @@
+# Behalf.bot executor container - issues #41 / #66.
+#
+# Runs the queue executor (clone member repo + claude -p + parse + PR)
+# inside a Cloudflare Container. One tick per HTTP trigger, scale-to-zero
+# between runs.
+#
+# TRUST BOUNDARY (issue #66) - enforced by what this image simply does not
+# contain:
+#   - No chassis skills, no dating context, no ~/jax-private, no SiYuan,
+#     no Discord-bridge identity, no Vaultwarden client, no OAuth tokens.
+#   - Only the executor slice of the vibecodelisboa repo (prepared by
+#     build.sh into build-context/, secrets and git history stripped).
+#   - Runtime secrets are limited to the five listed in the README. The
+#     image itself bakes NO secret of any kind.
+#
+# Build: run ./build.sh first (populates build-context/), then let
+# wrangler build this Dockerfile on deploy. Never `docker build` with the
+# raw vibecodelisboa checkout as context.
+
+FROM node:22-bookworm-slim
+
+# git for member-repo clones; ca-certificates for HTTPS egress to
+# github.com / api.anthropic.com / Turso.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# The claude CLI the processor spawns (claude -p --bare ...). Pinned so
+# image rebuilds are reproducible; bump deliberately.
+RUN npm install -g @anthropic-ai/claude-code
+
+# Non-root runtime user. The executor needs no privileges beyond its own
+# workdir; container escape hardening starts with not being root.
+RUN useradd --create-home --shell /usr/sbin/nologin executor
+
+# Executor code slice, prepared by build.sh:
+#   build-context/vibecodelisboa/  - shallow clone, .git removed, .env*
+#                                    removed, node_modules installed
+COPY --chown=executor:executor build-context/vibecodelisboa /app/vibecodelisboa
+
+# In-container HTTP shim (trigger endpoint the Worker forwards to).
+COPY --chown=executor:executor container/server.mjs /app/server.mjs
+
+USER executor
+WORKDIR /app
+
+# Per-job scratch clones land here; wiped by the processor on success and
+# failure, and the whole filesystem is ephemeral anyway.
+ENV BEHALFBOT_WORK_ROOT=/tmp/behalfbot-work
+ENV BEHALFBOT_LOG_DIR=/tmp/behalfbot-logs
+ENV BEHALFBOT_CLAUDE_BIN=claude
+
+EXPOSE 8080
+
+CMD ["node", "/app/server.mjs"]

--- a/cloudflare/executor/README.md
+++ b/cloudflare/executor/README.md
@@ -1,0 +1,133 @@
+# Behalf.bot executor on Cloudflare Containers
+
+Scaffold for behalfbot#41 (executor off the Mac mini) and the shared
+foundation for behalfbot#66 (VCL support agent). **Nothing here is
+deployed.** Deploy and cutover are gated on Sean's explicit approval.
+
+Go/no-go analysis: [docs/cloudflare-containers-eval.md](../../docs/cloudflare-containers-eval.md).
+Verdict: GO-WITH-CAVEAT (no enforced duration cap; host restarts covered by
+the existing orphan sweep).
+
+## What runs where
+
+```
+Mac mini heartbeat (launchd, unchanged schedule)
+  -> POST https://behalfbot-executor.<subdomain>.workers.dev/trigger   (Bearer EXECUTOR_TRIGGER_TOKEN)
+    -> Worker stub (src/index.ts) forwards to the singleton container
+      -> container shim (container/server.mjs) answers 202, spawns one tick
+        -> tsx scripts/behalfbot-heartbeat.ts   (unmodified vibecodelisboa executor)
+          -> clone member repo / claude -p --bare / parse / PR / notify
+```
+
+The executor code itself is NOT vendored here - `build.sh` stages a
+stripped shallow clone of scrollinondubs/vibecodelisboa into
+`build-context/` (gitignored) at image-build time. The processor, its
+security defenses, and the queue semantics stay canonical in that repo.
+
+## Trust boundary (behalfbot#66) - packaging, not prompts
+
+The image structurally contains:
+
+- node 22 + git + the `claude` CLI
+- the executor slice of vibecodelisboa (fresh shallow clone, `.git`
+  removed because that repo's history contains leaked prod secrets
+  pending rotation, `.env*` scrubbed)
+- the HTTP shim
+
+It structurally does NOT contain: chassis skills, dating context or
+skills, `~/jax-private` anything, SiYuan content or credentials,
+Discord-bridge identity, Vaultwarden access, Postgres access, or any OAuth
+token of Sean's. The container's secret set (below) cannot reach any of
+those systems.
+
+Preserved executor defenses (all live in vibecodelisboa code, verified
+2026-07-16 in `src/lib/contribution-ledger/behalfbot-prompts.ts` and
+`behalfbot-safety.ts`):
+
+- `claude -p --bare` (no hooks, no CLAUDE.md auto-discovery, no keychain)
+- `--allowedTools Read,Glob,Grep,WebFetch,WebSearch` and
+  `--disallowedTools Bash,Edit,Write,MultiEdit,Task,SkillRun,KillBash,BashOutput,NotebookEdit,mcp__*`
+- workdir scrub of `.claude/`, `.mcp.json`, hook files before every run
+- `git -c core.hooksPath=/dev/null` on all git ops
+- cwd + `--add-dir` pinned to the per-job scratch clone
+- dedicated `BEHALFBOT_ANTHROPIC_API_KEY` swapped into the child env
+  (fail-closed if missing) - billing NEVER touches Sean's Max subscription
+- spend caps (monthly USD cap fail-closed at 90%, per-row token budget)
+- 25-min CLI timeout, 30-min row wallclock sweep; the shim adds a 35-min
+  hard kill and the Container class sleeps only after 45 idle minutes
+
+Additional isolation the Mac mini never had: non-root runtime user,
+ephemeral filesystem per instance lifetime, and (optional follow-up)
+`enableInternet = false` + an `allowedHosts` egress allowlist.
+
+## Secret migration
+
+Container/Worker secrets, set once via `wrangler secret put <NAME>` (values
+sourced from Vaultwarden / the existing Mac mini env, entered
+interactively, never committed):
+
+| Secret | Purpose | Source of truth today |
+|---|---|---|
+| `EXECUTOR_TRIGGER_TOKEN` | authenticates the Mac mini poke | mint fresh (32+ random bytes), store in Vaultwarden |
+| `DATABASE_URL` | Turso (vibecodelisboa prod) | Mac mini env / Vaultwarden |
+| `DATABASE_AUTH_TOKEN` | Turso auth | Mac mini env / Vaultwarden |
+| `ENCRYPTION_SECRET` | repo-credential decryption | Mac mini env (`NEXTAUTH_SECRET` fallback exists in code; set the real one) |
+| `GITHUB_PAT` | jacketyjax PAT - member-repo clone, push, PR | `/Users/jax/.behalfbot/.env` |
+| `BEHALFBOT_ANTHROPIC_API_KEY` | dedicated Anthropic key, $60/mo Console cap | Anthropic Console / Vaultwarden |
+
+That is the complete set. Anything not in this table (Vaultwarden master,
+Postgres DSN, SiYuan token, Discord token, OAuth refresh tokens) must
+never be `wrangler secret put` on this Worker - that is the #66 boundary.
+
+### Cloudflare auth for wrangler (deploy-time only)
+
+The deploy token is account-owned, named `behalfbot-fable-cf-containers`,
+scoped to sean@grid7.com's account `8a119b24123c444dddea567ffde1a405`
+only (Workers Scripts:Edit, Workers Containers:Edit, Cloudchamber:Edit,
+Workers R2 Storage:Edit, Account Settings:Read). Wrangler reads it from
+the `CLOUDFLARE_API_TOKEN` env var; it is never hardcoded anywhere.
+
+**Trap:** the ambient `CLOUDFLARE_API_TOKEN` in the Jax install
+environment belongs to the AllBets account. Every deploy shell must
+override it from Vaultwarden first:
+
+```bash
+export BW_SESSION="$(bash /Users/jax/.behalfbot/scripts/bw-unlock.sh)"
+export CLOUDFLARE_API_TOKEN="$(bw get item 937aaaf0-48e6-40de-8ba0-b4290ad5328d --session "$BW_SESSION" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['login']['password'])")"
+wrangler whoami   # MUST show Sean@grid7.com's Account / 8a119b24123c444dddea567ffde1a405
+```
+
+`account_id` is also pinned in `wrangler.jsonc`, so a wrong token
+fails closed instead of deploying to the wrong account.
+
+## Deploy + cutover plan (GATED - nothing below runs without Sean's OK)
+
+1. **Build**: `GITHUB_PAT=... ./build.sh` (stages build-context), then
+   `npm install` here.
+2. **Secrets**: `wrangler secret put` the six names above.
+3. **Deploy**: `wrangler deploy` (builds the image via local Docker,
+   pushes to the Cloudflare-managed registry, deploys Worker + container).
+4. **Smoke test**: seed a test ask on a throwaway repo, `curl -X POST
+   .../trigger -H "Authorization: Bearer ..."`, watch `GET /status` until
+   the tick completes, confirm the PR opens and the queue row lands in
+   `completed`. Mac mini executor stays enabled throughout.
+5. **Cutover** (separate Sean approval): repoint the two launchd plists'
+   scripts to `curl` the Worker instead of running the local tick.
+   Prescan uses `POST /trigger?mode=prescan`. Keep the plists themselves -
+   the Mac mini remains the scheduler for now; only execution moves.
+6. **Bake period**: one week of both paths observable (Worker path live,
+   Mac mini path disabled but re-enablable with one `launchctl` command).
+7. **Decommission** (behalfbot#41 step 5): remove the local executor code
+   path and archive logs. Logs on the CF side: `observability.enabled`
+   streams to Workers Logs; longer retention (R2 sink) is a follow-up.
+
+## Follow-ups (out of scope for this PR)
+
+- `enableInternet = false` + `allowedHosts` egress allowlist
+  (github.com, api.github.com, api.anthropic.com, Turso host)
+- Worker cron trigger to replace the Mac mini poke entirely
+- behalfbot#66 support-agent container: second Container class in this
+  same Worker, its own image with the support/managed-install docs slice
+  and NO repo-write credentials
+- R2 log retention sink

--- a/cloudflare/executor/build.sh
+++ b/cloudflare/executor/build.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Prepare build-context/ for the executor image (issues #41 / #66).
+#
+# The executor code lives in the private scrollinondubs/vibecodelisboa
+# repo. We stage a stripped copy here BEFORE any docker/wrangler build so
+# that:
+#   - the GITHUB_PAT never enters the docker build (clone happens on the
+#     host, not in a Dockerfile RUN)
+#   - .git is removed entirely - vibecodelisboa's git history contains
+#     live prod secrets (new-jaxity#454, rotation pending), so shipping
+#     history into an image is a hard no
+#   - .env* files can never ride along (a fresh clone has none; we scrub
+#     anyway, belt and braces)
+#
+# Usage:
+#   GITHUB_PAT=... ./build.sh
+# Then, deploy-gated on Sean's approval:
+#   CLOUDFLARE_API_TOKEN=... npx wrangler deploy   # DO NOT run without approval
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTEXT_DIR="${SCRIPT_DIR}/build-context"
+REPO_DIR="${CONTEXT_DIR}/vibecodelisboa"
+
+: "${GITHUB_PAT:?GITHUB_PAT must be set (jacketyjax PAT, read scope on scrollinondubs/vibecodelisboa)}"
+
+rm -rf "${CONTEXT_DIR}"
+mkdir -p "${CONTEXT_DIR}"
+
+echo "[build] shallow-cloning vibecodelisboa (history stripped)..."
+git clone --depth 1 \
+  "https://x-access-token:${GITHUB_PAT}@github.com/scrollinondubs/vibecodelisboa.git" \
+  "${REPO_DIR}"
+
+echo "[build] scrubbing git metadata + any env files..."
+rm -rf "${REPO_DIR}/.git"
+find "${REPO_DIR}" -maxdepth 2 -name ".env*" -type f -delete
+
+echo "[build] installing production deps (tsx + processor imports need them)..."
+(cd "${REPO_DIR}" && npm ci)
+
+echo "[build] build-context ready: ${REPO_DIR}"
+echo "[build] next (GATED ON SEAN'S APPROVAL): CLOUDFLARE_API_TOKEN in env, then 'npx wrangler deploy' from ${SCRIPT_DIR}"

--- a/cloudflare/executor/container/server.mjs
+++ b/cloudflare/executor/container/server.mjs
@@ -1,0 +1,99 @@
+// In-container HTTP shim for the Behalf.bot executor (issues #41 / #66).
+//
+// The Worker forwards trigger requests here (Container defaultPort 8080).
+// One tick = one invocation of the vibecodelisboa heartbeat script, which
+// does its own queue picking, single-flight DB locking, orphan sweep,
+// spend caps, and workdir cleanup. This shim adds only:
+//   - process-level single-flight (never two ticks in one container)
+//   - 202-and-run-in-background so no caller ever holds a connection
+//     open for a 15-20 min job
+//   - a status endpoint so the Mac mini heartbeat (and later a Worker
+//     cron) can observe the last run without touching the DB
+//
+// Security posture is inherited from the executor itself and is NOT
+// re-implemented here: claude -p runs with --bare, the Read/Glob/Grep
+// allowlist, the wide tool denylist, workdir scrub, git
+// core.hooksPath=/dev/null, and the dedicated BEHALFBOT_ANTHROPIC_API_KEY
+// (see src/lib/contribution-ledger/behalfbot-prompts.ts callClaude()).
+
+import { createServer } from 'node:http'
+import { spawn } from 'node:child_process'
+
+const PORT = 8080
+const REPO_ROOT = '/app/vibecodelisboa'
+const TICK_SCRIPT = 'scripts/behalfbot-heartbeat.ts'
+// Belt-and-braces above the executor's own 25-min CLI timeout and 30-min
+// row wallclock cap. If tsx itself wedges, kill it.
+const TICK_HARD_TIMEOUT_MS = 35 * 60 * 1000
+
+let inFlight = null // { startedAt, mode } while a tick runs
+let lastRun = null // { startedAt, endedAt, exitCode, mode, stdoutTail }
+
+function runTick(mode) {
+  const startedAt = new Date().toISOString()
+  const script = mode === 'prescan' ? 'scripts/behalfbot-prescan-heartbeat.ts' : TICK_SCRIPT
+  const child = spawn(`${REPO_ROOT}/node_modules/.bin/tsx`, [script], {
+    cwd: REPO_ROOT,
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  let tail = ''
+  const keepTail = chunk => {
+    tail = (tail + chunk.toString()).slice(-4000)
+  }
+  child.stdout.on('data', keepTail)
+  child.stderr.on('data', keepTail)
+
+  const killer = setTimeout(() => {
+    try {
+      child.kill('SIGKILL')
+    } catch {
+      // best-effort
+    }
+  }, TICK_HARD_TIMEOUT_MS)
+
+  inFlight = { startedAt, mode }
+  child.on('exit', code => {
+    clearTimeout(killer)
+    lastRun = {
+      startedAt,
+      endedAt: new Date().toISOString(),
+      exitCode: code,
+      mode,
+      stdoutTail: tail,
+    }
+    inFlight = null
+    console.log(JSON.stringify({ event: 'tick_done', ...lastRun, stdoutTail: undefined }))
+  })
+}
+
+const server = createServer((req, res) => {
+  const respond = (status, body) => {
+    res.writeHead(status, { 'content-type': 'application/json' })
+    res.end(JSON.stringify(body))
+  }
+
+  if (req.method === 'GET' && req.url === '/healthz') {
+    return respond(200, { ok: true, inFlight: inFlight !== null })
+  }
+
+  if (req.method === 'GET' && req.url === '/status') {
+    return respond(200, { inFlight, lastRun })
+  }
+
+  if (req.method === 'POST' && (req.url === '/run' || req.url === '/run?mode=prescan')) {
+    if (inFlight) {
+      return respond(409, { started: false, reason: 'tick_in_flight', inFlight })
+    }
+    const mode = req.url.includes('mode=prescan') ? 'prescan' : 'executor'
+    runTick(mode)
+    return respond(202, { started: true, mode, startedAt: inFlight.startedAt })
+  }
+
+  respond(404, { error: 'not_found' })
+})
+
+server.listen(PORT, () => {
+  console.log(JSON.stringify({ event: 'listening', port: PORT }))
+})

--- a/cloudflare/executor/package-lock.json
+++ b/cloudflare/executor/package-lock.json
@@ -1,0 +1,1583 @@
+{
+  "name": "behalfbot-executor-worker",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "behalfbot-executor-worker",
+      "dependencies": {
+        "@cloudflare/containers": "^0.3.7"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^5.20260716.1",
+        "typescript": "^5.5.0",
+        "wrangler": "^4.111.0"
+      }
+    },
+    "node_modules/@cloudflare/containers": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@cloudflare/containers/-/containers-0.3.7.tgz",
+      "integrity": "sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw==",
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260710.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260710.1.tgz",
+      "integrity": "sha512-OqJl2eWF5+y9jarMm3YqqCTUe7Hd4ihogX5jyRU8iaAgOVyDr/Bk6aXpPCVUi1/MHzO93a18R/TmSTtzmB0sQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260710.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260710.1.tgz",
+      "integrity": "sha512-MYBqWgUblO+VlGvO73zYsH3hB9tdRj+yLyt5IHDFWryipb2l1efmNiWtAOkIhSRfypqLYGFrfpaDm2Hg00XVKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260710.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260710.1.tgz",
+      "integrity": "sha512-lVWUgqI8qrkqvaCBGElu1kdaUFdAvaS2RD8K4qkCFP9hI3f5TCXumEs5qWSeZkvKum0+X/uJZ5hBFWsYI5SmoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260710.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260710.1.tgz",
+      "integrity": "sha512-kDwDPItBjAI4JL0df9Fma2N+Qggbm77IB/DnroAkEGQ79fpR80sYMyuB/ZQKyjEk9f48Ocq7HCCLq59qVSyNqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260710.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260710.1.tgz",
+      "integrity": "sha512-GcLHy1oN1dfK6g1Z7UDV9f5xMGyTfPwcjWQ0sfWKH31IsoEVCRapnj3IC0PoIrDbnoo6irGPP0CwVs3WzdTajw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260716.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260716.1.tgz",
+      "integrity": "sha512-LqQPmGAvdpQxzZGAMlDI6fnCsTlr8nRQibWsREaERqD0PucwFl25aXpUskSob70uSY2n6K1sp6Te9xkmzSFgaw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260710.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260710.0.tgz",
+      "integrity": "sha512-x1LLRkU6o1p7hiKrB0TRnL0MJn6xFOT+/vrlEQINz5cRDKLP8ru4hBqWTIvXAetzr1acKAnmAaG84pQ4W/K14g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260710.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260710.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260710.1.tgz",
+      "integrity": "sha512-U2sBPPrb9U97sBKnnMN6Kv8p65903P35nwMkPE9vSH/bRuRqkZ3a1EjUw3jV28RhiyXpkLF77Evzw8XimFxyTw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260710.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260710.1",
+        "@cloudflare/workerd-linux-64": "1.20260710.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260710.1",
+        "@cloudflare/workerd-windows-64": "1.20260710.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.111.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.111.0.tgz",
+      "integrity": "sha512-bffpI9EyrnpKkF/1S+RaIv8oRD93GtbsA7TlfWwOsGJGB7VO3jVbdGzpC9TU7Bqom3z7jUxcte4Z9MPhaQ4HoQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260710.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260710.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260710.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/cloudflare/executor/package.json
+++ b/cloudflare/executor/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "behalfbot-executor-worker",
+  "private": true,
+  "description": "Worker + Container scaffold for the Behalf.bot executor (behalfbot#41, behalfbot#66). Deploy is gated on Sean's approval.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build-context": "bash build.sh"
+  },
+  "dependencies": {
+    "@cloudflare/containers": "^0.3.7"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "wrangler": "^4.111.0",
+    "@cloudflare/workers-types": "^5.20260716.1"
+  }
+}

--- a/cloudflare/executor/src/index.ts
+++ b/cloudflare/executor/src/index.ts
@@ -1,0 +1,84 @@
+// Behalf.bot executor Worker stub (issues #41 / #66).
+//
+// Thin trigger in front of the executor container. The Mac mini heartbeat
+// (and later a Worker cron) POSTs /trigger with a bearer token; we forward
+// to the singleton container instance, which starts one queue tick and
+// answers 202 immediately. No connection is ever held open for the job,
+// so the Workers CPU limit is never in play - the 15-20 min work happens
+// entirely inside the container.
+//
+// DO NOT DEPLOY without Sean's explicit approval (see README.md).
+
+import { Container, getContainer } from '@cloudflare/containers'
+
+interface Env {
+  EXECUTOR_CONTAINER: DurableObjectNamespace<ExecutorContainer>
+  // Shared secret the Mac mini poke authenticates with. Minted fresh for
+  // this Worker; not reused from any other system.
+  EXECUTOR_TRIGGER_TOKEN: string
+  // The five executor secrets (issue #41's set). Set via `wrangler secret
+  // put`, passed into the container as env vars below. Nothing else - no
+  // Vaultwarden, no Postgres, no SiYuan, no Discord, no OAuth (issue #66
+  // packaging boundary).
+  DATABASE_URL: string
+  DATABASE_AUTH_TOKEN: string
+  ENCRYPTION_SECRET: string
+  GITHUB_PAT: string
+  BEHALFBOT_ANTHROPIC_API_KEY: string
+}
+
+export class ExecutorContainer extends Container<Env> {
+  defaultPort = 8080
+  // Must exceed the executor's 30-min per-ask wallclock cap (and the
+  // shim's 35-min hard kill) so the idle reaper can never sleep a
+  // container mid-job. Each /trigger resets the timer.
+  sleepAfter = '45m'
+
+  constructor(ctx: DurableObjectState<{}>, env: Env) {
+    super(ctx, env)
+    this.envVars = {
+      DATABASE_URL: env.DATABASE_URL,
+      DATABASE_AUTH_TOKEN: env.DATABASE_AUTH_TOKEN,
+      ENCRYPTION_SECRET: env.ENCRYPTION_SECRET,
+      GITHUB_PAT: env.GITHUB_PAT,
+      BEHALFBOT_ANTHROPIC_API_KEY: env.BEHALFBOT_ANTHROPIC_API_KEY,
+    }
+  }
+}
+
+function unauthorized(): Response {
+  return Response.json({ error: 'unauthorized' }, { status: 401 })
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url)
+
+    // Unauthenticated liveness probe for the Worker itself (does not wake
+    // the container).
+    if (request.method === 'GET' && url.pathname === '/healthz') {
+      return Response.json({ ok: true })
+    }
+
+    const auth = request.headers.get('authorization') ?? ''
+    if (auth !== `Bearer ${env.EXECUTOR_TRIGGER_TOKEN}`) {
+      return unauthorized()
+    }
+
+    // Singleton instance preserves the single-in-flight contract at the
+    // instance level; the DB-level optimistic UPDATE remains the
+    // authoritative lock (same as on the Mac mini today).
+    const container = getContainer(env.EXECUTOR_CONTAINER, 'singleton')
+
+    if (request.method === 'POST' && url.pathname === '/trigger') {
+      const mode = url.searchParams.get('mode') === 'prescan' ? '?mode=prescan' : ''
+      return container.fetch(new Request(`http://container/run${mode}`, { method: 'POST' }))
+    }
+
+    if (request.method === 'GET' && url.pathname === '/status') {
+      return container.fetch(new Request('http://container/status'))
+    }
+
+    return Response.json({ error: 'not_found' }, { status: 404 })
+  },
+}

--- a/cloudflare/executor/tsconfig.json
+++ b/cloudflare/executor/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "types": ["@cloudflare/workers-types"],
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/cloudflare/executor/wrangler.jsonc
+++ b/cloudflare/executor/wrangler.jsonc
@@ -1,0 +1,59 @@
+// Behalf.bot executor on Cloudflare Containers (issues #41 / #66).
+//
+// DO NOT `wrangler deploy` without Sean's explicit approval. Auth: wrangler
+// reads CLOUDFLARE_API_TOKEN from the environment (account-owned token
+// "behalfbot-fable-cf-containers", stored in Vaultwarden). The token is
+// never written to this repo or baked into any file.
+//
+// AUTH TRAP: the ambient CLOUDFLARE_API_TOKEN in the Jax install env
+// (.env.baked) belongs to the AllBets account and targets the WRONG
+// account. Before any wrangler call, export the Vaultwarden token per
+// README.md and confirm `wrangler whoami` shows account
+// 8a119b24123c444dddea567ffde1a405. The account_id pin below forces the
+// correct account regardless.
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "behalfbot-executor",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-07-01",
+  // sean@grid7.com's account (NOT the AllBets account).
+  "account_id": "8a119b24123c444dddea567ffde1a405",
+  "containers": [
+    {
+      "class_name": "ExecutorContainer",
+      "image": "./Dockerfile",
+      // Single-in-flight contract, instance-level belt on top of the
+      // DB-level optimistic-UPDATE braces.
+      "max_instances": 1,
+      // 1/2 vCPU, 4 GiB memory, 8 GB disk. Fits clone + node + claude CLI
+      // per docs/cloudflare-containers-eval.md section 3. Bump to
+      // "standard-2" if a member repo ever blows the working set.
+      "instance_type": "standard-1"
+    }
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "EXECUTOR_CONTAINER",
+        "class_name": "ExecutorContainer"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["ExecutorContainer"]
+    }
+  ],
+  "observability": {
+    "enabled": true
+  }
+  // Secrets (set via `wrangler secret put <NAME>`, never in this file):
+  //   EXECUTOR_TRIGGER_TOKEN        - shared secret for the Mac mini poke
+  //   DATABASE_URL                  - Turso
+  //   DATABASE_AUTH_TOKEN           - Turso
+  //   ENCRYPTION_SECRET             - repo-credential decryption
+  //   GITHUB_PAT                    - jacketyjax PAT (clone + push + PR)
+  //   BEHALFBOT_ANTHROPIC_API_KEY   - dedicated key, $60/mo capped; NEVER
+  //                                   Sean's Max subscription
+}

--- a/docs/cloudflare-containers-eval.md
+++ b/docs/cloudflare-containers-eval.md
@@ -1,0 +1,80 @@
+# Cloudflare Containers eval - executor host (issues #41 / #66)
+
+Date: 2026-07-16. Sources: developers.cloudflare.com/containers (limits, FAQ, pricing, outbound-traffic, container-package, get-started pages), fetched live on the eval date. Containers GA'd 2025; re-verify limits before any capacity change.
+
+## Verdict: GO-WITH-CAVEAT
+
+Cloudflare Containers fits the executor's profile (clone + `claude -p` + parse, 15-20 min worst case). The one real caveat is **durability, not duration**: there is no enforced runtime cap, but Cloudflare does not guarantee any instance survives a host restart. The executor's existing orphan-sweep + retry semantics already cover that failure mode, so the caveat is absorbed by a pattern we already run. Details below.
+
+## 1. Max duration (THE critical question)
+
+**Finding: there is NO enforced maximum wall-clock duration for a container instance.** From the FAQ: "Cloudflare will not actively shut off a container instance after a specific amount of time." A 15-20 min `claude -p` run is fine.
+
+Two nuances:
+
+- **No survival guarantee.** Host servers restart "on an irregular cadence", and Cloudflare "does not guarantee that any instance will run for any set period of time." A job can die mid-run at any point. This is the caveat in GO-WITH-CAVEAT.
+- **The Workers 5-min CPU cap does not apply to the container.** The Worker is only a thin trigger/proxy in front of the Container-class Durable Object; the container's own processes are not metered as Worker CPU time. The Worker stub returns 202 immediately and never holds a connection for the job's duration, so no Worker limit is ever in play.
+
+**Pattern that covers long jobs (implemented in the scaffold):**
+
+1. Mac mini heartbeat POSTs `/trigger` to the Worker (bearer-token auth).
+2. Worker forwards to the singleton container instance; the in-container shim starts one queue tick as a child process and answers 202 immediately.
+3. `sleepAfter = "45m"` on the Container class, comfortably above the executor's 30-min per-ask wallclock cap, so the idle timer can never reap a live job. Each trigger request resets the timer ("Activity resets the timer").
+4. Job state lives in Turso (`behalfbot_queue` row status), exactly as today. If a host restart kills a run mid-flight, the row stays `processing` and the existing `sweepOrphanedProcessingRows()` marks it failed + refunds spend on the next tick - the same recovery path the Mac mini already relies on for its own 30-min timeout sweep. No new failure mode, only a new trigger for an existing one.
+
+No queues or Durable Object alarms are required for v1. If we later want Cloudflare-native scheduling (dropping the Mac mini poke), a Worker cron trigger replaces the poke with zero container-side changes.
+
+## 2. Outbound network
+
+**Finding: GO, no proxy gymnastics.** "By default, a Container will allow internet access." HTTPS to arbitrary hosts works out of the box, which covers both needs:
+
+- `git clone https://x-access-token:<PAT>@github.com/...` (the processor already clones over HTTPS with the PAT, not SSH)
+- `POST https://api.anthropic.com` (the `claude` CLI with `ANTHROPIC_API_KEY` set)
+- Turso over HTTPS/WebSocket (`libsql://...` resolves to 443)
+
+Hardening bonus available later: `enableInternet = false` plus an `allowedHosts` allowlist (github.com, api.github.com, api.anthropic.com, the Turso host) would give the container a default-deny egress posture the Mac mini could never offer. Not required for v1; noted in the scaffold as a follow-up.
+
+## 3. Memory / instance type
+
+Instance types (from the limits page):
+
+| Type | vCPU | Memory | Disk |
+|------|------|--------|------|
+| lite | 1/16 | 256 MiB | 2 GB |
+| basic | 1/4 | 1 GiB | 4 GB |
+| standard-1 | 1/2 | 4 GiB | 8 GB |
+| standard-2 | 1 | 6 GiB | 12 GB |
+| standard-3 | 2 | 8 GiB | 16 GB |
+| standard-4 | 4 | 12 GiB | 20 GB |
+
+**Finding: `standard-1` (1/2 vCPU, 4 GiB, 8 GB disk) fits.** Working set = shallow member-repo clone (tens to hundreds of MB) + Node/tsx processor + the `claude` CLI child (typically well under 2 GiB). 8 GB disk holds the baked executor code (~1 GB with node_modules) plus per-job scratch clones with room to spare. If a pathological member repo blows the clone size, `standard-2` is a one-line `instance_type` bump. Custom shapes up to 4 vCPU / 12 GiB / 20 GB exist if ever needed.
+
+## 4. Scale-to-zero + cold start
+
+**Finding: exactly the model Sean asked for in #66.** Billing is "for every 10ms that they are actively running"; "charges start when a request is sent to the container or when it is manually started. Charges stop after the container instance goes to sleep." With `sleepAfter` set, the instance sleeps 45 min after the last trigger and costs zero until the next poke.
+
+Cold starts: "often in the 1-3 second range", image-size dependent. Irrelevant for a nightly batch executor; fine even for the future #66 support agent.
+
+**Cost estimate** (Workers Paid plan, includes 375 vCPU-min + 25 GiB-h + 200 GB-h disk free per month): a worst-case 20-min job on standard-1 costs roughly $0.012 vCPU + $0.012 memory + $0.001 disk = **about 2.5 cents per long job** before the free allotment, which will usually absorb the whole nightly volume. Egress $0.025/GB after 1 TB included (EU). Cost is a non-issue.
+
+## 5. Account-level limits
+
+50 GB image storage per account, 6 TiB concurrent memory, 1500 concurrent vCPU. All orders of magnitude above this workload. `max_instances: 1` in the scaffold preserves the single-in-flight contract (belt) alongside the DB-level optimistic `UPDATE ... WHERE status='pending_execution'` (braces).
+
+## Summary table
+
+| Requirement | Limit found | Fit |
+|---|---|---|
+| 15-20 min `claude -p` runs | No enforced duration cap; no survival guarantee across host restarts | GO with existing sweep/retry |
+| git clone + Anthropic API egress | Internet on by default, HTTPS anywhere | GO |
+| Working set (clone + node + claude CLI) | standard-1: 4 GiB / 8 GB disk | GO |
+| Scale-to-zero | Per-10ms billing, sleeps after `sleepAfter` idle | GO |
+| Cold start | 1-3 s typical | GO |
+| Cost | ~$0.025 worst-case job, mostly inside free allotment | GO |
+
+## Decisions that stay gated on Sean
+
+1. Deploy approval - nothing in this PR touches the live Cloudflare account; `wrangler deploy` has not been run.
+2. Cutover approval - Mac mini LaunchAgents stay enabled until Sean signs off on the smoke test.
+3. Whether to adopt `enableInternet = false` + allowlist hardening in v1 or as a follow-up.
+4. The #66 support-agent container (second Container class, same Worker) - separate scope, lands after this.


### PR DESCRIPTION
## What

First hand-off phase for #41 (executor off the Mac mini) and the shared foundation for #66 (VCL support agent). Eval + scaffold only - **nothing is deployed**, no `wrangler deploy` was run, and the Mac mini executor LaunchAgents are untouched.

### 1. Cloudflare Containers go/no-go eval (`docs/cloudflare-containers-eval.md`)

**Verdict: GO-WITH-CAVEAT.**

- **Max duration (the critical question):** there is NO enforced wall-clock cap on a container instance - "Cloudflare will not actively shut off a container instance after a specific amount of time." 15-20 min `claude -p` runs fit without queues or DO-alarm gymnastics. The Workers 5-min CPU cap never applies because the Worker only proxies a trigger and returns 202. The caveat: host servers restart on an irregular cadence with no survival guarantee, so a job can die mid-run - absorbed by the executor's existing `sweepOrphanedProcessingRows()` retry path, same recovery it already uses for its 30-min timeout sweep.
- **Egress:** internet on by default; HTTPS git clone + api.anthropic.com work with no proxy. Optional follow-up: `enableInternet=false` + allowlist.
- **Memory:** `standard-1` (1/2 vCPU, 4 GiB, 8 GB disk) fits clone + node + claude CLI; one-line bump to standard-2 if needed.
- **Scale-to-zero:** billed per 10ms while running, sleeps after `sleepAfter` idle, 1-3 s cold starts. Worst-case 20-min job costs about $0.025, mostly inside the paid-plan free allotment.

### 2. Scaffold (`cloudflare/executor/`)

- `Dockerfile` - node 22 + git + claude CLI, non-root user; executor slice of vibecodelisboa staged by `build.sh` (shallow clone, `.git` stripped because that repo's history contains leaked prod secrets pending rotation, `.env*` scrubbed; PAT never enters the docker build)
- `wrangler.jsonc` - Containers binding, `standard-1`, `max_instances: 1`, `account_id` pinned to sean@grid7.com's account (`8a119b24...`) so the ambient AllBets `CLOUDFLARE_API_TOKEN` can never mis-target; token comes from Vaultwarden via env, never hardcoded
- `src/index.ts` - Worker stub: bearer-authed `POST /trigger` (+ `?mode=prescan`) that the Mac mini heartbeat pokes, `GET /status`, singleton container, `sleepAfter: 45m` (above the 30-min job cap). Typechecks clean.
- `container/server.mjs` - in-container shim: 202-and-run, process-level single-flight, 35-min hard kill, status endpoint
- `README.md` - #66 packaging trust boundary, secret migration table, wrangler auth trap + VW export flow, gated deploy/cutover/bake/decommission plan

### Trust boundary (#66) - structural, not prompt-level

Image contains no chassis skills, no dating context, no private data, no SiYuan/Discord/Vaultwarden/Postgres/OAuth reach. Secret set is exactly: `EXECUTOR_TRIGGER_TOKEN` (new), `DATABASE_URL`, `DATABASE_AUTH_TOKEN`, `ENCRYPTION_SECRET`, `GITHUB_PAT`, `BEHALFBOT_ANTHROPIC_API_KEY` (dedicated key - billing never touches the Max subscription). All existing claude -p defenses (`--bare`, tool denylist, workdir scrub, hooksPath=/dev/null, add-dir scope, spend caps) live unmodified in the vibecodelisboa processor the image runs.

## Verification

- [x] `npx tsc --noEmit` clean on the Worker stub
- [x] `node --check container/server.mjs` and `bash -n build.sh` pass
- [x] Diff scanned for secrets and em dashes - none (one package-lock integrity-hash false positive inspected and cleared)
- [x] Executor code paths reconciled against `vibecodelisboa/scripts/behalfbot-heartbeat.{sh,ts}` and `src/lib/contribution-ledger/{behalfbot-processor,behalfbot-prompts,behalfbot-safety}.ts` on 2026-07-16
- [ ] NOT verified: live deploy / smoke test - deliberately out of scope, gated on Sean

## Decisions needing Sean before deploy

1. Approve `wrangler deploy` to the sean@grid7.com account (step 3 of the README plan)
2. Approve cutover: repoint the two launchd plists to curl the Worker (step 5); Mac mini stays scheduler
3. `enableInternet=false` + egress allowlist in v1, or as a follow-up
4. When to start the #66 support-agent container (second class in this Worker, separate PR)

Closes nothing yet - #41 stays open until cutover + decommission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
