### PR TITLE
fix(executor): install npm deps inside the image, not on the build host

### DIFF
--- a/cloudflare/executor/Dockerfile
+++ b/cloudflare/executor/Dockerfile
@@ -35,7 +35,21 @@ RUN useradd --create-home --shell /usr/sbin/nologin executor
 
 # Executor code slice, prepared by build.sh:
 #   build-context/vibecodelisboa/  - shallow clone, .git removed, .env*
-#                                    removed, node_modules installed
+#                                    removed, NO node_modules (installed
+#                                    below so platform binaries match the
+#                                    linux image, not the macOS build host)
+#
+# Manifests first so the dependency layer caches across source-only
+# rebuilds. npm install (not ci) because the repo lockfile is currently
+# out of sync with package.json (missing platform optionals); dev deps
+# included on purpose - tsx is a devDependency and the shim spawns it.
+COPY build-context/vibecodelisboa/package.json build-context/vibecodelisboa/package-lock.json /app/vibecodelisboa/
+# HUSKY=0: the repo's prepare script runs husky, which fails in a context
+# with no .git (build.sh strips it).
+RUN cd /app/vibecodelisboa \
+  && HUSKY=0 npm install --no-audit --no-fund \
+  && npm cache clean --force
+
 COPY --chown=executor:executor build-context/vibecodelisboa /app/vibecodelisboa
 
 # In-container HTTP shim (trigger endpoint the Worker forwards to).

--- a/cloudflare/executor/build.sh
+++ b/cloudflare/executor/build.sh
@@ -37,8 +37,11 @@ echo "[build] scrubbing git metadata + any env files..."
 rm -rf "${REPO_DIR}/.git"
 find "${REPO_DIR}" -maxdepth 2 -name ".env*" -type f -delete
 
-echo "[build] installing production deps (tsx + processor imports need them)..."
-(cd "${REPO_DIR}" && npm ci)
+# node_modules is deliberately NOT installed here. The image targets
+# linux/amd64; a host-side install on the macOS arm64 Mac mini would bake
+# darwin binaries (esbuild, @libsql, sqlite-vec) into the image and tsx
+# would fail at runtime. The Dockerfile runs npm install inside the image
+# instead, so platform-specific optional deps resolve for the container.
 
 echo "[build] build-context ready: ${REPO_DIR}"
 echo "[build] next (GATED ON SEAN'S APPROVAL): CLOUDFLARE_API_TOKEN in env, then 'npx wrangler deploy' from ${SCRIPT_DIR}"


### PR DESCRIPTION
## What changed

- `cloudflare/executor/build.sh`: drop the host-side `npm ci` when staging the vibecodelisboa build context
- `cloudflare/executor/Dockerfile`: install deps inside the image instead - manifests copied first so the dependency layer caches across source-only rebuilds, `HUSKY=0 npm install` (not `ci`), then the source COPY

## Why

Found while executing the approved deploy for #41. The merged scaffold (#69) could not produce a working image:

1. `npm ci` aborts - the vibecodelisboa lockfile is out of sync with package.json (`Missing: sqlite-vec-linux-arm64@ from lock file`), so `build.sh` never completed
2. Even past that, a host-side install on the macOS arm64 Mac mini selects darwin-arm64 optional deps (esbuild, @libsql, sqlite-vec) which then ship into a linux/amd64 image - `tsx` would fail at container runtime on the platform mismatch

`npm install` instead of `npm ci` is deliberate until the upstream vibecodelisboa lockfile is regenerated (tracked there, not here). `HUSKY=0` because the repo's `prepare` script runs husky, which needs the `.git` that build.sh deliberately strips for secret-history reasons.

## Test plan

- [x] `./build.sh` completes (clone + scrub only, no host install)
- [x] `docker build --platform linux/amd64` completes on the Mac mini (qemu emulation), image 570MB
- [x] Container boots, shim answers `GET /healthz` with `{"ok":true,"inFlight":false}`
- [x] `node -e 'console.log(process.arch)'` in-container prints `x64`
- [x] `node_modules/.bin/tsx -e` executes (esbuild native binary matches platform)
- [x] `claude --version` in-container: 2.1.211
- [x] `npx tsc --noEmit` on the Worker: clean

Part of #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)