### PR TITLE
fix(executor): pass RESEND_API_KEY into the container so member notify works

### DIFF
--- a/cloudflare/executor/README.md
+++ b/cloudflare/executor/README.md
@@ -72,8 +72,9 @@ interactively, never committed):
 | `DATABASE_URL` | Turso (vibecodelisboa prod) | Mac mini env / Vaultwarden |
 | `DATABASE_AUTH_TOKEN` | Turso auth | Mac mini env / Vaultwarden |
 | `ENCRYPTION_SECRET` | repo-credential decryption | Mac mini env (`NEXTAUTH_SECRET` fallback exists in code; set the real one) |
-| `GITHUB_PAT` | jacketyjax PAT - member-repo clone, push, PR | `/Users/jax/.behalfbot/.env` |
+| `GITHUB_PAT` | jacketyjax PAT - member-repo clone, push, PR | `/Users/jax/.behalfbot/.env.baked` |
 | `BEHALFBOT_ANTHROPIC_API_KEY` | dedicated Anthropic key, $60/mo Console cap | Anthropic Console / Vaultwarden |
+| `RESEND_API_KEY` | member notify emails after job completion (#73) | Vaultwarden `resend-api-key-vcl` |
 
 That is the complete set. Anything not in this table (Vaultwarden master,
 Postgres DSN, SiYuan token, Discord token, OAuth refresh tokens) must

--- a/cloudflare/executor/src/index.ts
+++ b/cloudflare/executor/src/index.ts
@@ -16,15 +16,19 @@ interface Env {
   // Shared secret the Mac mini poke authenticates with. Minted fresh for
   // this Worker; not reused from any other system.
   EXECUTOR_TRIGGER_TOKEN: string
-  // The five executor secrets (issue #41's set). Set via `wrangler secret
-  // put`, passed into the container as env vars below. Nothing else - no
-  // Vaultwarden, no Postgres, no SiYuan, no Discord, no OAuth (issue #66
-  // packaging boundary).
+  // The executor secrets (issue #41's set + RESEND_API_KEY per #73). Set
+  // via `wrangler secret put`, passed into the container as env vars
+  // below. Nothing else - no Vaultwarden, no Postgres, no SiYuan, no
+  // Discord, no OAuth (issue #66 packaging boundary).
   DATABASE_URL: string
   DATABASE_AUTH_TOKEN: string
   ENCRYPTION_SECRET: string
   GITHUB_PAT: string
   BEHALFBOT_ANTHROPIC_API_KEY: string
+  // Member notifications. Without it the processor's notify step throws at
+  // module load (resend-client constructs at import time) AFTER the PR has
+  // shipped, retroactively marking completed jobs failed (#73).
+  RESEND_API_KEY: string
 }
 
 export class ExecutorContainer extends Container<Env> {
@@ -42,6 +46,7 @@ export class ExecutorContainer extends Container<Env> {
       ENCRYPTION_SECRET: env.ENCRYPTION_SECRET,
       GITHUB_PAT: env.GITHUB_PAT,
       BEHALFBOT_ANTHROPIC_API_KEY: env.BEHALFBOT_ANTHROPIC_API_KEY,
+      RESEND_API_KEY: env.RESEND_API_KEY,
     }
   }
 }

--- a/cloudflare/executor/wrangler.jsonc
+++ b/cloudflare/executor/wrangler.jsonc
@@ -56,4 +56,5 @@
   //   GITHUB_PAT                    - jacketyjax PAT (clone + push + PR)
   //   BEHALFBOT_ANTHROPIC_API_KEY   - dedicated key, $60/mo capped; NEVER
   //                                   Sean's Max subscription
+  //   RESEND_API_KEY                - member notify emails (#73)
 }


### PR DESCRIPTION
## What changed

- `src/index.ts`: `RESEND_API_KEY` added to the Env interface and forwarded into the container's envVars
- `wrangler.jsonc` + `README.md`: secret table updated (7 secrets now); README's GITHUB_PAT source corrected to `.env.baked`

## Why

Closes #73. The #41 smoke test shipped a real PR from the CF container, then the notify step crashed on module-level `new Resend(process.env.RESEND_API_KEY!)` and marked the completed row `failed`. Sean approved adding the key as the 7th secret.

Key sourced from Vaultwarden `resend-api-key-vcl` (validated read-only: its Resend account lists vibecodelisboa.com as a verified domain). Note: the `.env.local` RESEND_API_KEY on the Mac mini returns 401 on `GET /domains` - either sending-only scope or stale; flagged in the deploy report.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Deployed from this branch and re-verified end to end: controlled job lands the queue row in `completed` with notify succeeding (evidence in the #41 deploy report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)