### PR TITLE
feat(plugins): runtime-pull plugin machinery - Phase 0 consumption (behalfbot#53)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -526,23 +526,48 @@ preflight_bot_identity() {
 activate_plugins() {
     step "9/14" "Activate enabled plugins"
 
-    log "TODO: for each plugin in plugins/ directory:"
-    log "  - Read its openclaw.plugin.json"
-    log "  - Check chassis.config.yaml.modules.<plugin>.enabled"
-    log "  - If enabled: source plugin's activation hook + export its env vars"
-    log "  - Write chassis-env.sh that the launchd/systemd unit sources"
-    log ""
-    log "Per-plugin chassis-env.sh exports (V1-known):"
-    log "  whatsapp: CHASSIS_WHATSAPP_SAFE=\$CHASSIS_PLUGINS_ROOT/whatsapp/scripts/wacli-safe.sh"
-    log "  bfl:      BFL_ARCHIVE_DIR=<from config>"
-    log "  dating:   SOCIAL_CHANNEL_ID=<from config>"
-    log "  etc."
-    log ""
-    log "Plugin trigger merge (per chassis/scripts/merge-plugin-triggers.sh):"
-    log "  - Reads contracts.triggers from each enabled plugin's openclaw.plugin.json"
-    log "  - Writes merged registry to \$CUSTOMER_HOME/triggers.yaml"
-    log "  - Read by chassis/scripts/dispatch-trigger.sh on every inbound message"
-    log "  - Re-run any time a plugin is enabled/disabled or its manifest changes"
+    # Real implementation lives in chassis/scripts/activate-plugins.sh
+    # (behalfbot#53 Phase 0 - replaces the former log-only stub). The meat is
+    # kept in a chassis script, not inline here, because bootstrap.sh is
+    # image-baked while chassis scripts ride the clone overlay: fixes to
+    # activation logic ship via clone refresh without an image release.
+    #
+    # It discovers plugins across the layered roots (plugins-local >
+    # customer plugins > vendored-plugins fetched from behalfbot-plugins >
+    # image-baked /app/plugins fallback), gates on chassis.config.yaml
+    # modules.<name>.enabled, runs each plugin's setup.sh, writes
+    # $CUSTOMER_HOME/chassis-env.sh from contracts.env, merges
+    # contracts.mcpServers into .mcp.json (managed markers), and re-merges
+    # plugin triggers via merge-plugin-triggers.sh.
+    local activator=""
+    local candidate
+    for candidate in \
+        "$CHASSIS_HOME/chassis/chassis/scripts/activate-plugins.sh" \
+        "$CHASSIS_HOME/chassis/scripts/activate-plugins.sh" \
+        "${CHASSIS_ROOT:-/app/chassis}/scripts/activate-plugins.sh"; do
+        if [[ -f "$candidate" ]]; then
+            activator="$candidate"
+            break
+        fi
+    done
+
+    if [[ -z "$activator" ]]; then
+        # Mixed-state migration window (new image, stale clone): behave like
+        # the old stub - log and continue, baked plugins still drive.
+        log "  WARN: activate-plugins.sh not found in clone or image - skipping"
+        log "  plugin activation (refresh the chassis clone to enable it)"
+        return 0
+    fi
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log "  [dry-run] would run: $activator"
+        return 0
+    fi
+
+    if ! CHASSIS_HOME="$CHASSIS_HOME" CUSTOMER_HOME="${CUSTOMER_HOME:-$CHASSIS_HOME}" \
+        bash "$activator" 2>&1 | tee -a "$TRANSCRIPT"; then
+        log "  WARN: plugin activation reported errors (non-fatal, see above)"
+    fi
 }
 
 # ============================================================

--- a/chassis/PLUGINS_PIN
+++ b/chassis/PLUGINS_PIN
@@ -1,0 +1,15 @@
+# behalfbot-plugins runtime-pull pin (behalfbot#53 Phase 0)
+#
+# Format: single non-comment line "<tag> <40-hex-commit-sha>"
+#   example: v0.1.0 0123456789abcdef0123456789abcdef01234567
+#
+# The SHA is the gate, not the tag. fetch-plugins.sh resolves the tag remotely
+# and REFUSES to fetch when the resolved SHA differs from the SHA below - a
+# force-moved tag never auto-refetches (fleet-RCE fix, #53 review finding 3).
+#
+# This pin moves ONLY at a chassis VERSION bump (Sean-gated), in the same PR
+# that touches the sibling chassis/VERSION file.
+#
+# UNPINNED: scrollinondubs/behalfbot-plugins does not exist yet. While no pin
+# line is present below, fetch-plugins.sh is a no-op and the image-baked
+# /app/plugins tree remains the active plugin source.

--- a/chassis/scripts/_env.sh
+++ b/chassis/scripts/_env.sh
@@ -73,7 +73,13 @@ if [[ -z "${CHASSIS_ROOT:-}" ]]; then
 fi
 
 if [[ -z "${CHASSIS_PLUGINS_ROOT:-}" ]]; then
-    if [[ -d "/app/plugins" ]]; then
+    # Runtime-pull layering (behalfbot#53): a fetched vendored-plugins tree
+    # validated by plugins.lock wins over the image-baked fallback. The
+    # customer-local $CHASSIS_HOME/plugins dir is NOT the fetch destination -
+    # it holds customer-local plugins and stays the last-resort host default.
+    if [[ -n "${CHASSIS_HOME:-}" && -f "$CHASSIS_HOME/plugins.lock" && -d "$CHASSIS_HOME/vendored-plugins" ]]; then
+        export CHASSIS_PLUGINS_ROOT="$CHASSIS_HOME/vendored-plugins"
+    elif [[ -d "/app/plugins" ]]; then
         export CHASSIS_PLUGINS_ROOT="/app/plugins"
     elif [[ -n "${CHASSIS_HOME:-}" && -d "$CHASSIS_HOME/plugins" ]]; then
         export CHASSIS_PLUGINS_ROOT="$CHASSIS_HOME/plugins"

--- a/chassis/scripts/activate-plugins.sh
+++ b/chassis/scripts/activate-plugins.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# activate-plugins.sh - real plugin activation (replaces the bootstrap.sh
+# activate_plugins() log-only stub; behalfbot#53 Phase 0).
+#
+# For every ENABLED plugin (chassis.config.yaml modules.<name>.enabled):
+#   1. Discover its directory across the layered plugin roots (first hit wins):
+#        a. $CUSTOMER_HOME/plugins-local     - customer-private plugins, never
+#           in the public behalfbot-plugins repo (e.g. angel-protocol, dating
+#           on Sean's install). Highest precedence: local always overrides.
+#        b. $CUSTOMER_HOME/plugins           - legacy customer-local plugins
+#           (pre-dates this layering; midnight-oil lives here today). Kept for
+#           back-compat; new private plugins should use plugins-local/.
+#        c. $CUSTOMER_HOME/vendored-plugins  - fetched from behalfbot-plugins
+#           at the pinned tag+SHA by fetch-plugins.sh.
+#        d. /app/plugins                     - image-baked OFFLINE FALLBACK
+#           (migration-era; goes away one VERSION cycle after Phase 2).
+#   2. Run its setup.sh (idempotent contract). Failure is a WARN, not fatal.
+#   3. Collect contracts.env into $CUSTOMER_HOME/chassis-env.sh.
+#   4. Merge contracts.mcpServers into $CUSTOMER_HOME/.mcp.json inside a
+#      managed marker ("_managed_by": "behalfbot-plugin:<name>") so re-runs
+#      replace rather than duplicate, and manual entries are never touched.
+#   5. Re-merge plugin triggers via merge-plugin-triggers.sh.
+#
+# Idempotent: running twice with no plugin changes produces identical outputs.
+# Never exits nonzero for a single plugin failure; exits nonzero only when the
+# environment itself is unusable (no config, no python3).
+
+set -euo pipefail
+
+: "${CHASSIS_HOME:?CHASSIS_HOME must be set}"
+: "${CUSTOMER_HOME:=$CHASSIS_HOME}"
+: "${CHASSIS_ROOT:=/app/chassis}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG="$CUSTOMER_HOME/chassis.config.yaml"
+[[ -f "$CONFIG" ]] || CONFIG="$CHASSIS_HOME/chassis.config.yaml"
+
+log() { printf '[activate-plugins] %s\n' "$*"; }
+
+if [[ ! -f "$CONFIG" ]]; then
+    log "ERROR: chassis.config.yaml not found - run earlier bootstrap steps first"
+    exit 1
+fi
+command -v python3 >/dev/null 2>&1 || { log "ERROR: python3 not found"; exit 1; }
+
+# Layered search path, highest precedence first. Overridable for tests.
+: "${CHASSIS_PLUGINS_SEARCH_PATH:=$CUSTOMER_HOME/plugins-local:$CUSTOMER_HOME/plugins:$CUSTOMER_HOME/vendored-plugins:${CHASSIS_PLUGINS_ROOT:-/app/plugins}}"
+export CHASSIS_PLUGINS_SEARCH_PATH
+
+enabled=$(python3 "$SCRIPT_DIR/lib/enabled-plugins.py" "$CONFIG")
+if [[ -z "$enabled" ]]; then
+    log "no enabled plugin modules in $CONFIG - nothing to activate"
+    exit 0
+fi
+log "enabled modules: $(tr '\n' ' ' <<<"$enabled")"
+
+# --- discover: name<TAB>dir for each enabled plugin that exists on disk -----
+discovered=$(ENABLED="$enabled" python3 - <<'PY'
+import os
+from pathlib import Path
+search = [Path(p) for p in os.environ["CHASSIS_PLUGINS_SEARCH_PATH"].split(":") if p]
+for name in os.environ["ENABLED"].split():
+    for root in search:
+        pdir = root / name
+        if (pdir / "openclaw.plugin.json").is_file():
+            print(f"{name}\t{pdir}")
+            break
+PY
+)
+
+if [[ -z "$discovered" ]]; then
+    log "none of the enabled modules have a plugin directory on disk - done"
+    exit 0
+fi
+
+# --- run setup.sh per plugin (idempotent contract, WARN on failure) ---------
+while IFS=$'\t' read -r name pdir; do
+    [[ -z "$name" ]] && continue
+    log "activating $name ($pdir)"
+    if [[ -f "$pdir/setup.sh" ]]; then
+        if ! CHASSIS_HOME="$CHASSIS_HOME" CUSTOMER_HOME="$CUSTOMER_HOME" \
+             PLUGIN_DIR="$pdir" bash "$pdir/setup.sh"; then
+            log "WARN: $name setup.sh exited nonzero - plugin may be degraded"
+        fi
+    fi
+done <<<"$discovered"
+
+# --- contracts.env -> chassis-env.sh; contracts.mcpServers -> .mcp.json -----
+DISCOVERED="$discovered" CUSTOMER_HOME="$CUSTOMER_HOME" CHASSIS_HOME="$CHASSIS_HOME" \
+python3 - <<'PY'
+import json, os, sys, tempfile
+from pathlib import Path
+
+customer = Path(os.environ["CUSTOMER_HOME"])
+chassis_home = os.environ["CHASSIS_HOME"]
+rows = [r.split("\t") for r in os.environ["DISCOVERED"].splitlines() if r.strip()]
+
+MARKER_KEY = "_managed_by"
+MARKER_PREFIX = "behalfbot-plugin:"
+
+def expand(value, plugin_dir):
+    if not isinstance(value, str):
+        return value
+    return (value
+            .replace("${CHASSIS_HOME}", chassis_home)
+            .replace("${CUSTOMER_HOME}", str(customer))
+            .replace("${PLUGIN_DIR}", str(plugin_dir)))
+
+env_lines = []
+mcp_servers = {}  # server-name -> (plugin, config)
+
+for name, pdir in rows:
+    pdir = Path(pdir)
+    try:
+        manifest = json.loads((pdir / "openclaw.plugin.json").read_text())
+    except Exception as e:
+        print(f"[activate-plugins] WARN: {name} manifest unreadable: {e}", file=sys.stderr)
+        continue
+    contracts = manifest.get("contracts", {}) or {}
+
+    for key, val in sorted((contracts.get("env") or {}).items()):
+        env_lines.append(f'export {key}="{expand(val, pdir)}"  # plugin: {name}')
+
+    for sname, sconf in sorted((contracts.get("mcpServers") or {}).items()):
+        if sname in mcp_servers:
+            print(f"[activate-plugins] WARN: MCP server '{sname}' declared by both "
+                  f"{mcp_servers[sname][0]} and {name} - keeping {mcp_servers[sname][0]} "
+                  f"(higher-precedence layer)", file=sys.stderr)
+            continue
+        conf = json.loads(json.dumps(sconf))  # deep copy
+        for k in ("command",):
+            if k in conf:
+                conf[k] = expand(conf[k], pdir)
+        if isinstance(conf.get("args"), list):
+            conf["args"] = [expand(a, pdir) for a in conf["args"]]
+        if isinstance(conf.get("env"), dict):
+            conf["env"] = {k: expand(v, pdir) for k, v in conf["env"].items()}
+        conf[MARKER_KEY] = MARKER_PREFIX + name
+        mcp_servers[sname] = (name, conf)
+
+# chassis-env.sh - fully regenerated each run (managed file).
+env_path = customer / "chassis-env.sh"
+header = [
+    "#!/usr/bin/env bash",
+    "# chassis-env.sh - GENERATED by activate-plugins.sh. Do not edit; your",
+    "# changes will be overwritten on the next bootstrap. Sourced by the",
+    "# dispatcher / launchd / systemd units to expose plugin env contracts.",
+    "",
+]
+env_path.write_text("\n".join(header + env_lines) + "\n")
+print(f"[activate-plugins] wrote {env_path} ({len(env_lines)} exports)")
+
+# .mcp.json merge - only inside our managed marker entries.
+mcp_path = customer / ".mcp.json"
+if not mcp_path.is_file():
+    if mcp_servers:
+        print(f"[activate-plugins] WARN: {mcp_path} missing - cannot register "
+              f"{len(mcp_servers)} plugin MCP server(s). Run bootstrap-mcp-config.sh first.",
+              file=sys.stderr)
+else:
+    try:
+        mcp = json.loads(mcp_path.read_text())
+    except Exception as e:
+        print(f"[activate-plugins] WARN: {mcp_path} unparseable ({e}) - skipping MCP merge",
+              file=sys.stderr)
+        mcp = None
+    if mcp is not None:
+        servers = mcp.setdefault("mcpServers", {})
+        removed = [k for k, v in servers.items()
+                   if isinstance(v, dict) and str(v.get(MARKER_KEY, "")).startswith(MARKER_PREFIX)]
+        for k in removed:
+            del servers[k]
+        added = []
+        for sname, (pname, conf) in sorted(mcp_servers.items()):
+            if sname in servers:
+                print(f"[activate-plugins] WARN: '{sname}' already exists in .mcp.json "
+                      f"(unmanaged) - leaving the manual entry alone", file=sys.stderr)
+                continue
+            servers[sname] = conf
+            added.append(sname)
+        fd, tmp = tempfile.mkstemp(dir=str(customer), prefix=".mcp.json.")
+        with os.fdopen(fd, "w") as f:
+            json.dump(mcp, f, indent=2)
+            f.write("\n")
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, mcp_path)
+        print(f"[activate-plugins] .mcp.json: removed {len(removed)} stale managed "
+              f"entr{'y' if len(removed)==1 else 'ies'}, added {added or 'none'}")
+PY
+
+# --- trigger merge (already-real machinery, now pointed at the layers) ------
+MERGER=""
+for cand in \
+    "$SCRIPT_DIR/merge-plugin-triggers.sh" \
+    "$CHASSIS_ROOT/scripts/merge-plugin-triggers.sh"; do
+    [[ -f "$cand" ]] && { MERGER="$cand"; break; }
+done
+if [[ -n "$MERGER" ]]; then
+    if ! CHASSIS_HOME="$CHASSIS_HOME" CHASSIS_PLUGINS_SEARCH_PATH="$CHASSIS_PLUGINS_SEARCH_PATH" \
+         bash "$MERGER"; then
+        log "WARN: merge-plugin-triggers.sh failed - triggers.yaml may be stale"
+    fi
+else
+    log "WARN: merge-plugin-triggers.sh not found - skipping trigger merge"
+fi
+
+log "activation complete"

--- a/chassis/scripts/fetch-plugins.sh
+++ b/chassis/scripts/fetch-plugins.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# fetch-plugins.sh - runtime-pull plugin fetcher (behalfbot#53, Phase 0).
+#
+# Fetches the behalfbot-plugins repo at the tag+SHA pinned in PLUGINS_PIN,
+# verifies the SHA, and atomically installs the tree into
+# $CUSTOMER_HOME/vendored-plugins, writing $CUSTOMER_HOME/plugins.lock.
+#
+# NOTE on canonical home: once scrollinondubs/behalfbot-plugins exists, the
+# canonical copy of this script lives THERE (tools/fetch-plugins.sh) so the
+# fetcher itself cannot drift between chassis. This chassis copy is the seed /
+# bootstrap shim that both chassis carry.
+#
+# Security model (fleet-RCE fix from the behalfbot#53 adversarial review,
+# finding 3): the pin records BOTH the tag and the commit SHA. A tag is
+# human-readable; the SHA is the gate. If the tag no longer resolves to the
+# pinned SHA (i.e. someone force-moved the tag), this script REFUSES to fetch
+# and keeps the previous tree. A moved tag never auto-refetches.
+#
+# Destination (finding 1 from the same review): $CUSTOMER_HOME/vendored-plugins.
+# NOT $CUSTOMER_HOME/plugins - that directory already holds live customer-local
+# plugins (e.g. midnight-oil) and must never be clobbered by a fetch.
+# vendored-plugins/ sits on the existing customer bind mount: writable by the
+# runtime uid, survives container recreate.
+#
+# Pin resolution order (first file found wins):
+#   1. $PLUGINS_PIN_FILE (explicit override)
+#   2. $CUSTOMER_HOME/chassis/chassis/PLUGINS_PIN  (chassis clone overlay - ships
+#      via clone refresh, no image release needed for a pin bump)
+#   3. $CHASSIS_ROOT/PLUGINS_PIN                   (image-baked fallback)
+#
+# Pin file format: single non-comment line "<tag> <40-hex-sha>".
+# No non-comment line = unpinned = no-op (baked /app/plugins stays active).
+#
+# Exit codes:
+#   0 - fetched, or valid no-op (already current / unpinned / frozen / offline
+#       with a previous tree still in place)
+#   3 - SECURITY: tag resolved to a SHA that does not match the pin. No fetch
+#       performed, previous tree untouched.
+#   4 - corrupt staging tree (sanity check failed). Previous tree untouched.
+#
+# Boot callers (entrypoint.sh) treat nonzero as WARN and continue on the
+# previous/baked tree - a fetch problem must never take the bot down.
+#
+# Usage:
+#   fetch-plugins.sh                # fetch/verify per pin
+#   fetch-plugins.sh --freeze       # mark lockfile frozen; skip all future fetches
+#   fetch-plugins.sh --unfreeze     # re-enter the fetch flow
+#   fetch-plugins.sh --tag vX.Y.Z --sha <sha>   # test override (bypasses pin file)
+
+set -euo pipefail
+
+: "${PLUGINS_REPO:=scrollinondubs/behalfbot-plugins}"
+: "${CUSTOMER_HOME:=${CHASSIS_HOME:-/app/customer}}"
+: "${CHASSIS_ROOT:=/app/chassis}"
+: "${PLUGINS_FETCH_ROOT:=$CUSTOMER_HOME/vendored-plugins}"
+LOCK_FILE="$CUSTOMER_HOME/plugins.lock"
+
+log() { printf '[fetch-plugins] %s\n' "$*" >&2; }
+
+# --- args -------------------------------------------------------------------
+OVERRIDE_TAG=""
+OVERRIDE_SHA=""
+ACTION="fetch"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --freeze)   ACTION="freeze" ;;
+        --unfreeze) ACTION="unfreeze" ;;
+        --tag)      OVERRIDE_TAG="${2:?--tag needs a value}"; shift ;;
+        --sha)      OVERRIDE_SHA="${2:?--sha needs a value}"; shift ;;
+        *) log "unknown arg: $1"; exit 2 ;;
+    esac
+    shift
+done
+
+set_frozen() {
+    local val="$1"
+    if [[ ! -f "$LOCK_FILE" ]]; then
+        log "no $LOCK_FILE yet - nothing to $ACTION"
+        exit 0
+    fi
+    python3 - "$LOCK_FILE" "$val" <<'PY'
+import json, sys
+path, val = sys.argv[1], sys.argv[2] == "true"
+data = json.load(open(path))
+data["frozen"] = val
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+PY
+    log "lockfile frozen=$val"
+    exit 0
+}
+[[ "$ACTION" == "freeze"   ]] && set_frozen true
+[[ "$ACTION" == "unfreeze" ]] && set_frozen false
+
+# --- read pin ---------------------------------------------------------------
+PIN_TAG="$OVERRIDE_TAG"
+PIN_SHA="$OVERRIDE_SHA"
+if [[ -z "$PIN_TAG" ]]; then
+    PIN_FILE=""
+    for cand in \
+        "${PLUGINS_PIN_FILE:-}" \
+        "$CUSTOMER_HOME/chassis/chassis/PLUGINS_PIN" \
+        "$CHASSIS_ROOT/PLUGINS_PIN"; do
+        [[ -n "$cand" && -f "$cand" ]] && { PIN_FILE="$cand"; break; }
+    done
+    if [[ -z "$PIN_FILE" ]]; then
+        log "no PLUGINS_PIN file found - unpinned, skipping fetch (baked plugins stay active)"
+        exit 0
+    fi
+    pin_line=$(grep -vE '^\s*(#|$)' "$PIN_FILE" | head -1 || true)
+    if [[ -z "$pin_line" ]]; then
+        log "PLUGINS_PIN at $PIN_FILE has no pin line - unpinned, skipping fetch"
+        exit 0
+    fi
+    PIN_TAG=$(awk '{print $1}' <<<"$pin_line")
+    PIN_SHA=$(awk '{print $2}' <<<"$pin_line")
+fi
+
+if [[ ! "$PIN_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+    log "SECURITY: pin SHA missing or malformed ('$PIN_SHA') - a bare tag is not a"
+    log "valid pin (tags can be force-moved). Refusing to fetch."
+    exit 3
+fi
+
+# --- frozen? already current? ----------------------------------------------
+lock_field() {
+    python3 - "$LOCK_FILE" "$1" <<'PY' 2>/dev/null || true
+import json, sys
+try:
+    print(json.load(open(sys.argv[1])).get(sys.argv[2], ""))
+except Exception:
+    pass
+PY
+}
+
+if [[ -f "$LOCK_FILE" ]]; then
+    if [[ "$(lock_field frozen)" == "True" ]]; then
+        log "lockfile is frozen - skipping fetch entirely"
+        exit 0
+    fi
+    if [[ "$(lock_field commit)" == "$PIN_SHA" && -d "$PLUGINS_FETCH_ROOT" ]]; then
+        log "already current at $PIN_TAG ($PIN_SHA) - no-op"
+        exit 0
+    fi
+fi
+
+# --- resolve tag remotely and verify against the pin ------------------------
+log "resolving $PLUGINS_REPO tag $PIN_TAG ..."
+resolved=""
+if refs=$(git ls-remote "https://github.com/$PLUGINS_REPO.git" \
+        "refs/tags/$PIN_TAG^{}" "refs/tags/$PIN_TAG" 2>/dev/null); then
+    # Prefer the peeled ref (annotated tag -> commit), fall back to the tag ref.
+    resolved=$(awk '$2 ~ /\^\{\}$/ {print $1; exit}' <<<"$refs")
+    [[ -z "$resolved" ]] && resolved=$(awk 'NR==1 {print $1}' <<<"$refs")
+fi
+
+if [[ -z "$resolved" ]]; then
+    if [[ -d "$PLUGINS_FETCH_ROOT" && -f "$LOCK_FILE" ]]; then
+        log "WARN: cannot reach $PLUGINS_REPO (offline or repo missing) - keeping previous fetched tree"
+        exit 0
+    fi
+    log "WARN: cannot reach $PLUGINS_REPO and nothing fetched yet - baked plugins stay active"
+    exit 0
+fi
+
+if [[ "$resolved" != "$PIN_SHA" ]]; then
+    log "SECURITY: tag $PIN_TAG resolves to $resolved but the pin says $PIN_SHA."
+    log "The tag has MOVED since it was pinned. Refusing to fetch - previous tree untouched."
+    log "If the move is legitimate, update PLUGINS_PIN in a reviewed chassis PR."
+    exit 3
+fi
+
+# --- download tarball at the pinned SHA -------------------------------------
+parent=$(dirname "$PLUGINS_FETCH_ROOT")
+mkdir -p "$parent"
+staging=$(mktemp -d "$parent/.plugins-staging.XXXXXX")
+cleanup() { rm -rf "$staging" 2>/dev/null || true; }
+trap cleanup EXIT
+
+log "downloading $PLUGINS_REPO @ $PIN_SHA ..."
+fetched=false
+if curl -fsSL --retry 2 "https://codeload.github.com/$PLUGINS_REPO/tar.gz/$PIN_SHA" \
+        -o "$staging/repo.tar.gz" 2>/dev/null; then
+    tar -xzf "$staging/repo.tar.gz" -C "$staging" && fetched=true
+    rm -f "$staging/repo.tar.gz"
+fi
+if [[ "$fetched" != "true" ]]; then
+    log "tarball download failed - falling back to git clone"
+    if git clone --quiet "https://github.com/$PLUGINS_REPO.git" "$staging/clone" 2>/dev/null \
+        && git -C "$staging/clone" checkout --quiet "$PIN_SHA" 2>/dev/null; then
+        rm -rf "$staging/clone/.git"
+        fetched=true
+    fi
+fi
+if [[ "$fetched" != "true" ]]; then
+    log "WARN: fetch failed - keeping previous state"
+    exit 0
+fi
+
+# Locate the extracted tree root (codeload roots at <repo>-<sha>/).
+tree=$(find "$staging" -mindepth 1 -maxdepth 1 -type d | head -1)
+if [[ -z "$tree" || ! -f "$tree/registry.json" ]]; then
+    log "ERROR: staging tree is corrupt (no registry.json) - aborting, previous state untouched"
+    exit 4
+fi
+
+# --- sanity check: every registry plugin present, every manifest parses -----
+if ! python3 - "$tree" <<'PY'
+import json, sys
+from pathlib import Path
+tree = Path(sys.argv[1])
+reg = json.loads((tree / "registry.json").read_text())
+ok = True
+for p in reg.get("plugins", []):
+    pdir = tree / p.get("path", p["name"])
+    manifest = pdir / "openclaw.plugin.json"
+    if not pdir.is_dir():
+        print(f"missing plugin dir: {pdir}", file=sys.stderr); ok = False; continue
+    if not manifest.is_file():
+        print(f"missing manifest: {manifest}", file=sys.stderr); ok = False; continue
+    try:
+        json.loads(manifest.read_text())
+    except Exception as e:
+        print(f"manifest parse error {manifest}: {e}", file=sys.stderr); ok = False
+sys.exit(0 if ok else 1)
+PY
+then
+    log "ERROR: sanity check failed - aborting swap, previous state untouched"
+    exit 4
+fi
+
+# --- atomic swap ------------------------------------------------------------
+previous=""
+if [[ -d "$PLUGINS_FETCH_ROOT" ]]; then
+    previous="$parent/.vendored-plugins.previous.$$"
+    mv "$PLUGINS_FETCH_ROOT" "$previous"
+fi
+if ! mv "$tree" "$PLUGINS_FETCH_ROOT"; then
+    log "ERROR: swap failed - restoring previous tree"
+    [[ -n "$previous" ]] && mv "$previous" "$PLUGINS_FETCH_ROOT"
+    exit 4
+fi
+[[ -n "$previous" ]] && rm -rf "$previous"
+
+# --- write lockfile ---------------------------------------------------------
+CHASSIS_VERSION="unknown"
+for vf in "$CUSTOMER_HOME/chassis/chassis/VERSION" "$CHASSIS_ROOT/VERSION"; do
+    [[ -f "$vf" ]] && { CHASSIS_VERSION=$(<"$vf"); break; }
+done
+
+PIN_TAG="$PIN_TAG" PIN_SHA="$PIN_SHA" PLUGINS_REPO="$PLUGINS_REPO" \
+CHASSIS_VERSION="$CHASSIS_VERSION" FETCH_ROOT="$PLUGINS_FETCH_ROOT" \
+python3 - "$LOCK_FILE" <<'PY'
+import json, os, sys, datetime
+from pathlib import Path
+lock_path = sys.argv[1]
+root = Path(os.environ["FETCH_ROOT"])
+tag, sha = os.environ["PIN_TAG"], os.environ["PIN_SHA"]
+plugins = {}
+for manifest in sorted(root.glob("*/openclaw.plugin.json")):
+    try:
+        data = json.loads(manifest.read_text())
+    except Exception:
+        continue
+    name = manifest.parent.name
+    plugins[name] = {
+        "version": data.get("version", "unknown"),
+        "tag": tag,
+        "sha": sha,
+    }
+lock = {
+    "schema": 1,
+    "repo": os.environ["PLUGINS_REPO"],
+    "tag": tag,
+    "commit": sha,
+    "fetched_at": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "chassis_version": os.environ["CHASSIS_VERSION"].strip(),
+    "frozen": False,
+    "plugins": plugins,
+}
+with open(lock_path, "w") as f:
+    json.dump(lock, f, indent=2)
+    f.write("\n")
+PY
+
+log "fetched $PLUGINS_REPO @ $PIN_TAG ($PIN_SHA) into $PLUGINS_FETCH_ROOT"
+log "lockfile written: $LOCK_FILE"

--- a/chassis/scripts/lib/enabled-plugins.py
+++ b/chassis/scripts/lib/enabled-plugins.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Print the enabled plugin/module names from chassis.config.yaml, one per line.
+
+Shared by merge-plugin-triggers.sh and activate-plugins.sh so the two callers
+cannot drift (extracted per the behalfbot#53 design, section 4).
+
+Tiny YAML reader sufficient for the chassis.config.yaml modules block - avoids
+a PyYAML hard dep. Handles both shapes:
+
+    modules:
+      admin: true                 # inline boolean
+      loom-vision:
+        enabled: true             # nested enabled key
+
+Usage: enabled-plugins.py <path-to-chassis.config.yaml>
+"""
+import re
+import sys
+
+
+def enabled_modules(path):
+    in_modules = False
+    plugin = None
+    plugins = []
+    for raw in open(path):
+        line = raw.rstrip("\n")
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        stripped = line.strip()
+        if indent == 0:
+            in_modules = stripped == "modules:"
+            plugin = None
+            continue
+        if not in_modules:
+            continue
+        if indent == 2:
+            m = re.match(r"^([A-Za-z0-9_-]+):\s*(true|false)\s*(#.*)?$", stripped)
+            if m:
+                if m.group(2) == "true":
+                    plugins.append(m.group(1))
+                plugin = None
+                continue
+            if stripped.endswith(":"):
+                plugin = stripped[:-1]
+                continue
+            plugin = None
+            continue
+        if indent == 4 and plugin is not None:
+            m = re.match(r"enabled:\s*(true|false)\b", stripped)
+            if m:
+                if m.group(1) == "true":
+                    plugins.append(plugin)
+                plugin = None  # one shot per plugin
+    return sorted(set(plugins))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: enabled-plugins.py <chassis.config.yaml>", file=sys.stderr)
+        sys.exit(2)
+    print("\n".join(enabled_modules(sys.argv[1])))

--- a/chassis/scripts/merge-plugin-triggers.sh
+++ b/chassis/scripts/merge-plugin-triggers.sh
@@ -40,42 +40,16 @@ fi
 
 # Discover enabled plugins via chassis.config.yaml. We avoid yq here for the
 # same chassis-portability reasons as elsewhere — Python is everywhere.
-enabled_plugins=$(python3 - "$CONFIG" <<'PY'
-import sys
-import re
+# Parser extracted to lib/enabled-plugins.py so activate-plugins.sh shares it
+# (behalfbot#53 design section 4 - no drift between the two callers).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+enabled_plugins=$(python3 "$SCRIPT_DIR/lib/enabled-plugins.py" "$CONFIG")
 
-# Tiny YAML parser sufficient for chassis.config.yaml's modules block. Avoids
-# shipping PyYAML as a hard dep. Handles the modules: <plugin>: enabled: <bool>
-# pattern only.
-path = sys.argv[1]
-in_modules = False
-plugin = None
-plugins = []
-for raw in open(path):
-    line = raw.rstrip("\n")
-    if not line.strip() or line.lstrip().startswith("#"):
-        continue
-    indent = len(line) - len(line.lstrip())
-    stripped = line.strip()
-    if indent == 0:
-        in_modules = stripped == "modules:"
-        plugin = None
-        continue
-    if not in_modules:
-        continue
-    if indent == 2 and stripped.endswith(":"):
-        plugin = stripped[:-1]
-        continue
-    if indent == 4 and plugin is not None:
-        m = re.match(r"enabled:\s*(true|false)\b", stripped)
-        if m and m.group(1) == "true":
-            plugins.append(plugin)
-            plugin = None  # one shot per plugin
-        elif m and m.group(1) == "false":
-            plugin = None
-print("\n".join(sorted(plugins)))
-PY
-)
+# Layered plugin roots, highest precedence first (behalfbot#53 Phase 0):
+# customer-private plugins-local/, legacy customer plugins/, fetched
+# vendored-plugins/, image-baked /app/plugins fallback. First hit wins.
+: "${CHASSIS_PLUGINS_SEARCH_PATH:=$CHASSIS_HOME/plugins-local:$CHASSIS_HOME/plugins:$CHASSIS_HOME/vendored-plugins:${CHASSIS_PLUGINS_ROOT:-/app/plugins}}"
+export CHASSIS_PLUGINS_SEARCH_PATH
 
 # Build merged triggers section
 merged=$(python3 - <<PY
@@ -87,10 +61,21 @@ from pathlib import Path
 chassis_home = Path(os.environ["CHASSIS_HOME"])
 plugin_names = """$enabled_plugins""".strip().splitlines()
 
+# Layered lookup: first root containing the plugin's manifest wins. Replaces
+# the old hardcoded chassis_home/"plugins" path (behalfbot#53 review finding 1).
+search_roots = [Path(p) for p in os.environ.get("CHASSIS_PLUGINS_SEARCH_PATH", "").split(":") if p]
+if not search_roots:
+    search_roots = [chassis_home / "plugins"]
+
 entries = []
 for name in plugin_names:
-    manifest = chassis_home / "plugins" / name / "openclaw.plugin.json"
-    if not manifest.exists():
+    manifest = None
+    for root in search_roots:
+        cand = root / name / "openclaw.plugin.json"
+        if cand.exists():
+            manifest = cand
+            break
+    if manifest is None:
         continue
     try:
         data = json.loads(manifest.read_text())

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,6 +6,9 @@
 #   bootstrap        - one-shot: hydrate .mcp.json/CLAUDE.md/HEARTBEATS.md, seed memory
 #   install-plugin <name>
 #                    - one-shot: run plugins/<name>/install.sh
+#   update-plugins   - one-shot: fetch behalfbot-plugins at the pinned tag+SHA
+#                      into $CUSTOMER_HOME/vendored-plugins (behalfbot#53);
+#                      supports --freeze / --unfreeze for air-gapped installs
 #   hydrate-env      - one-shot: pull secrets from Vaultwarden via rbw, write to .env
 #   smoke-test       - one-shot: run chassis + plugin smoke checks
 #   claude           - interactive Claude CLI (needs -it)
@@ -19,14 +22,43 @@
 set -euo pipefail
 
 : "${CHASSIS_ROOT:=/app/chassis}"
-: "${CHASSIS_PLUGINS_ROOT:=/app/plugins}"
 # Issue #6 customer-state split. CUSTOMER_HOME is the canonical name for the
 # customer-state mount inside the container; CHASSIS_HOME is kept as an alias
 # pointing at the SAME path so legacy chassis scripts (which read
 # $CHASSIS_HOME/.env, $CHASSIS_HOME/briefings, etc.) keep working untouched.
 : "${CUSTOMER_HOME:=/app/customer}"
 : "${CHASSIS_HOME:=$CUSTOMER_HOME}"
-export CUSTOMER_HOME CHASSIS_HOME CHASSIS_ROOT CHASSIS_PLUGINS_ROOT
+
+# Runtime-pull plugin roots (behalfbot#53 Phase 0):
+#   PLUGINS_FETCH_ROOT - fetched from behalfbot-plugins at the pinned tag+SHA.
+#     Deliberately NOT $CUSTOMER_HOME/plugins: that dir holds live
+#     customer-local plugins and must never be clobbered by a fetch.
+#     vendored-plugins/ is on the customer bind mount - writable at runtime,
+#     survives container recreate.
+#   PLUGINS_LOCAL_ROOT - customer-private plugins layered on top of fetched
+#     ones (never published to the public plugins repo).
+#   PLUGINS_BAKED_ROOT - image-baked offline fallback during migration.
+: "${PLUGINS_FETCH_ROOT:=$CUSTOMER_HOME/vendored-plugins}"
+: "${PLUGINS_LOCAL_ROOT:=$CUSTOMER_HOME/plugins-local}"
+: "${PLUGINS_BAKED_ROOT:=/app/plugins}"
+
+# CHASSIS_PLUGINS_ROOT resolution: an explicit env value always wins; else the
+# fetched tree wins when a lockfile validates it; else the baked fallback.
+# Re-runnable (called again after update-plugins fetches a new tree).
+_PLUGINS_ROOT_EXPLICIT="${CHASSIS_PLUGINS_ROOT:-}"
+resolve_plugins_root() {
+    if [[ -n "$_PLUGINS_ROOT_EXPLICIT" ]]; then
+        CHASSIS_PLUGINS_ROOT="$_PLUGINS_ROOT_EXPLICIT"
+    elif [[ -f "$CUSTOMER_HOME/plugins.lock" && -d "$PLUGINS_FETCH_ROOT" ]]; then
+        CHASSIS_PLUGINS_ROOT="$PLUGINS_FETCH_ROOT"
+    else
+        CHASSIS_PLUGINS_ROOT="$PLUGINS_BAKED_ROOT"
+    fi
+    export CHASSIS_PLUGINS_ROOT
+}
+resolve_plugins_root
+export CUSTOMER_HOME CHASSIS_HOME CHASSIS_ROOT CHASSIS_PLUGINS_ROOT \
+       PLUGINS_FETCH_ROOT PLUGINS_LOCAL_ROOT PLUGINS_BAKED_ROOT
 : "${DISPATCHER_INTERVAL_SECONDS:=900}"
 : "${DISPATCHER_SCRIPT:=$CHASSIS_ROOT/scheduled-tasks/heartbeat-dispatcher.sh}"
 
@@ -41,7 +73,34 @@ ensure_customer_layout() {
     # Bind-mount may be empty on first run. Don't clobber existing state.
     # Use CUSTOMER_HOME (which equals CHASSIS_HOME in the container) so the
     # naming matches the new issue #6 semantics.
-    mkdir -p "$CUSTOMER_HOME"/{briefings,logs/scheduled,scheduled-tasks,state,data,memory,plugins,temp,scripts}
+    # plugins-local/ is the customer-private plugin layer (behalfbot#53);
+    # vendored-plugins/ is created by fetch-plugins.sh on first fetch.
+    mkdir -p "$CUSTOMER_HOME"/{briefings,logs/scheduled,scheduled-tasks,state,data,memory,plugins,plugins-local,temp,scripts}
+}
+
+fetch_plugins() {
+    # Runtime-pull fetch (behalfbot#53 Phase 0). Best-effort at boot: a fetch
+    # problem must never take the bot down - fetch-plugins.sh degrades to the
+    # previous fetched tree or the baked fallback, and we resolve the root
+    # again afterwards. Prefer the clone-overlay copy (freshest, ships without
+    # an image release), fall back to the image-baked copy.
+    local fetcher=""
+    local cand
+    for cand in \
+        "$CUSTOMER_HOME/chassis/chassis/scripts/fetch-plugins.sh" \
+        "$CHASSIS_ROOT/scripts/fetch-plugins.sh"; do
+        [[ -f "$cand" ]] && { fetcher="$cand"; break; }
+    done
+    if [[ -z "$fetcher" ]]; then
+        log "fetch-plugins.sh not found (stale clone + old image) - baked plugins stay active"
+        return 0
+    fi
+    if ! CUSTOMER_HOME="$CUSTOMER_HOME" CHASSIS_ROOT="$CHASSIS_ROOT" \
+         PLUGINS_FETCH_ROOT="$PLUGINS_FETCH_ROOT" bash "$fetcher" "$@"; then
+        log "WARN: fetch-plugins.sh exited nonzero - continuing on previous/baked plugin tree"
+    fi
+    resolve_plugins_root
+    log "plugin root: $CHASSIS_PLUGINS_ROOT"
 }
 
 source_env() {
@@ -81,6 +140,7 @@ run_dispatcher_once() {
 cmd_dispatcher() {
     ensure_customer_layout
     source_env
+    fetch_plugins
     log "dispatcher loop starting - tick=${DISPATCHER_INTERVAL_SECONDS}s, CHASSIS_HOME=$CHASSIS_HOME"
     # Touch sentinel up-front so healthcheck doesn't fail before first tick.
     touch /tmp/dispatcher.alive
@@ -97,8 +157,32 @@ cmd_dispatcher() {
 cmd_bootstrap() {
     ensure_customer_layout
     source_env
+    fetch_plugins
     log "running bootstrap.sh against CHASSIS_HOME=$CHASSIS_HOME"
     CHASSIS_HOME="$CHASSIS_HOME" bash /app/bootstrap.sh "$@"
+}
+
+cmd_update_plugins() {
+    # Explicit fetch/refresh: propagates fetch-plugins.sh's exit code so a
+    # SECURITY refusal (moved tag, exit 3) or corrupt tree (exit 4) is
+    # visible to the operator, unlike the best-effort boot-time fetch.
+    ensure_customer_layout
+    source_env
+    local fetcher=""
+    local cand
+    for cand in \
+        "$CUSTOMER_HOME/chassis/chassis/scripts/fetch-plugins.sh" \
+        "$CHASSIS_ROOT/scripts/fetch-plugins.sh"; do
+        [[ -f "$cand" ]] && { fetcher="$cand"; break; }
+    done
+    if [[ -z "$fetcher" ]]; then
+        log "FATAL: fetch-plugins.sh not found in clone or image"
+        exit 2
+    fi
+    CUSTOMER_HOME="$CUSTOMER_HOME" CHASSIS_ROOT="$CHASSIS_ROOT" \
+        PLUGINS_FETCH_ROOT="$PLUGINS_FETCH_ROOT" bash "$fetcher" "$@"
+    resolve_plugins_root
+    log "plugin root: $CHASSIS_PLUGINS_ROOT"
 }
 
 cmd_install_plugin() {
@@ -155,13 +239,14 @@ case "$MODE" in
     dispatcher)       cmd_dispatcher       "$@" ;;
     bootstrap)        cmd_bootstrap        "$@" ;;
     install-plugin)   cmd_install_plugin   "$@" ;;
+    update-plugins)   cmd_update_plugins   "$@" ;;
     hydrate-env)      cmd_hydrate_env      "$@" ;;
     smoke-test)       cmd_smoke_test       "$@" ;;
     claude)           cmd_claude           "$@" ;;
     shell)            cmd_shell            "$@" ;;
     *)
         echo "unknown mode: $MODE" >&2
-        echo "valid modes: dispatcher | bootstrap | install-plugin <name> | hydrate-env | smoke-test | claude | shell" >&2
+        echo "valid modes: dispatcher | bootstrap | install-plugin <name> | update-plugins [--freeze|--unfreeze] | hydrate-env | smoke-test | claude | shell" >&2
         exit 2
         ;;
 esac

--- a/docs/runtime-pull-plugins.md
+++ b/docs/runtime-pull-plugins.md
@@ -1,0 +1,72 @@
+# Runtime-pull plugins (behalfbot#53, Phase 0)
+
+Plugins are moving from image-baked copies to a single source-of-truth repo,
+`scrollinondubs/behalfbot-plugins` (PLUGINS_REPO), fetched at a pinned tag+SHA.
+This kills the copy-drift class of bug (the loom-vision transcript break of
+2026-07-15) structurally: one copy, fetched fresh, nothing local to fall out
+of sync.
+
+## The four layers
+
+Plugin discovery searches these roots in order; the first directory containing
+`<name>/openclaw.plugin.json` wins:
+
+| Layer | Path (container) | What lives here |
+|---|---|---|
+| 1. plugins-local | `$CUSTOMER_HOME/plugins-local/` | Customer-private plugins that are never published (e.g. angel-protocol, dating on the reference install). Highest precedence - local always overrides. |
+| 2. legacy customer | `$CUSTOMER_HOME/plugins/` | Pre-existing customer-local plugins (midnight-oil etc.). Kept for back-compat; new private plugins should use plugins-local/. NEVER a fetch destination. |
+| 3. vendored (fetched) | `$CUSTOMER_HOME/vendored-plugins/` | Public plugins fetched from behalfbot-plugins at the pinned tag+SHA. On the customer bind mount: writable at runtime, survives container recreate. Gitignored customer-side; reproducible from plugins.lock. |
+| 4. baked fallback | `/app/plugins` | Image-baked OFFLINE FALLBACK during migration. Read-only. Goes away one VERSION cycle after Phase 2. |
+
+## Pin and lockfile
+
+- **`chassis/PLUGINS_PIN`** (next to `chassis/VERSION`): one line, `<tag> <40-hex-sha>`.
+  The SHA is the gate. `fetch-plugins.sh` resolves the tag remotely and refuses
+  to fetch when the resolved SHA differs from the pin - a force-moved tag never
+  auto-refetches. The pin moves ONLY at a chassis VERSION bump (Sean-gated),
+  in the same PR as VERSION.
+- **`$CUSTOMER_HOME/plugins.lock`** (committed customer-side): records repo,
+  tag, commit, fetched_at, chassis_version, frozen flag, and per-plugin
+  `{version, tag, sha}`. The lockfile diff in each customer repo is the audit
+  trail for every plugin change.
+
+## Flow
+
+1. `docker/entrypoint.sh` runs `fetch_plugins` at `dispatcher` and `bootstrap`
+   boot (best-effort - a fetch problem never takes the bot down), and exposes
+   an explicit `update-plugins` mode that propagates failures.
+2. `chassis/scripts/fetch-plugins.sh` reads the pin, verifies tag-vs-SHA,
+   downloads the tarball at the pinned SHA, sanity-checks the tree against
+   `registry.json`, atomically swaps it into `vendored-plugins/`, and writes
+   `plugins.lock`. Unpinned (no pin line) = no-op; `--freeze` skips fetching
+   entirely for air-gapped installs.
+3. `bootstrap.sh` step 9 (`activate_plugins`) calls
+   `chassis/scripts/activate-plugins.sh`, which for each enabled module
+   (`chassis.config.yaml` `modules.<name>.enabled`, parsed by the shared
+   `chassis/scripts/lib/enabled-plugins.py`):
+   - runs the plugin's `setup.sh` (idempotent contract; failures WARN),
+   - writes `$CUSTOMER_HOME/chassis-env.sh` from manifest `contracts.env`,
+   - merges manifest `contracts.mcpServers` into `$CUSTOMER_HOME/.mcp.json`
+     using `"_managed_by": "behalfbot-plugin:<name>"` markers (re-runs replace
+     managed entries; manual entries are never touched),
+   - re-merges plugin triggers via `merge-plugin-triggers.sh`, which now
+     searches the same four layers.
+
+## Delivery caveat (not zero-touch)
+
+`entrypoint.sh` and `bootstrap.sh` execute from the IMAGE, not the clone
+overlay. Activating this machinery therefore requires an image release plus a
+container recreate. Until then, a refreshed clone alone changes nothing at
+boot (old image has no fetch step), and a new image with a stale clone
+degrades gracefully: `activate_plugins` finds no `activate-plugins.sh` and
+skips with a WARN, `fetch_plugins` finds no pin line and no-ops, and the baked
+tree keeps driving - byte-identical behavior to today. The chassis-script side
+(fetcher, activator, trigger merge) deliberately rides the clone so later
+fixes there do NOT need an image release.
+
+## Status
+
+Phase 0 ships the machinery dormant: `scrollinondubs/behalfbot-plugins` does
+not exist yet and `PLUGINS_PIN` is unpinned, so every install keeps running the
+baked tree until Sean creates the repo, tags it, and lands a pin + VERSION
+bump. Repo creation, first tag, and every pin move are Sean-gated.


### PR DESCRIPTION
Phase 0 consumption machinery for the runtime-pull plugin decision on #53 (Option B - install-time fetch). Nothing activates until Sean creates `scrollinondubs/behalfbot-plugins`, tags it, and lands a pin: `chassis/PLUGINS_PIN` ships UNPINNED, so every install keeps running the image-baked `/app/plugins` tree byte-identically.

## What it does

- **Fetch**: `chassis/scripts/fetch-plugins.sh` reads `chassis/PLUGINS_PIN` (`<tag> <40-hex-sha>`, sibling of `chassis/VERSION`), resolves the tag via `git ls-remote`, downloads the tarball at the pinned SHA, sanity-checks the tree against `registry.json`, atomically swaps it into `$CUSTOMER_HOME/vendored-plugins/`, and writes `$CUSTOMER_HOME/plugins.lock` (repo, tag, commit, per-plugin `{version, tag, sha}`). `--freeze` / `--unfreeze` for air-gapped installs. Boot-time fetch is best-effort - a network failure never takes the bot down; the explicit `update-plugins` entrypoint mode propagates failures.
- **Activation**: `bootstrap.sh` step 9 `activate_plugins()` is no longer a log-only stub. It calls `chassis/scripts/activate-plugins.sh`, which discovers enabled plugins across the layers, runs each plugin's `setup.sh`, writes `$CUSTOMER_HOME/chassis-env.sh` from manifest `contracts.env`, merges `contracts.mcpServers` into `.mcp.json` under `"_managed_by": "behalfbot-plugin:<name>"` markers (re-runs replace managed entries, manual entries untouched), and re-merges triggers.
- **Layering** (first hit wins): `$CUSTOMER_HOME/plugins-local/` (customer-private plugins, never published) > `$CUSTOMER_HOME/plugins/` (legacy customer-local, e.g. midnight-oil) > `$CUSTOMER_HOME/vendored-plugins/` (fetched) > `/app/plugins` (image-baked offline fallback during migration).

## The 4 adversarial-review fixes applied (from the #53 review)

1. **Fetch destination is NOT `$CUSTOMER_HOME/plugins`** (finding 1). That dir holds live customer-local plugins and is never written by the fetcher. Fetch lands in `$CUSTOMER_HOME/vendored-plugins/` - on the existing customer bind mount, writable by the runtime uid, survives container recreate. `merge-plugin-triggers.sh`'s hardcoded `chassis_home/"plugins"` lookup is replaced with the layered search path as an in-scope code change, not an assumed-true one.
2. **SHA is the gate, not the tag** (finding 3, fleet-RCE). `PLUGINS_PIN` records `<tag> <sha>`; the fetcher resolves the tag remotely and REFUSES to fetch (exit 3, previous tree untouched) when the resolved SHA differs from the pin. A force-moved tag never auto-refetches. A bare tag with no SHA is rejected as malformed. Verified live against a real public tag with a mismatched pin.
3. **Mixed image/clone states degrade gracefully** (finding 2). `entrypoint.sh` and `bootstrap.sh` execute from the image, so old-image + new-clone keeps booting byte-identically (no fetch step exists there), and new-image + stale-clone finds no pin/activator and WARN-skips onto the baked tree. The activation and fetch MEAT lives in chassis scripts that ride the clone overlay, so post-release fixes there do not need another image release.
4. **Real `activate_plugins()`** (original review's weakest-assumption finding). Enabled-gating via a shared parser (`lib/enabled-plugins.py`, extracted so `merge-plugin-triggers.sh` and the activator cannot drift), `setup.sh` execution with WARN-not-fatal failures, env contract emission, managed MCP registration, trigger merge across layers. Functionally tested: layering precedence, idempotent re-runs, manual `.mcp.json` entries preserved.

## Migration note - NOT zero-touch

Because `entrypoint.sh` and `bootstrap.sh` are image-baked, activating this machinery requires an **image release + container recreate**. A chassis clone refresh alone changes nothing at boot. Until that release, this PR is inert everywhere.

## Sean-gated items (none of them in this PR)

- Creating `scrollinondubs/behalfbot-plugins` (public; only public-safe plugins - private ones stay install-side in `plugins-local/`)
- First tag + first pin line in `PLUGINS_PIN`
- chassis VERSION bump (untouched here, still 0.1.1)
- Image release / recreate

Do not merge without Sean's ratification.
