### PR TITLE
fix(chassis-update): make the post-update healthcheck able to fail

### DIFF
--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -1,0 +1,33 @@
+name: Shell unit tests
+
+# shell-lint.yml runs shellcheck, which catches syntax and idiom problems but
+# no behavior. The chassis-update healthcheck bug this job guards was valid
+# shell that always returned success, so lint could never have caught it.
+#
+# Scoped to the self-contained suites only. test-daily-log-gather.sh is not
+# here: it needs python3 + jq and is run by hand.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'chassis/scripts/_chassis-update-health.sh'
+      - 'chassis/scripts/chassis-update.sh'
+      - 'chassis/scripts/test-chassis-update-health.sh'
+      - '.github/workflows/shell-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'chassis/scripts/_chassis-update-health.sh'
+      - 'chassis/scripts/chassis-update.sh'
+      - 'chassis/scripts/test-chassis-update-health.sh'
+      - '.github/workflows/shell-tests.yml'
+  workflow_dispatch:
+
+jobs:
+  chassis-update-health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # No docker daemon needed - the suite stubs the docker CLI on PATH.
+      - run: bash chassis/scripts/test-chassis-update-health.sh

--- a/chassis/scripts/_chassis-update-health.sh
+++ b/chassis/scripts/_chassis-update-health.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# _chassis-update-health.sh - container discovery + VERSION probe for the
+# post-update healthcheck in chassis-update.sh.
+#
+# Sourced, never executed. Split out of chassis-update.sh so the discovery and
+# probe logic is testable without running a real update
+# (see test-chassis-update-health.sh).
+#
+# Why this exists
+# ===============
+# The original healthcheck (chassis-update.sh v0.1.0 - v0.1.1) was decorative.
+# Two independent defects stacked:
+#
+#   1. It ran `docker exec "$c" cat /chassis/VERSION`. The Dockerfile copies the
+#      tree to /app/chassis (`COPY chassis/ /app/chassis/`), so that read has
+#      NEVER succeeded on any image the repo has ever published. Verified by
+#      building `FROM busybox` + the same COPY line: /app/chassis/VERSION reads
+#      0.1.1, /chassis/VERSION does not exist.
+#   2. It found the container with `docker ps --filter label=com.behalfbot.chassis`.
+#      Nothing in the repo ever set that label - not the Dockerfile (it has no
+#      LABEL instruction at all), not docker-compose.yml, not docker-publish.yml
+#      (which stamps only org.opencontainers.image.* via metadata-action). The
+#      filter matched zero containers on a live install with the chassis
+#      container up and healthy.
+#
+# Either defect alone dropped the check through to a host-disk fallback that
+# compared the VERSION file the subtree pull had just advanced against the
+# upstream VERSION it was pulled from. That comparison is a tautology: it passes
+# whether or not the container ever restarted. Net effect - a container stuck on
+# the old image reported healthy, and the rollback in step 7 could not fire.
+#
+# The contract now: in container mode the container read is the ONLY evidence
+# that counts. There is no disk fallback. A healthcheck that cannot read the
+# container does not get to report success.
+
+# Where the image puts the chassis tree. Matches `COPY chassis/ /app/chassis/`
+# in the Dockerfile and the CHASSIS_ROOT env the compose stack exports. Used
+# only when the container does not report CHASSIS_ROOT itself.
+CHASSIS_CONTAINER_ROOT_DEFAULT="/app/chassis"
+
+# Name of the running chassis container, or empty string if none is up.
+#
+# Three probes, most authoritative first. Compose knows the project layout, so
+# it wins. The label probe is kept because docker-compose.yml now sets
+# com.behalfbot.chassis - it covers installs whose compose file this script
+# cannot see. The container_name probe is the last resort for hand-run
+# `docker run` installs.
+chassis_find_container() {
+    local compose_dir="${1:-}"
+    local name=""
+
+    if [[ -n "$compose_dir" && -f "${compose_dir}/docker-compose.yml" ]]; then
+        name=$(cd "$compose_dir" && docker compose ps --format '{{.Name}}' chassis 2>/dev/null | head -1)
+    fi
+    if [[ -z "$name" ]]; then
+        name=$(docker ps --filter "label=com.behalfbot.chassis" --format '{{.Names}}' 2>/dev/null | head -1)
+    fi
+    if [[ -z "$name" ]]; then
+        name=$(docker ps --filter "name=^behalfbot$" --format '{{.Names}}' 2>/dev/null | head -1)
+    fi
+
+    printf '%s' "$name"
+}
+
+# Print the VERSION the given container is actually running. Returns non-zero
+# and prints nothing when the read fails, so callers can tell "container says
+# 0.1.1" apart from "could not ask the container".
+#
+# CHASSIS_ROOT is read from the container rather than hardcoded. That way a
+# future image that relocates the tree stays correct without another silent
+# path drift like the /chassis one this replaces.
+chassis_container_version() {
+    local container="$1"
+    local root version
+
+    [[ -z "$container" ]] && return 1
+
+    root=$(docker exec "$container" printenv CHASSIS_ROOT 2>/dev/null | tr -d '[:space:]')
+    [[ -z "$root" ]] && root="$CHASSIS_CONTAINER_ROOT_DEFAULT"
+
+    version=$(docker exec "$container" cat "${root}/VERSION" 2>/dev/null | tr -d '[:space:]')
+    [[ -z "$version" ]] && return 1
+
+    printf '%s' "$version"
+}
+
+# Which healthcheck contract applies: "container" or "host".
+#
+# Container mode requires proof from inside the container. Host mode (no docker
+# binary, or no compose file to bring a container up with) is the legitimate
+# case for a disk-based check - some installs run the dispatcher directly on the
+# host. The distinction is made ONCE, up front, from facts that do not change
+# mid-poll. It is deliberately not a per-iteration fallback: that is exactly how
+# the old check degraded into always passing.
+chassis_healthcheck_mode() {
+    local compose_dir="${1:-}"
+
+    command -v docker >/dev/null 2>&1 || { printf 'host'; return; }
+    [[ -n "$compose_dir" && -f "${compose_dir}/docker-compose.yml" ]] || { printf 'host'; return; }
+
+    printf 'container'
+}
+
+# Image ref the chassis container is currently running, for rollback pinning.
+# Empty when there is no container to ask.
+chassis_container_image() {
+    local container="$1"
+    [[ -z "$container" ]] && return 1
+    docker inspect --format '{{.Image}}' "$container" 2>/dev/null | tr -d '[:space:]'
+}

--- a/chassis/scripts/chassis-update.sh
+++ b/chassis/scripts/chassis-update.sh
@@ -30,6 +30,10 @@ CUSTOMER_HOME="${CUSTOMER_HOME:-${HOME}/.behalfbot}"
 # overlay-mount install layouts; see gather-chassis-update-check.sh header).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LOCAL_VERSION_FILE="${SCRIPT_DIR}/../VERSION"
+# Container discovery + VERSION probe. Split into a sourceable lib so the
+# healthcheck logic is testable without running a real update.
+# shellcheck source=chassis/scripts/_chassis-update-health.sh
+source "${SCRIPT_DIR}/_chassis-update-health.sh"
 UPSTREAM_REMOTE_URL="${CHASSIS_UPDATE_REMOTE:-https://github.com/scrollinondubs/behalfbot.git}"
 UPSTREAM_REMOTE_NAME="chassis"
 UPSTREAM_BRANCH="main"
@@ -57,13 +61,30 @@ mkdir -p "$STATE_DIR" "$BACKUP_DIR"
 log() { printf '[chassis-update] %s\n' "$*"; }
 die() { printf '[chassis-update] FATAL: %s\n' "$*" >&2; exit 1; }
 
+# This script runs without `set -e` on purpose - the healthcheck and drain
+# loops depend on non-zero exits being survivable. That made dry_or_run a silent
+# failure sink: `eval` returning non-zero was discarded, so a failed
+# `git subtree pull` or a failed `docker compose up -d` flowed straight on to
+# the healthcheck as though it had worked. Every step that must succeed now
+# aborts here instead.
 dry_or_run() {
     if [[ $DRY_RUN -eq 1 ]]; then
         log "DRY-RUN: $*"
-    else
-        log "+ $*"
-        eval "$@"
+        return 0
     fi
+    log "+ $*"
+    eval "$@" || die "command failed: $*"
+}
+
+# Best-effort variant for the rollback path, where a failing step must be loud
+# but must not abort before the remaining recovery steps get a chance to run.
+dry_or_run_soft() {
+    if [[ $DRY_RUN -eq 1 ]]; then
+        log "DRY-RUN: $*"
+        return 0
+    fi
+    log "+ $*"
+    eval "$@" || { log "WARN: command failed (continuing recovery): $*"; return 1; }
 }
 
 # --- Mode detection ---
@@ -84,13 +105,46 @@ detect_mode() {
 MODE=$(detect_mode)
 log "Mode: $MODE"
 
+# --- Snapshot restore, shared by --rollback and the healthcheck failure path ---
+#
+# Restoring chassis/ on disk is only half of a rollback. When the install runs
+# containers, the code that actually executes lives in the image, and
+# `docker compose up -d` after a restore just re-resolves the same (new) tag.
+# So each snapshot carries a sidecar recording the image the container was on
+# BEFORE the update, and the restore pins CHASSIS_IMAGE back to it.
+restore_snapshot() {
+    local snapshot="$1"
+    local compose_dir="$2"
+    local image_sidecar="${snapshot%.tgz}.image"
+    local pinned_image=""
+
+    log "Restoring from $snapshot"
+    dry_or_run_soft "cd '$CHASSIS_HOME' && tar xzf '$snapshot'"
+
+    if [[ ! -f "${compose_dir}/docker-compose.yml" ]]; then
+        log "No docker-compose.yml at $compose_dir; disk restore only, no container to roll back"
+        return 0
+    fi
+
+    if [[ -s "$image_sidecar" ]]; then
+        pinned_image=$(tr -d '[:space:]' < "$image_sidecar")
+    fi
+    if [[ -n "$pinned_image" ]]; then
+        log "Pinning container back to pre-update image: $pinned_image"
+        dry_or_run_soft "cd '$compose_dir' && CHASSIS_IMAGE='$pinned_image' docker compose up -d --force-recreate"
+    else
+        log "WARN: no pre-update image recorded for this snapshot. The disk tree is"
+        log "WARN: restored but the container will come back up on whatever"
+        log "WARN: CHASSIS_IMAGE currently resolves to. Verify the running version by hand."
+        dry_or_run_soft "cd '$compose_dir' && docker compose up -d"
+    fi
+}
+
 # --- Rollback path (independent of normal apply flow) ---
 if [[ $ROLLBACK -eq 1 ]]; then
     LATEST_BACKUP=$(ls -1t "$BACKUP_DIR"/chassis-pre-v*.tgz 2>/dev/null | head -1)
     [[ -z "$LATEST_BACKUP" ]] && die "no backups found in $BACKUP_DIR"
-    log "Restoring from $LATEST_BACKUP"
-    dry_or_run "cd '$CHASSIS_HOME' && tar xzf '$LATEST_BACKUP'"
-    dry_or_run "cd '$CHASSIS_HOME' && docker compose up -d"
+    restore_snapshot "$LATEST_BACKUP" "$CHASSIS_HOME"
     log "Rollback complete. Verify health manually."
     exit 0
 fi
@@ -151,6 +205,21 @@ SNAPSHOT="${BACKUP_DIR}/chassis-pre-v${UPSTREAM_VERSION}-$(date -u +%Y%m%dT%H%M%
 log "Snapshot: $SNAPSHOT"
 dry_or_run "cd '$CHASSIS_HOME' && tar czf '$SNAPSHOT' chassis/"
 
+# Record the image the container is on right now, so a rollback can pin back to
+# it. Without this the container half of a rollback is a no-op: restoring the
+# source tree does nothing to a container running a published image.
+PRE_UPDATE_CONTAINER=$(chassis_find_container "$CHASSIS_HOME")
+if [[ $DRY_RUN -eq 0 && -n "$PRE_UPDATE_CONTAINER" ]]; then
+    PRE_UPDATE_IMAGE=$(chassis_container_image "$PRE_UPDATE_CONTAINER" || echo "")
+    if [[ -n "$PRE_UPDATE_IMAGE" ]]; then
+        printf '%s\n' "$PRE_UPDATE_IMAGE" > "${SNAPSHOT%.tgz}.image"
+        log "Pre-update image recorded: $PRE_UPDATE_IMAGE"
+    else
+        log "WARN: could not read the current image of container '$PRE_UPDATE_CONTAINER'."
+        log "WARN: a rollback will restore the disk tree but not the container image."
+    fi
+fi
+
 # --- Step 4: drain in-flight heartbeats ---
 log "Drain: waiting for in-flight heartbeat (timeout ${DRAIN_TIMEOUT_SECONDS}s)..."
 if [[ $DRY_RUN -eq 0 ]]; then
@@ -194,38 +263,57 @@ else
 fi
 
 # --- Step 7: healthcheck ---
-log "Healthcheck: polling (timeout ${HEALTHCHECK_TIMEOUT_SECONDS}s)..."
+#
+# The contract, decided ONCE before the poll starts rather than per-iteration:
+#
+#   container mode - docker is present and there is a compose file, so the code
+#       that runs lives in an image. The ONLY acceptable evidence is the running
+#       container reporting the new VERSION. There is no disk fallback. If the
+#       container cannot be found or cannot be read, that is a failure.
+#   host mode - no docker, or no compose file. Nothing was containerized, so the
+#       VERSION file on disk is the real artifact and checking it is honest.
+#
+# The old code tried container mode inside the loop and fell through to the disk
+# check on any miss. Since the disk check compares the file the subtree pull
+# just wrote against the upstream value it was pulled from, it passed
+# unconditionally - which is why the rollback below had never once fired.
+HEALTHCHECK_MODE=$(chassis_healthcheck_mode "$COMPOSE_DIR")
+log "Healthcheck: ${HEALTHCHECK_MODE} mode, polling (timeout ${HEALTHCHECK_TIMEOUT_SECONDS}s)..."
 if [[ $DRY_RUN -eq 0 ]]; then
     healthy=0
+    last_reason="no poll ran"
     for ((i=0; i<HEALTHCHECK_TIMEOUT_SECONDS; i++)); do
-        # Verify the running container reports the same VERSION we just pulled.
-        # Docker exec is the canonical check; fall back to file-based check if
-        # no container is running (some installs run the dispatcher on the host).
-        if command -v docker >/dev/null 2>&1; then
-            CONTAINER_NAME=$(docker ps --filter "label=com.behalfbot.chassis" --format '{{.Names}}' 2>/dev/null | head -1)
-            if [[ -n "$CONTAINER_NAME" ]]; then
-                RUNNING_VERSION=$(docker exec "$CONTAINER_NAME" cat /chassis/VERSION 2>/dev/null | tr -d '[:space:]' || echo "")
-                if [[ "$RUNNING_VERSION" == "$UPSTREAM_VERSION" ]]; then
+        if [[ "$HEALTHCHECK_MODE" == "container" ]]; then
+            CONTAINER_NAME=$(chassis_find_container "$COMPOSE_DIR")
+            if [[ -z "$CONTAINER_NAME" ]]; then
+                last_reason="no running chassis container found"
+            else
+                RUNNING_VERSION=$(chassis_container_version "$CONTAINER_NAME") || RUNNING_VERSION=""
+                if [[ -z "$RUNNING_VERSION" ]]; then
+                    last_reason="container '$CONTAINER_NAME' is up but VERSION could not be read from it"
+                elif [[ "$RUNNING_VERSION" == "$UPSTREAM_VERSION" ]]; then
                     healthy=1
+                    log "Container '$CONTAINER_NAME' reports v$RUNNING_VERSION"
                     break
+                else
+                    last_reason="container '$CONTAINER_NAME' still reports v$RUNNING_VERSION, expected v$UPSTREAM_VERSION"
                 fi
             fi
-        fi
-        # Host-mode fallback: just verify VERSION file on disk advanced.
-        DISK_VERSION=$(tr -d '[:space:]' < "$LOCAL_VERSION_FILE" 2>/dev/null || echo "")
-        if [[ "$DISK_VERSION" == "$UPSTREAM_VERSION" ]]; then
-            healthy=1
-            break
+        else
+            DISK_VERSION=$(tr -d '[:space:]' < "$LOCAL_VERSION_FILE" 2>/dev/null || echo "")
+            if [[ "$DISK_VERSION" == "$UPSTREAM_VERSION" ]]; then
+                healthy=1
+                log "Host-mode VERSION on disk is v$DISK_VERSION"
+                break
+            fi
+            last_reason="VERSION on disk is v${DISK_VERSION:-<unreadable>}, expected v$UPSTREAM_VERSION"
         fi
         sleep 1
     done
     if [[ $healthy -eq 0 ]]; then
         log "FAIL: healthcheck did not converge within ${HEALTHCHECK_TIMEOUT_SECONDS}s"
-        log "Rolling back from snapshot: $SNAPSHOT"
-        dry_or_run "cd '$CHASSIS_HOME' && tar xzf '$SNAPSHOT'"
-        if [[ -f "${COMPOSE_DIR}/docker-compose.yml" ]]; then
-            dry_or_run "cd '$COMPOSE_DIR' && docker compose up -d"
-        fi
+        log "FAIL: last observed state - $last_reason"
+        restore_snapshot "$SNAPSHOT" "$COMPOSE_DIR"
         die "update failed and was rolled back"
     fi
 fi
@@ -233,6 +321,12 @@ fi
 # --- Step 8: run migration script if present ---
 # Migrations are strictly automated shell scripts. Judgment-heavy migrations
 # would have been flagged BREAKING CHANGES and gated behind --force above.
+#
+# chassis/scripts/chassis-migrations/ does not exist in the repo yet - no
+# release has needed a state migration. That is fine and deliberate: the `-f`
+# test below is false for a path under a missing directory just as it is for a
+# missing file, so the step no-ops. The directory gets created by whichever
+# release first ships a migration. Do not pre-create it empty.
 MIGRATION_SCRIPT="${CHASSIS_HOME}/chassis/scripts/chassis-migrations/v${UPSTREAM_VERSION}.sh"
 if [[ -f "$MIGRATION_SCRIPT" ]]; then
     log "Running migration: $MIGRATION_SCRIPT"

--- a/chassis/scripts/test-chassis-update-health.sh
+++ b/chassis/scripts/test-chassis-update-health.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# test-chassis-update-health.sh - Unit tests for the chassis-update healthcheck
+# primitives in _chassis-update-health.sh.
+#
+# The bug these lock down
+# =======================
+# chassis-update.sh's post-update healthcheck could not fail. It looked for the
+# container with `docker ps --filter label=com.behalfbot.chassis` (a label
+# nothing set) and read `/chassis/VERSION` (a path the image does not have - the
+# Dockerfile copies to /app/chassis). Both misses fell through to a host-disk
+# check that compared the VERSION file the subtree pull had just written against
+# the upstream value it came from, so it passed unconditionally. The rollback it
+# was supposed to trigger therefore never ran.
+#
+# These tests stub `docker` on PATH, so no daemon, no image and no network are
+# needed. Chassis test infra deliberately avoids both.
+#
+# Exit codes:
+#   0 - all scenarios passed
+#   1 - one or more scenarios failed
+#   2 - test harness itself broke
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="${SCRIPT_DIR}/_chassis-update-health.sh"
+
+if [[ ! -f "$LIB" ]]; then
+    echo "test-chassis-update-health: lib not found at $LIB" >&2
+    exit 2
+fi
+# shellcheck source=chassis/scripts/_chassis-update-health.sh
+source "$LIB"
+
+fail=0
+pass=0
+
+check() {
+    local name="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        pass=$((pass + 1))
+    else
+        echo "FAIL [$name] expected '$expected', got '$actual'"
+        fail=$((fail + 1))
+    fi
+}
+
+check_status() {
+    local name="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        pass=$((pass + 1))
+    else
+        echo "FAIL [$name] expected exit $expected, got $actual"
+        fail=$((fail + 1))
+    fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+STUB_BIN="${TMP}/bin"
+mkdir -p "$STUB_BIN"
+ORIGINAL_PATH="$PATH"
+
+# Install a `docker` stub. $1 is a shell body; it receives the real docker
+# argv and is responsible for the whole response.
+stub_docker() {
+    { printf '#!/bin/bash\n'; printf '%s\n' "$1"; } > "${STUB_BIN}/docker"
+    chmod +x "${STUB_BIN}/docker"
+    PATH="${STUB_BIN}:${ORIGINAL_PATH}"
+}
+
+# PATH is narrowed to the stub dir alone, not prepended, so a real docker on
+# the developer's machine cannot satisfy the `command -v docker` probe. The
+# functions under test use only bash builtins, so nothing else is needed.
+no_docker() {
+    rm -f "${STUB_BIN}/docker"
+    PATH="${STUB_BIN}"
+}
+
+# A compose dir is just a directory holding a docker-compose.yml.
+COMPOSE_DIR="${TMP}/install"
+mkdir -p "$COMPOSE_DIR"
+echo "services: {}" > "${COMPOSE_DIR}/docker-compose.yml"
+BARE_DIR="${TMP}/hostmode"
+mkdir -p "$BARE_DIR"
+
+# ---------------------------------------------------------------------------
+# chassis_healthcheck_mode
+# ---------------------------------------------------------------------------
+stub_docker 'exit 0'
+check "mode/compose-present-is-container" "container" "$(chassis_healthcheck_mode "$COMPOSE_DIR")"
+check "mode/no-compose-is-host" "host" "$(chassis_healthcheck_mode "$BARE_DIR")"
+check "mode/empty-dir-arg-is-host" "host" "$(chassis_healthcheck_mode "")"
+
+no_docker
+check "mode/no-docker-binary-is-host" "host" "$(chassis_healthcheck_mode "$COMPOSE_DIR")"
+PATH="${STUB_BIN}:${ORIGINAL_PATH}"
+
+# ---------------------------------------------------------------------------
+# chassis_find_container
+# ---------------------------------------------------------------------------
+# Compose is authoritative when the project file is visible.
+stub_docker '
+if [[ "$1" == "compose" ]]; then echo "behalfbot-from-compose"; exit 0; fi
+if [[ "$1" == "ps" ]]; then echo "behalfbot-from-ps"; exit 0; fi
+exit 1'
+check "find/compose-wins" "behalfbot-from-compose" "$(chassis_find_container "$COMPOSE_DIR")"
+
+# The regression that mattered: the label filter matches nothing on every real
+# install, because nothing set com.behalfbot.chassis. Discovery must still find
+# the container via the container_name probe.
+stub_docker '
+if [[ "$1" == "compose" ]]; then exit 1; fi
+if [[ "$1" == "ps" ]]; then
+    for a in "$@"; do
+        [[ "$a" == "label=com.behalfbot.chassis" ]] && exit 0   # matches nothing
+    done
+    echo "behalfbot"; exit 0
+fi
+exit 1'
+check "find/falls-back-past-unset-label" "behalfbot" "$(chassis_find_container "$COMPOSE_DIR")"
+
+# Nothing running anywhere: empty string, never a guess.
+stub_docker 'exit 0'
+check "find/nothing-running-is-empty" "" "$(chassis_find_container "$COMPOSE_DIR")"
+
+# ---------------------------------------------------------------------------
+# chassis_container_version
+# ---------------------------------------------------------------------------
+# The image puts the tree at /app/chassis and exports CHASSIS_ROOT. Reading the
+# old hardcoded /chassis/VERSION must NOT be what happens.
+stub_docker '
+if [[ "$1" == "exec" ]]; then
+    shift; container="$1"; shift
+    if [[ "$1" == "printenv" ]]; then echo "/app/chassis"; exit 0; fi
+    if [[ "$1" == "cat" ]]; then
+        [[ "$2" == "/app/chassis/VERSION" ]] && { echo "0.2.0"; exit 0; }
+        exit 1
+    fi
+fi
+exit 1'
+check "version/reads-chassis-root-path" "0.2.0" "$(chassis_container_version behalfbot)"
+
+# CHASSIS_ROOT unset in an older image: fall back to the documented default,
+# which is still /app/chassis and still not /chassis.
+stub_docker '
+if [[ "$1" == "exec" ]]; then
+    shift; container="$1"; shift
+    if [[ "$1" == "printenv" ]]; then exit 1; fi
+    if [[ "$1" == "cat" ]]; then
+        [[ "$2" == "/app/chassis/VERSION" ]] && { echo "0.1.1"; exit 0; }
+        exit 1
+    fi
+fi
+exit 1'
+check "version/default-root-when-env-unset" "0.1.1" "$(chassis_container_version behalfbot)"
+
+# Whitespace and trailing newline are stripped, as the version compare is ==.
+stub_docker '
+if [[ "$1" == "exec" ]]; then
+    shift; shift
+    if [[ "$1" == "printenv" ]]; then echo "/app/chassis"; exit 0; fi
+    if [[ "$1" == "cat" ]]; then printf "  0.2.0 \n"; exit 0; fi
+fi
+exit 1'
+check "version/strips-whitespace" "0.2.0" "$(chassis_container_version behalfbot)"
+
+# THE core honesty property: an unreadable VERSION must report failure, not an
+# empty string a caller might compare loosely, and never a silent success. This
+# is the exact shape of the original bug - the read failed on every install.
+stub_docker '
+if [[ "$1" == "exec" ]]; then
+    shift; shift
+    if [[ "$1" == "printenv" ]]; then echo "/app/chassis"; exit 0; fi
+    if [[ "$1" == "cat" ]]; then echo "cat: no such file" >&2; exit 1; fi
+fi
+exit 1'
+out=$(chassis_container_version behalfbot); status=$?
+check_status "version/unreadable-returns-nonzero" 1 "$status"
+check "version/unreadable-prints-nothing" "" "$out"
+
+# No container name to ask: same contract.
+out=$(chassis_container_version ""); status=$?
+check_status "version/empty-container-returns-nonzero" 1 "$status"
+
+# ---------------------------------------------------------------------------
+# chassis_container_image
+# ---------------------------------------------------------------------------
+stub_docker '
+if [[ "$1" == "inspect" ]]; then echo "sha256:deadbeef"; exit 0; fi
+exit 1'
+check "image/reads-inspect" "sha256:deadbeef" "$(chassis_container_image behalfbot)"
+
+out=$(chassis_container_image ""); status=$?
+check_status "image/empty-container-returns-nonzero" 1 "$status"
+
+PATH="$ORIGINAL_PATH"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "test-chassis-update-health: $pass passed, $fail failed"
+if [[ $fail -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,14 @@ services:
         INSTALLER_UID: ${INSTALLER_UID:-1000}
         INSTALLER_GID: ${INSTALLER_GID:-1000}
     container_name: behalfbot
+    # Discovery label for chassis-update.sh's post-update healthcheck. The
+    # updater has filtered on `label=com.behalfbot.chassis` since v0.1.0, but
+    # nothing ever set it - not the Dockerfile (no LABEL instruction), not this
+    # file, not docker-publish.yml (which stamps only org.opencontainers.image.*).
+    # The filter matched zero containers on every install, which is half of why
+    # the healthcheck silently degraded into a check that always passed.
+    labels:
+      com.behalfbot.chassis: "true"
     user: "${INSTALLER_UID:-1000}:${INSTALLER_GID:-1000}"
     # group_add lets the container's chassis user reach /var/run/docker.sock
     # without changing primary GID. The host docker socket is typically


### PR DESCRIPTION
## The bug

`chassis-update.sh`'s post-update healthcheck **could not fail**, so the rollback it guards had never once fired. The safety net was decorative.

Two independent defects, either one sufficient:

**1. Wrong container path.** Line 207 ran `docker exec "$c" cat /chassis/VERSION`. The Dockerfile copies the tree to `/app/chassis`:

```
Dockerfile:317   COPY --chown=chassis:chassis chassis/   /app/chassis/
```

Verified by building a probe image with `FROM busybox` plus that exact COPY line:

```
/app/chassis/VERSION -> 0.1.1
/chassis/VERSION     -> cat: can't open: No such file or directory
```

That read has never succeeded on any image this repo has published.

**2. The discovery label does not exist.** Line 205 used `docker ps --filter "label=com.behalfbot.chassis"`. Nothing in the repo ever set it: the Dockerfile has no `LABEL` instruction at all, docker-compose.yml did not set it, and `docker-publish.yml` stamps only `org.opencontainers.image.*` via metadata-action. On Sean's live install, with the chassis container up and healthy:

```
$ docker ps --filter "label=com.behalfbot.chassis" --format '{{.Names}}'
(empty)
```

**Why both misses were silent.** Either one dropped through to the host-disk fallback at line 215, which compared the `VERSION` file the subtree pull had *just written* against the upstream value it was pulled *from*. That comparison is a tautology. It passed whether or not the container ever restarted.

## What changed

- **`chassis/scripts/_chassis-update-health.sh`** (new). Container discovery and VERSION probe, split out so it is testable without running a real update. Discovery tries compose first, then the label, then `container_name`. The VERSION path comes from the container's own `CHASSIS_ROOT` rather than a hardcoded constant, so a future image relocation cannot repeat this drift.
- **`chassis/scripts/chassis-update.sh`**
  - Healthcheck mode is now decided **once**, before the poll, from facts that do not change mid-loop. Container mode requires proof from inside the container and has **no disk fallback**. Host mode (no docker binary, or no compose file) keeps the disk check, which is honest there because nothing was containerized. Failures log the last observed state.
  - `dry_or_run` no longer swallows non-zero exits. The script runs without `set -e` on purpose, which made `eval` a silent failure sink: a failed `git subtree pull` or `docker compose up -d` flowed straight into the healthcheck as though it had worked. Added `dry_or_run_soft` for the recovery path, where a failing step must be loud but must not abort the remaining steps.
  - Snapshots record the pre-update image; rollback pins `CHASSIS_IMAGE` back to it. Restoring `chassis/` on disk is only half a rollback - on a containerized install the code that runs lives in the image, and `docker compose up -d` after a restore just re-resolves the same new tag.
- **`docker-compose.yml`**: sets `com.behalfbot.chassis: "true"` so the label the updater has always filtered on finally exists.
- **`chassis/scripts/test-chassis-update-health.sh`** (new): 15 unit tests stubbing the `docker` CLI. No daemon, no image, no network.
- **`.github/workflows/shell-tests.yml`** (new): runs that suite. `shell-lint.yml` could never have caught this - it was valid shell that always returned success.

## Other silent-degradation bugs found

| Bug | Status |
|---|---|
| `dry_or_run` discarded `eval` exit status (no `set -e`) - failed pull continued to healthcheck | Fixed |
| Rollback restored the disk tree but not the container image, so the container half was a no-op | Fixed |
| `--rollback` ran `docker compose up -d` without checking a compose file exists | Fixed |
| Live install runs an image built 2026-06-01, predating `chassis/VERSION` (2026-06-22), so `/app/chassis/VERSION` is absent there too | Not a code bug. Resolves when Sean pulls a current image. The new check reports this loudly instead of passing. |

## chassis-migrations

`chassis/scripts/chassis-migrations/` does not exist, and **the code handles that correctly**. `[[ -f "$MIGRATION_SCRIPT" ]]` is false for a path under a missing directory exactly as it is for a missing file, so step 8 no-ops. No fix needed. Added a comment saying so, and saying not to pre-create the directory empty.

## Test plan

- [x] `bash chassis/scripts/test-chassis-update-health.sh` - **15 passed, 0 failed**
- [x] `pytest chassis/second_brain/tests/ -q` - **108 passed** (unchanged, no Python touched)
- [x] `shellcheck -S error` on all three shell files - clean (CI severity)
- [x] Probe image proves `/app/chassis/VERSION` = 0.1.1 and `/chassis/VERSION` absent
- [x] Live install: old label filter returns empty, new discovery returns `behalfbot`
- [x] E2E sandbox, failed `git pull`: aborts at the pull instead of continuing to the healthcheck
- [x] E2E sandbox, container stuck on old version: healthcheck **FAILS**, logs `container 'behalfbot' still reports v0.1.1, expected v0.2.0`, restores the tree to 0.1.1, pins the image back. This is the exact case that used to pass silently.
- [x] E2E sandbox, container on new version: converges, logs `Container 'behalfbot' reports v0.2.0`
- [x] E2E sandbox, no compose file: `host mode`, disk check, succeeds

## Not in this PR

`chassis/VERSION` untouched, per the ask-first convention. No CHANGELOG entry - these changes belong in the v0.2.0 entry Jax will fold in once you approve the bump.

## Tags for Sean to push

**Not pushed by this PR** - tagging triggers `docker-publish.yml` and a real image release. Run these yourself.

`chassis-version-validate.yml` asserts on tag push that the tag matches `chassis/VERSION` **at that commit**, so these two commits are the only valid targets:

```bash
cd /path/to/behalfbot && git fetch --all

# v0.1.0 - merge of PR #34 (auto-updater, 2026-06-22). chassis/VERSION = 0.1.0 there.
git tag -a v0.1.0 8250a1d -m "chassis v0.1.0"

# v0.1.1 - merge of PR #43 (version bump, 2026-07-02). chassis/VERSION = 0.1.1 there.
git tag -a v0.1.1 965e037 -m "chassis v0.1.1"

git push origin v0.1.0 v0.1.1
```

For v0.2.0, after both PRs are merged **and** a separate PR bumps `chassis/VERSION` to `0.2.0`:

```bash
git checkout main && git pull
grep . chassis/VERSION          # must print 0.2.0 before tagging
git tag -a v0.2.0 -m "chassis v0.2.0"
git push origin v0.2.0
```

Each push builds and publishes a multi-arch image to `ghcr.io/scrollinondubs/behalfbot`.
