### PR TITLE
fix(second-brain): one Notion token var, guards, and no placeholder bearer tokens

### DIFF
--- a/chassis/.mcp.json.template
+++ b/chassis/.mcp.json.template
@@ -55,7 +55,7 @@
       "command": "npx",
       "args": ["-y", "@suekou/mcp-notion-server"],
       "env": {
-        "NOTION_API_TOKEN": "<NOTION_INTEGRATION_TOKEN>"
+        "NOTION_API_TOKEN": "<NOTION_API_TOKEN>"
       }
     },
 
@@ -70,7 +70,7 @@
         "SIYUAN_URL": "<SIYUAN_URL>",
         "SIYUAN_TOKEN": "<SIYUAN_TOKEN>",
         "SIYUAN_DEEPLINK_BASE": "<SIYUAN_DEEPLINK_BASE>",
-        "NOTION_API_TOKEN": "<NOTION_INTEGRATION_TOKEN>"
+        "NOTION_API_TOKEN": "<NOTION_API_TOKEN>"
       }
     },
 

--- a/chassis/scripts/hydrate-env-from-vw.sh
+++ b/chassis/scripts/hydrate-env-from-vw.sh
@@ -71,6 +71,13 @@ fi
 #
 # "@dotenv" means parse the notes field as a KEY=value dotenv block.
 
+# Notion note: the Vaultwarden ITEM name below is unchanged. Only the env var
+# it is written out as changed, NOTION_INTEGRATION_TOKEN -> NOTION_API_TOKEN.
+# The chassis carried two names for one secret - the factory and .env.example
+# said NOTION_API_TOKEN, this script and .mcp.json.template said
+# NOTION_INTEGRATION_TOKEN. The Vaultwarden path happened to work; an installer
+# who followed .env.example instead shipped the literal placeholder string as
+# their bearer token and 401'd on every call. No VW item needs renaming.
 DEFAULT_MANIFEST=$(cat <<'JSON'
 {
   "Behalf.bot - Google Workspace agent": {
@@ -87,7 +94,7 @@ DEFAULT_MANIFEST=$(cat <<'JSON'
   "Behalf.bot - Slack bot token": "SLACK_BOT_TOKEN",
   "Behalf.bot - Slack workspace_id": "SLACK_WORKSPACE_ID",
   "Behalf.bot - Slack Marc user_id": "INSTALLER_SLACK_USER_ID",
-  "Behalf.bot - Notion integration token": "NOTION_INTEGRATION_TOKEN",
+  "Behalf.bot - Notion integration token": "NOTION_API_TOKEN",
   "Behalf.bot - Notion DB IDs": {"notes": "@dotenv"},
   "Behalf.bot - Vaultwarden API token": "RBW_VW_API_TOKEN",
   "Behalf.bot - Postgres password": "POSTGRES_PASSWORD",

--- a/chassis/scripts/hydrate-mcp-json.py
+++ b/chassis/scripts/hydrate-mcp-json.py
@@ -246,13 +246,55 @@ def substitute_placeholders(value, env, unresolved):
     return value
 
 
+# Env var names that carry a secret. An unresolved placeholder in one of these
+# becomes an Authorization header, so it must never survive into the output.
+# Names outside this set (GOOGLE_OAUTH_CREDENTIALS, SIYUAN_URL, *_DIR, ...) are
+# paths and hosts: a leftover placeholder there is visibly wrong at startup and
+# leaks nothing, so it keeps the existing pass-through-and-warn behavior.
+_CREDENTIAL_NAME_PAT = re.compile(r'(TOKEN|SECRET|PASSWORD|_KEY|APIKEY|_PAT)$')
+
+
+def drop_unresolved_env(entry, unresolved):
+    """Remove credential env keys whose value still carries a <PLACEHOLDER>.
+
+    An unresolved placeholder used to survive into the output verbatim, so a
+    server got `"NOTION_API_TOKEN": "<NOTION_API_TOKEN>"` in its environment and
+    sent that literal string as its bearer token. Every call 401'd while the
+    config looked correctly filled in.
+
+    Dropping the key gives the server the same view it would have had if nobody
+    had written a placeholder at all - the var is simply unset - and unset is a
+    failure mode consumers already handle loudly (the second_brain factory
+    raises on an empty token).
+    """
+    env = entry.get('env')
+    if not isinstance(env, dict) or not unresolved:
+        return entry, []
+    tokens = {f'<{key}>' for key in unresolved}
+    dropped = [k for k, v in env.items()
+               if isinstance(v, str)
+               and _CREDENTIAL_NAME_PAT.search(k)
+               and any(t in v for t in tokens)]
+    if not dropped:
+        return entry, []
+    entry = dict(entry)
+    entry['env'] = {k: v for k, v in env.items() if k not in dropped}
+    return entry, dropped
+
+
 def strip_meta_keys(entry):
     """Drop keys starting with `_` from a dict (template-only metadata)."""
     return {k: v for k, v in entry.items() if not k.startswith('_')}
 
 
-def hydrate(config, template, env):
-    """Build the hydrated mcpServers dict and return (output, unresolved)."""
+def hydrate(config, template, env, dropped_env=None):
+    """Build the hydrated mcpServers dict and return (output, unresolved).
+
+    Pass a dict as `dropped_env` to collect server name -> list of env keys
+    removed because their value did not resolve. It is an out-parameter rather
+    than a third return value so the existing two-tuple contract holds for
+    callers that do not care. See drop_unresolved_env.
+    """
     unresolved = set()
     out = {}
     servers = template.get('mcpServers', {})
@@ -268,6 +310,9 @@ def hydrate(config, template, env):
         overridden = apply_overrides(entry, config)
         stripped = strip_meta_keys(overridden)
         substituted = substitute_placeholders(stripped, env, unresolved)
+        substituted, dropped = drop_unresolved_env(substituted, unresolved)
+        if dropped and dropped_env is not None:
+            dropped_env[name] = dropped
         out[name] = substituted
     return {'mcpServers': out}, unresolved
 
@@ -292,7 +337,8 @@ def main():
     template = load_json(args.template)
     env = load_env(args.env)
 
-    hydrated, unresolved = hydrate(config, template, env)
+    dropped_env = {}
+    hydrated, unresolved = hydrate(config, template, env, dropped_env)
     output_text = json.dumps(hydrated, indent=2)
 
     if args.dry_run:
@@ -303,6 +349,18 @@ def main():
             f.write('\n')
         print(f'wrote {args.output} '
               f'({len(hydrated["mcpServers"])} mcpServers)')
+
+    if dropped_env:
+        for server, keys in sorted(dropped_env.items()):
+            print(f'WARN: {server}: dropped env {sorted(keys)} - the value did '
+                  f'not resolve.', file=sys.stderr)
+        print('      These vars are now UNSET for that server rather than being '
+              'set to the\n'
+              '      literal placeholder text. A credential placeholder shipped '
+              'as a value is\n'
+              '      a bearer token that 401s on every call while the config '
+              'looks correct.',
+              file=sys.stderr)
 
     if unresolved:
         print(f'WARN: unresolved placeholders left in output: '

--- a/chassis/scripts/setup-wizard/README.md
+++ b/chassis/scripts/setup-wizard/README.md
@@ -140,7 +140,7 @@ matching - a single typo causes silent hydration failure.
 
 | Item name | VW field | Env var |
 |---|---|---|
-| `Behalf.bot - Notion integration token` | password | `NOTION_INTEGRATION_TOKEN` |
+| `Behalf.bot - Notion integration token` | password | `NOTION_API_TOKEN` |
 | `Behalf.bot - Notion DB IDs` | notes (KEY=value per line) | `NOTION_PROJECT_TRACKER_DB_ID`, `NOTION_READING_LIST_DB_ID`, `NOTION_MEMORY_PAGE_ID` |
 | `Behalf.bot - Google OAuth client` | username = CLIENT_ID, password = CLIENT_SECRET | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` |
 

--- a/chassis/scripts/smoke-test.sh
+++ b/chassis/scripts/smoke-test.sh
@@ -11,7 +11,7 @@
 # smoke test reports OK.
 #
 # Required env: sourced from $CHASSIS_HOME/.env at entrypoint time, so the
-# script can assume INSTANCE_NAME, BRIEFINGS_WEBHOOK_URL, NOTION_INTEGRATION_TOKEN,
+# script can assume INSTANCE_NAME, BRIEFINGS_WEBHOOK_URL, NOTION_API_TOKEN,
 # etc. are exported. Per-check fail-soft if env missing - just reports SKIP.
 #
 # Usage:
@@ -207,12 +207,12 @@ check_slack_intake_helper() {
 }
 
 check_second_brain_backend_reachable() {
-    if [[ -z "${NOTION_INTEGRATION_TOKEN:-}" ]]; then
-        record SKIP notion_read "NOTION_INTEGRATION_TOKEN not set"
+    if [[ -z "${NOTION_API_TOKEN:-}" ]]; then
+        record SKIP notion_read "NOTION_API_TOKEN not set"
         return
     fi
     local resp
-    resp=$(curl -fsS -H "Authorization: Bearer $NOTION_INTEGRATION_TOKEN" -H "Notion-Version: 2022-06-28" \
+    resp=$(curl -fsS -H "Authorization: Bearer $NOTION_API_TOKEN" -H "Notion-Version: 2022-06-28" \
         https://api.notion.com/v1/users/me 2>/dev/null || echo "")
     if echo "$resp" | jq -e .id >/dev/null 2>&1; then
         local bot_id

--- a/chassis/second_brain/factory.py
+++ b/chassis/second_brain/factory.py
@@ -95,6 +95,26 @@ def _resolve_env(value: Any) -> Any:
     return out
 
 
+def _is_unhydrated_placeholder(value: str) -> bool:
+    """True for a bare `<NAME>` token that hydration should have replaced.
+
+    hydrate-mcp-json.py substitutes `<TOKEN>` markers from .env. When the var is
+    unset it used to leave the marker in place, the MCP server received the
+    literal string in its environment, and it went out as
+    `Authorization: Bearer <NOTION_API_TOKEN>` - a 401 on every call from a
+    config that looked correctly filled in. The hydrator now drops credential
+    keys it could not resolve; this is the second line of defense, so a
+    hand-edited .env or .mcp.json cannot reintroduce the same shape.
+    """
+    stripped = value.strip()
+    return (
+        len(stripped) > 2
+        and stripped.startswith("<")
+        and stripped.endswith(">")
+        and stripped[1:-1].replace("_", "").isalnum()
+    )
+
+
 def _first_set(*candidates: Any) -> str:
     """First candidate that resolves to a non-empty string, '' when none do.
 
@@ -189,6 +209,15 @@ def get_adapter(config_path: Path | None = None) -> SecondBrainAdapter:
             os.environ.get("SIYUAN_DEEPLINK_BASE"),
             "siyuan://blocks/",
         )
+        # Same placeholder guard the Notion branch applies. SiYuan's token comes
+        # through the same <SIYUAN_TOKEN> marker in .mcp.json.template, so it can
+        # arrive in the same unhydrated shape.
+        if token and _is_unhydrated_placeholder(token):
+            raise ValueError(
+                f"SiYuan adapter token is the unhydrated placeholder {token!r}, not a "
+                "credential. Set SIYUAN_TOKEN in the chassis .env and re-run "
+                "hydrate-mcp-json.py."
+            )
         if not token:
             raise ValueError(
                 "SiYuan adapter has no API token. Set SIYUAN_TOKEN in the chassis .env "
@@ -213,16 +242,44 @@ def get_adapter(config_path: Path | None = None) -> SecondBrainAdapter:
         from chassis.second_brain.notion import NotionAdapter
 
         # Same credential source as the native notion MCP server (.env), same
-        # notes_root fallback as siyuan. Notion adapter mode is not validated as
-        # hard as siyuan yet - see docs/second-brain-adapters.md.
+        # notes_root fallback as siyuan.
         databases = sb_config.get("databases") or {}
+        token = _first_set(
+            backend_config.get("token"), os.environ.get("NOTION_API_TOKEN")
+        )
+        notes_root = _first_set(
+            backend_config.get("notes_root"), databases.get("notes_root")
+        )
+        # Same lesson as the SiYuan guards above, which exist because that exact
+        # failure burned an install (928c657). A happily-constructed adapter with
+        # an empty credential is worse than a startup error: every call comes
+        # back 401 and the config looks correct. Fail here instead.
+        if token and _is_unhydrated_placeholder(token):
+            raise ValueError(
+                f"Notion adapter token is the unhydrated placeholder {token!r}, not a "
+                "credential. hydrate-mcp-json.py leaves <NAME> markers in place when "
+                "the var is unset. Set NOTION_API_TOKEN in the chassis .env and re-run "
+                "the hydrator. Sending this string as a bearer token 401s on every call."
+            )
+        if not token:
+            raise ValueError(
+                "Notion adapter has no API token. Set NOTION_API_TOKEN in the chassis "
+                ".env (the same var direct mode uses), or second_brain.notion.token in "
+                "chassis.config.yaml to override it. Notion answers an empty or "
+                "placeholder bearer token with 401 on every call. Note the var was "
+                "briefly documented as NOTION_INTEGRATION_TOKEN in some files; "
+                "NOTION_API_TOKEN is the only name now."
+            )
+        if not notes_root:
+            raise ValueError(
+                "Notion adapter has no notes_root. Set second_brain.databases.notes_root "
+                "in chassis.config.yaml (the default write target), or "
+                "second_brain.notion.notes_root to override it. Without it, create_doc "
+                "has no parent page to write under."
+            )
         return NotionAdapter(
-            token=_first_set(
-                backend_config.get("token"), os.environ.get("NOTION_API_TOKEN")
-            ),
-            notes_root=_first_set(
-                backend_config.get("notes_root"), databases.get("notes_root")
-            ),
+            token=token,
+            notes_root=notes_root,
             databases={k: _resolve_env(v) for k, v in (backend_config.get("databases") or {}).items()},
             natural_keys=backend_config.get("natural_keys") or {},
             active_database=backend_config.get("active_database"),

--- a/chassis/second_brain/notion.py
+++ b/chassis/second_brain/notion.py
@@ -11,7 +11,7 @@ Per-installer config (chassis.config.yaml):
     second_brain:
       backend: notion
       notion:
-        token: ${NOTION_INTEGRATION_TOKEN}        # from .env / Vaultwarden
+        token: ${NOTION_API_TOKEN}        # from .env / Vaultwarden
         notes_root: <page-id>                       # parent page for create_doc
         databases:                                  # named handles → uuid
           lp_crm: <database-id>

--- a/chassis/second_brain/tests/test_factory_credentials.py
+++ b/chassis/second_brain/tests/test_factory_credentials.py
@@ -64,6 +64,24 @@ def _shipped_as_siyuan(raw: str, siyuan_block: str = "") -> str:
     return patched
 
 
+def _shipped_as_notion(raw: str, notion_block: str = "") -> str:
+    """The REAL shipped config text, backend pinned to notion.
+
+    Same substitution contract as _shipped_as_siyuan. The shipped config already
+    ships `backend: notion`, but pinning it explicitly means these tests keep
+    testing Notion if the shipped default ever changes.
+    """
+    patched, count = re.subn(
+        r"^(\s*)backend:\s*\w+.*$",
+        lambda m: f"{m.group(1)}backend: notion" + notion_block,
+        raw,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    assert count == 1, "expected exactly one second_brain.backend key in chassis.config.yaml"
+    return patched
+
+
 class SiYuanCredentialResolutionTest(unittest.TestCase):
     def setUp(self) -> None:
         self._tmp = tempfile.TemporaryDirectory(prefix="sb-factory-creds-")
@@ -189,6 +207,135 @@ class SiYuanCredentialResolutionTest(unittest.TestCase):
             with self.assertRaises(ValueError) as ctx:
                 get_adapter(path)
         self.assertIn("SIYUAN_TOKEN", str(ctx.exception))
+
+
+class NotionCredentialResolutionTest(unittest.TestCase):
+    """Notion's half of the same contract SiYuanCredentialResolutionTest covers.
+
+    Notion had two gaps SiYuan did not:
+
+    1. Two env var names for one secret. The factory read NOTION_API_TOKEN and
+       .env.example documented it, while .mcp.json.template, hydrate-env-from-vw.sh
+       and smoke-test.sh used NOTION_INTEGRATION_TOKEN. The Vaultwarden path
+       worked by accident; an installer who followed .env.example got the literal
+       string "<NOTION_INTEGRATION_TOKEN>" shipped as their bearer token.
+    2. No guards. get_adapter() built a NotionAdapter unconditionally, so an
+       empty token or empty notes_root produced a happily-constructed adapter
+       that 401'd on every call. SiYuan only got its guards after that exact
+       failure burned an install (928c657).
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory(prefix="sb-factory-notion-")
+        self.tmp_dir = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        self.shipped_raw = SHIPPED_CONFIG.read_text(encoding="utf-8")
+        self.config_path = self._write("shipped-notion.yaml", _shipped_as_notion(self.shipped_raw))
+
+    def _write(self, name: str, text: str) -> Path:
+        path = self.tmp_dir / name
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def test_env_token_reaches_the_adapter(self) -> None:
+        # The shipped config carries no second_brain.notion block, so .env is the
+        # only credential source an install actually has.
+        with mock.patch.dict("os.environ", {"NOTION_API_TOKEN": FAKE_TOKEN}, clear=True):
+            adapter = get_adapter(self.config_path)
+        self.assertEqual(adapter.backend, "notion")
+        self.assertEqual(adapter.notes._token, FAKE_TOKEN)
+        # The structured surface shares the one credential - no second copy.
+        self.assertEqual(adapter.database._token, FAKE_TOKEN)
+
+    def test_the_only_token_var_is_notion_api_token(self) -> None:
+        # The rename's regression guard. NOTION_INTEGRATION_TOKEN is dead: setting
+        # it alone must NOT satisfy the factory, or the two-name split is back and
+        # installers get a silent 401 depending on which doc they followed.
+        with mock.patch.dict(
+            "os.environ", {"NOTION_INTEGRATION_TOKEN": FAKE_TOKEN}, clear=True
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                get_adapter(self.config_path)
+        self.assertIn("NOTION_API_TOKEN", str(ctx.exception))
+
+    def test_notes_root_falls_back_to_databases_notes_root(self) -> None:
+        expected = _load_config(self.config_path)["second_brain"]["databases"]["notes_root"]
+        self.assertTrue(expected, "shipped config lost second_brain.databases.notes_root")
+        with mock.patch.dict("os.environ", {"NOTION_API_TOKEN": FAKE_TOKEN}, clear=True):
+            adapter = get_adapter(self.config_path)
+        self.assertEqual(adapter.notes._notes_root, expected)
+
+    def test_missing_token_raises_instead_of_building_a_dead_adapter(self) -> None:
+        with mock.patch.dict("os.environ", {}, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                get_adapter(self.config_path)
+        message = str(ctx.exception)
+        self.assertIn("NOTION_API_TOKEN", message)
+        self.assertIn("second_brain.notion.token", message)
+
+    def test_missing_notes_root_raises(self) -> None:
+        blanked = self.shipped_raw.replace("notes_root: TBD_at_install", "notes_root:")
+        self.assertNotIn("notes_root: TBD_at_install", blanked)
+        path = self._write("no-notes-root.yaml", _shipped_as_notion(blanked))
+        with mock.patch.dict("os.environ", {"NOTION_API_TOKEN": FAKE_TOKEN}, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                get_adapter(path)
+        self.assertIn("notes_root", str(ctx.exception))
+
+    def test_yaml_block_overrides_env(self) -> None:
+        override = (
+            "\n  notion:"
+            "\n    token: yaml-wins"
+            "\n    notes_root: 1234abcd-5678-90ef-1234-567890abcdef"
+            "\n    active_database: lp_crm"
+            "\n    databases:"
+            "\n      lp_crm: aaaa1111-bbbb-2222-cccc-333333333333"
+            "\n    natural_keys:"
+            "\n      lp_crm: email"
+        )
+        path = self._write("notion-override.yaml", _shipped_as_notion(self.shipped_raw, override))
+        with mock.patch.dict("os.environ", {"NOTION_API_TOKEN": FAKE_TOKEN}, clear=True):
+            adapter = get_adapter(path)
+        self.assertEqual(adapter.notes._token, "yaml-wins")
+        self.assertEqual(adapter.notes._notes_root, "1234abcd-5678-90ef-1234-567890abcdef")
+        self.assertEqual(adapter.database._active, "lp_crm")
+        self.assertEqual(
+            adapter.database._databases, {"lp_crm": "aaaa1111-bbbb-2222-cccc-333333333333"}
+        )
+        self.assertEqual(adapter.database._natural_keys, {"lp_crm": "email"})
+
+    def test_env_ref_in_yaml_that_expands_to_nothing_falls_through(self) -> None:
+        # `token: ${NOTION_API_TOKEN}` is exactly what docs/second-brain-adapters.md
+        # shows. With the var unset it resolves to '' and must reach the same
+        # ValueError rather than shadowing the env fallback with an empty string.
+        override = "\n  notion:\n    token: ${NOTION_API_TOKEN}"
+        path = self._write("notion-envref.yaml", _shipped_as_notion(self.shipped_raw, override))
+        with mock.patch.dict("os.environ", {}, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                get_adapter(path)
+        self.assertIn("NOTION_API_TOKEN", str(ctx.exception))
+
+    def test_env_ref_in_yaml_expands_from_env(self) -> None:
+        override = "\n  notion:\n    token: ${NOTION_API_TOKEN}"
+        path = self._write("notion-envref-set.yaml", _shipped_as_notion(self.shipped_raw, override))
+        with mock.patch.dict("os.environ", {"NOTION_API_TOKEN": FAKE_TOKEN}, clear=True):
+            adapter = get_adapter(path)
+        self.assertEqual(adapter.notes._token, FAKE_TOKEN)
+
+    def test_unresolved_placeholder_is_not_accepted_as_a_token(self) -> None:
+        # The concrete pre-existing failure: hydrate-mcp-json.py left
+        # "<NOTION_INTEGRATION_TOKEN>" in .mcp.json when the var was unset, the
+        # MCP server got that literal string in its environment, and it went out
+        # as `Authorization: Bearer <NOTION_INTEGRATION_TOKEN>`. The hydrator now
+        # drops such keys, but the factory must not accept the shape either.
+        for placeholder in ("<NOTION_API_TOKEN>", "<NOTION_INTEGRATION_TOKEN>"):
+            with self.subTest(placeholder=placeholder):
+                with mock.patch.dict(
+                    "os.environ", {"NOTION_API_TOKEN": placeholder}, clear=True
+                ):
+                    with self.assertRaises(ValueError) as ctx:
+                        get_adapter(self.config_path)
+                self.assertIn("NOTION_API_TOKEN", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/chassis/second_brain/tests/test_mcp_json_render.py
+++ b/chassis/second_brain/tests/test_mcp_json_render.py
@@ -30,6 +30,7 @@ import importlib.util
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT))
@@ -375,6 +376,102 @@ class EnableWhenEvaluatorTest(unittest.TestCase):
         self.assertFalse(self._eval("garbage"))
         self.assertFalse(self._eval(""))
         self.assertFalse(self._eval("a == 'x' && "))
+
+
+class UnresolvedCredentialEnvTest(unittest.TestCase):
+    """An unresolved <PLACEHOLDER> must never ship as a credential value.
+
+    The concrete failure: an installer who set NOTION_API_TOKEN was fine, but
+    one who set the other documented name got `"NOTION_API_TOKEN":
+    "<NOTION_INTEGRATION_TOKEN>"` written into .mcp.json. hydrate-mcp-json.py
+    warned and exited 2, and both callers treat exit 2 as loud-but-not-fatal, so
+    the MCP server started with the literal marker in its environment and sent
+    `Authorization: Bearer <NOTION_INTEGRATION_TOKEN>` on every request.
+
+    Credential-named keys are now dropped, so the var is unset instead. Keys
+    holding paths and hosts keep the pass-through behavior - a leftover marker
+    there is visibly wrong at startup and leaks nothing.
+    """
+
+    def setUp(self) -> None:
+        # substitute_placeholders falls back to os.environ when a key is absent
+        # from --env. On a developer machine that is a LIVE chassis shell, so an
+        # un-isolated test silently reads real SIYUAN_TOKEN / NOTION_API_TOKEN
+        # values and prints them on failure. Every scenario here runs against a
+        # cleared environment so "unresolved" means unresolved.
+        patcher = mock.patch.dict("os.environ", {}, clear=True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _render_with_env(self, config: dict, env: dict) -> tuple[dict, dict]:
+        template = hydrator.load_json(str(TEMPLATE_PATH))
+        dropped: dict = {}
+        hydrated, _unresolved = hydrator.hydrate(config, template, env, dropped)
+        return hydrated["mcpServers"], dropped
+
+    def test_notion_token_is_dropped_when_unresolved(self) -> None:
+        servers, dropped = self._render_with_env(
+            {"second_brain": {"backend": "notion"}}, env={}
+        )
+        self.assertIn("notion", servers)
+        self.assertNotIn("NOTION_API_TOKEN", servers["notion"].get("env", {}))
+        self.assertEqual(dropped.get("notion"), ["NOTION_API_TOKEN"])
+
+    def test_notion_token_survives_when_resolved(self) -> None:
+        servers, dropped = self._render_with_env(
+            {"second_brain": {"backend": "notion"}},
+            env={"NOTION_API_TOKEN": "secret-not-a-real-token"},
+        )
+        self.assertEqual(
+            servers["notion"]["env"]["NOTION_API_TOKEN"], "secret-not-a-real-token"
+        )
+        self.assertNotIn("notion", dropped)
+
+    def test_no_placeholder_text_reaches_any_credential_env_value(self) -> None:
+        # The property that matters, asserted across the whole rendered file
+        # rather than one server: nothing named like a secret may hold a marker.
+        template = hydrator.load_json(str(TEMPLATE_PATH))
+        config = {
+            "second_brain": {"backend": "notion"},
+            "modules": {"google": {"gmail": True, "calendar": True, "sheets": True}},
+        }
+        hydrated, _unresolved = hydrator.hydrate(config, template, env={})
+        offenders = [
+            (name, key, value)
+            for name, entry in hydrated["mcpServers"].items()
+            for key, value in (entry.get("env") or {}).items()
+            if isinstance(value, str)
+            and hydrator._CREDENTIAL_NAME_PAT.search(key)
+            and value.strip().startswith("<")
+        ]
+        self.assertEqual(offenders, [], f"placeholder shipped as a credential: {offenders}")
+
+    def test_non_credential_placeholders_still_pass_through(self) -> None:
+        # GOOGLE_OAUTH_CREDENTIALS is a file path. Dropping it would change
+        # behavior the existing render tests depend on, and it leaks nothing.
+        servers, dropped = self._render_with_env(
+            {"modules": {"google": {"calendar": True}}}, env={}
+        )
+        self.assertTrue(
+            servers["google-calendar"]["env"]["GOOGLE_OAUTH_CREDENTIALS"].startswith("<")
+        )
+        self.assertNotIn("google-calendar", dropped)
+
+    def test_adapter_mode_secondbrain_drops_only_the_token(self) -> None:
+        # The secondbrain server carries SIYUAN_URL and SIYUAN_DEEPLINK_BASE
+        # alongside the tokens. An unset deeplink base must not take the server
+        # down with it - only the credential keys go.
+        servers, dropped = self._render_with_env(
+            {"second_brain": {"backend": "notion", "mode": "adapter"}}, env={}
+        )
+        env = servers["secondbrain"]["env"]
+        self.assertNotIn("NOTION_API_TOKEN", env)
+        self.assertNotIn("SIYUAN_TOKEN", env)
+        self.assertIn("SIYUAN_URL", env)
+        self.assertIn("SIYUAN_DEEPLINK_BASE", env)
+        self.assertEqual(
+            sorted(dropped["secondbrain"]), ["NOTION_API_TOKEN", "SIYUAN_TOKEN"]
+        )
 
 
 if __name__ == "__main__":

--- a/docs/second-brain-adapters.md
+++ b/docs/second-brain-adapters.md
@@ -37,13 +37,13 @@ Pick the backend in `chassis.config.yaml`.
 | siyuan | `SIYUAN_URL` | `second_brain.siyuan.base_url` | `http://127.0.0.1:6806` |
 | siyuan | - | `second_brain.siyuan.notebook_id` | `second_brain.databases.notes_root`; empty raises `ValueError` |
 | siyuan | `SIYUAN_DEEPLINK_BASE` | `second_brain.siyuan.deeplink_template` | `siyuan://blocks/` - **desktop-app URI, does not open on a phone** (see below) |
-| notion | `NOTION_API_TOKEN` | `second_brain.notion.token` | none |
-| notion | - | `second_brain.notion.notes_root` | `second_brain.databases.notes_root` |
+| notion | `NOTION_API_TOKEN` | `second_brain.notion.token` | none - **empty token raises `ValueError` at startup** |
+| notion | - | `second_brain.notion.notes_root` | `second_brain.databases.notes_root`; empty raises `ValueError` |
 | obsidian | - (no credential) | `second_brain.obsidian.vault_path` | none - required |
 
 Resolution is: **YAML key if set, else env var, else the documented default.** A YAML value of `${SIYUAN_TOKEN}` that expands to nothing counts as unset and falls through rather than shadowing the env var.
 
-The SiYuan adapter refuses to construct with an empty token or an empty `notebook_id`. Both used to be silently tolerated, which produced an adapter that answered every call with `Auth failed [session]`. Failing loudly at server startup is deliberate - `mcp_server.main()` resolves the adapter eagerly so a broken config shows up in `claude mcp list` and the server log, not mid-task.
+The SiYuan and Notion adapters refuse to construct with an empty token or an empty write target (`notebook_id` / `notes_root`), and reject an unhydrated `<PLACEHOLDER>` in place of a token. Both used to be silently tolerated, which produced an adapter that answered every call with `Auth failed [session]`. Failing loudly at server startup is deliberate - `mcp_server.main()` resolves the adapter eagerly so a broken config shows up in `claude mcp list` and the server log, not mid-task.
 
 > **Container gotcha:** from inside the chassis container, `127.0.0.1` is the container itself. A SiYuan kernel running on the host is reachable at `http://host.docker.internal:6806`. Set `SIYUAN_URL` accordingly.
 
@@ -87,7 +87,7 @@ second_brain:
 second_brain:
   backend: notion
   notion:
-    token: ${NOTION_INTEGRATION_TOKEN}
+    token: ${NOTION_API_TOKEN}
     notes_root: 1234abcd-5678-90ef-1234-567890abcdef   # parent page for create_doc
     databases:
       lp_crm: aaaa1111-bbbb-2222-cccc-333333333333


### PR DESCRIPTION
Notion pre-release cleanup. Independent of #76 - no file overlap.

## a) One token name

The chassis carried **two env var names for one secret**:

| Name | Where |
|---|---|
| `NOTION_API_TOKEN` | `.env.example:71`, `factory.py:221` (the code that actually reads it), `chassis.config.yaml:141,165`, `docs/second-brain-adapters.md:40` |
| `NOTION_INTEGRATION_TOKEN` | `chassis/.mcp.json.template:58,73`, `hydrate-env-from-vw.sh:90`, `smoke-test.sh:210`, `notion.py:14`, `docs/second-brain-adapters.md:90`, `setup-wizard/README.md:143` |

The Vaultwarden path worked **by accident**. An installer who followed `.env.example` and set `NOTION_API_TOKEN` got this in their `.mcp.json`:

```json
"env": { "NOTION_API_TOKEN": "<NOTION_INTEGRATION_TOKEN>" }
```

`hydrate-mcp-json.py` left the marker in place, warned, and exited 2 - which both callers treat as loud-but-not-fatal. So the MCP server started with the literal string in its environment and sent `Authorization: Bearer <NOTION_INTEGRATION_TOKEN>` on every request. All 401. From a config that looked correctly filled in.

**Chose `NOTION_API_TOKEN`** - what the code reads and what `.env.example` documents.

### Vaultwarden side-effect: nothing for Sean to do

The VW **item** name is `Behalf.bot - Notion integration token` and it is **unchanged**. `hydrate-env-from-vw.sh` maps item name -> env var name, and only the right-hand side moved:

```diff
-  "Behalf.bot - Notion integration token": "NOTION_INTEGRATION_TOKEN",
+  "Behalf.bot - Notion integration token": "NOTION_API_TOKEN",
```

**No vault item needs renaming, re-creating, or re-entering.** Any install that already ran the VW hydration just gets the same secret written under the new name on the next run. A comment above the manifest says so, since a future reader will wonder.

### Loud failure for unresolved placeholders

An unresolved placeholder in a **credential-named** env key is now **dropped** instead of emitted. The var is UNSET for that server rather than set to marker text, and unset is a failure mode consumers already handle loudly. Keys holding paths and hosts (`GOOGLE_OAUTH_CREDENTIALS`, `SIYUAN_URL`) keep the existing pass-through-and-warn behavior - a leftover marker there is visibly wrong at startup and leaks nothing. The exit-2 contract both callers depend on is preserved.

Before and after, same command, `NOTION_API_TOKEN` unset:

```
before:  "env": { "NOTION_API_TOKEN": "<NOTION_INTEGRATION_TOKEN>" }
after:   "env": {}
         WARN: notion: dropped env ['NOTION_API_TOKEN'] - the value did not resolve.
```

**Bonus catch:** `GITHUB_PERSONAL_ACCESS_TOKEN` had the same shape and was shipping as a literal placeholder too. Same fix covers it.

## b) The missing guards

`factory.py:212-229` built a `NotionAdapter` unconditionally. SiYuan only has its empty-token and empty-`notebook_id` guards because that exact failure burned an install (`928c657`). Notion now raises the same way on:

- empty token
- empty `notes_root`
- an unhydrated `<PLACEHOLDER>` in place of a token

The placeholder guard is applied to **SiYuan as well** - its token arrives through the same `<SIYUAN_TOKEN>` marker and can land in the same shape. Second line of defense, so a hand-edited `.env` or `.mcp.json` cannot reintroduce it.

## c) Tests

- `NotionCredentialResolutionTest` in `test_factory_credentials.py`, mirroring `SiYuanCredentialResolutionTest`. Includes the rename's regression guard: setting **only** the dead `NOTION_INTEGRATION_TOKEN` must NOT satisfy the factory, or the two-name split is back.
- `UnresolvedCredentialEnvTest` in `test_mcp_json_render.py` for the hydrator drop, including a property assertion across the whole rendered file that no credential-named key holds a marker.

Both new suites clear `os.environ`. `substitute_placeholders` falls back to it, so on a live chassis shell an un-isolated test silently reads real `SIYUAN_TOKEN` / `NOTION_API_TOKEN` values and prints them on failure. I hit exactly that while writing these - worth knowing.

## Files changed

| File | Change |
|---|---|
| `chassis/.mcp.json.template` | `<NOTION_INTEGRATION_TOKEN>` -> `<NOTION_API_TOKEN>` (2 sites) |
| `chassis/scripts/hydrate-env-from-vw.sh` | manifest maps VW item to `NOTION_API_TOKEN`; comment on the unchanged item name |
| `chassis/scripts/hydrate-mcp-json.py` | `drop_unresolved_env` + `_CREDENTIAL_NAME_PAT` + warning; `hydrate()` gains an optional out-param (two-tuple return unchanged) |
| `chassis/scripts/smoke-test.sh` | var rename (4 sites) |
| `chassis/scripts/setup-wizard/README.md` | VW item table |
| `chassis/second_brain/factory.py` | Notion token + `notes_root` guards; `_is_unhydrated_placeholder` applied to both backends |
| `chassis/second_brain/notion.py` | docstring var name |
| `chassis/second_brain/tests/test_factory_credentials.py` | `NotionCredentialResolutionTest` (9 cases) |
| `chassis/second_brain/tests/test_mcp_json_render.py` | `UnresolvedCredentialEnvTest` (5 cases); env isolation |
| `docs/second-brain-adapters.md` | var name; guard rows in the resolution table |

## Test plan

- [x] `pytest chassis/second_brain/tests/ -v` - **122 passed** (108 baseline + 14 new, zero regressions)
- [x] `shellcheck -S error` on both changed shell scripts - clean
- [x] VW manifest heredoc still parses as JSON (`python3 -m json.tool`)
- [x] `.mcp.json.template` still parses as JSON
- [x] Hydrator CLI run with `NOTION_API_TOKEN` unset: notion env renders `{}`, warns, exits 2. Grep for `"*TOKEN": "<` across the output finds nothing.
- [x] Hydrator CLI run with the var set: token lands verbatim, no drop
- [x] `grep -rn NOTION_INTEGRATION_TOKEN` across the repo returns zero hits
- [x] Diff scanned for secrets - clean

## Not in this PR

`chassis/VERSION` untouched, per the ask-first convention. No CHANGELOG entry - fold these into v0.2.0 once you approve the bump. Tag commands are in #76.
