### PR TITLE
feat(second-brain): wire the adapter into chassis workflows (Stage 2)

### DIFF
--- a/chassis/scheduled-tasks/daily-log-prompt.md.template
+++ b/chassis/scheduled-tasks/daily-log-prompt.md.template
@@ -8,15 +8,30 @@ Chassis-supplied template. Customer install copies this file to
   "Sean Tierney's autonomous assistant", "Ben Lakoff's autonomous assistant")
 - `{{ CUSTOMER_ORG_HANDLES }}` - space-separated org handles the customer
   operates under (e.g. "vibecodelisboa fenerum" or just "kogent")
-- `{{ CUSTOMER_DAILY_LOG_PARENT_ID }}` - SiYuan block ID of the parent doc
-  under which daily logs are written (canonical ID, NOT a name-based path)
-- `{{ CUSTOMER_DAILY_LOG_NOTEBOOK_ID }}` - SiYuan notebook (box) ID hosting
-  the parent
+- `{{ CUSTOMER_DAILY_LOG_PARENT }}` - the parent daily logs are written
+  under, in whatever form the install's backend addresses a parent:
+    - SiYuan: the parent doc's canonical block ID (`20260507083000-abcd123`).
+      NOT a name-based hpath - see the double-parent incident below.
+    - Notion: the parent page id (32-char uuid).
+    - Obsidian: a vault-relative directory (`Daily Logs/`).
+  This replaces the old `{{ CUSTOMER_DAILY_LOG_PARENT_ID }}` +
+  `{{ CUSTOMER_DAILY_LOG_NOTEBOOK_ID }}` pair (2026-07-19). Two vars existed
+  because SiYuan needs a notebook AND a parent; the adapter's `create_doc`
+  takes one `parent`, and the SiYuan adapter resolves the notebook from
+  `second_brain.databases.notes_root` in chassis.config.yaml. Existing installs
+  keep working - bootstrap copies this template once and never rewrites it -
+  but should collapse the two on their next edit.
 
 The heartbeat dispatcher fires this nightly at 02:00 after
 `chassis/scripts/daily-log-gather.py` has already collected a full-day JSON
 payload from every operational surface Jax touched. This prompt consumes
-that payload, synthesizes it into a structured log, and writes to SiYuan.
+that payload, synthesizes it into a structured log, and writes it to the
+install's second brain.
+
+Backend-neutral by construction: every tool call below is `mcp__secondbrain__*`,
+the chassis-owned server that resolves SiYuan / Notion / Obsidian at startup.
+Do NOT reach for `mcp__siyuan__*` here even on a SiYuan install - in adapter
+mode it is not registered, and naming it is what made this prompt SiYuan-only.
 
 ---
 
@@ -24,7 +39,7 @@ You are Jax, {{ CUSTOMER_JAX_IDENTITY }}. Read CLAUDE.md for your full
 operating manual.
 
 Your task: read the gather payload for the day that just ended and write a
-structured daily log entry to SiYuan.
+structured daily log entry to the second brain.
 
 ## Step 1: Read the gather payload
 
@@ -49,9 +64,12 @@ as the "context" for this prompt. It has this shape:
     { "to": "...", "subject": "...", "excerpt": "...", "date": "..." }
   ],
   "gmail_scan_deferred": true|false,
-  "siyuan_activity": [
-    { "id": "...", "hpath": "/...", "len": N, "updated_at": "...", "excerpt": "..." }
+  "second_brain_backend": "siyuan|notion|obsidian",
+  "second_brain_activity": [
+    { "id": "...", "hpath": "/...", "title": "...", "len": N,
+      "updated_at": "...", "excerpt": "...", "deeplink": "..." }
   ],
+  "siyuan_activity": [ "deprecated alias holding the same list as second_brain_activity" ],
   "postmortems": [
     { "source": "discord msg <id>", "timestamp": "...", "excerpt": "..." }
   ],
@@ -86,55 +104,66 @@ From the payload, produce the log. **Groupings and priorities:**
 - Extract 3-5 items from `postmortems`. Format each as
   `{what happened} -> {what we learned}`. If there are zero items, keep
   the header and leave the body empty.
-- For `siyuan_activity`, note the meaningful writing (not empty auto-created
-  docs, not template stubs). The gather has already filtered by content
-  length > 200 chars, but you should apply editorial judgment: an entity-
-  formation plan is meaningful; a dating profile stub is not.
+- For `second_brain_activity`, note the meaningful writing (not empty
+  auto-created docs, not template stubs). The gather has already filtered by
+  content length > 200 chars, but you should apply editorial judgment: an
+  entity-formation plan is meaningful; a dating profile stub is not.
+- Weight that judgment by `second_brain_backend`. SiYuan rows come from block
+  `updated` timestamps and mean a doc actually changed. Obsidian rows come
+  from filesystem mtime, which a git pull or an iCloud resync also moves - on
+  an Obsidian install treat the list as candidates, and drop anything whose
+  excerpt shows no sign of real editing rather than reporting a sync as work.
 
-## Step 3: Write the daily log to SiYuan
+## Step 3: Write the daily log to the second brain
 
-Write under the canonical Daily Logs parent - NOT by name match, by exact
-ID. Using a name-based hpath caused a double-parent bug on Sean's install
+Write under the canonical Daily Logs parent - by exact ID, NOT by name
+match. Using a name-based path caused a double-parent bug on Sean's install
 2026-04-17/18 where logs landed in the wrong notebook or got a malformed
-sibling created with the parent's ID as its name.
+sibling created with the parent's ID as its name. The rule survives the
+backend change: pass the configured parent through verbatim, never a name
+you assembled yourself.
 
 **Canonical Daily Logs parent (customer-install-specific):**
-
-- Notebook (box): `{{ CUSTOMER_DAILY_LOG_NOTEBOOK_ID }}`
-- Parent node ID: `{{ CUSTOMER_DAILY_LOG_PARENT_ID }}`
+`{{ CUSTOMER_DAILY_LOG_PARENT }}`
 
 **Create the doc:**
 
 ```
-mcp__siyuan__create_doc(
-  notebook: "{{ CUSTOMER_DAILY_LOG_NOTEBOOK_ID }}",
-  path: "/Daily Logs/YYYY-MM-DD",
-  markdown: "...",
+mcp__secondbrain__create_doc(
+  parent: "{{ CUSTOMER_DAILY_LOG_PARENT }}",
+  title: "YYYY-MM-DD",
+  body: "...",
 )
 ```
 
-**Mandatory post-create verification** (chassis hardening pattern - after
-`create_doc`, verify with SQL against the SiYuan blocks table):
+It returns `{id, deeplink}`. Treat `id` as opaque - it is a SiYuan block ID,
+a Notion page id, or an Obsidian vault-relative path depending on the
+install, and nothing in this prompt should parse it.
 
-```sql
-SELECT id, hpath, box
-FROM blocks
-WHERE hpath = '/Daily Logs/YYYY-MM-DD'
-  AND box   = '{{ CUSTOMER_DAILY_LOG_NOTEBOOK_ID }}'
-  AND type  = 'd'
-LIMIT 3
+**Mandatory post-create verification** (chassis hardening pattern). The old
+version of this step ran a SQL SELECT against the SiYuan blocks table, which
+is why it only worked on one backend. Read the doc back instead - it proves
+the same thing (the write landed and is retrievable) on all three:
+
+```
+mcp__secondbrain__read_doc(doc_id: "<id returned by create_doc>")
 ```
 
-- Zero rows -> the tool call silently failed. Re-attempt once. If still
-  zero, print
-  `ERROR: daily-log doc not created at /Daily Logs/YYYY-MM-DD` to stdout
-  and exit non-zero so the dispatcher raises a Discord alert. Do NOT
-  fabricate a success confirmation.
-- More than one row -> you created a duplicate (or one already existed).
-  Print `WARNING: duplicate detected: [ids]` and stop; do not write again.
-- Exactly one row with matching `box` = `{{ CUSTOMER_DAILY_LOG_NOTEBOOK_ID }}`
-  -> success. Capture the returned block ID and use it in the Step 4 stdout
-  report.
+- `create_doc` returned no `id`, or `read_doc` errors, or the body comes
+  back empty -> the write silently failed. Re-attempt once. If it fails
+  again, print
+  `ERROR: daily-log doc not created under {{ CUSTOMER_DAILY_LOG_PARENT }}`
+  to stdout and exit non-zero so the dispatcher raises a Discord alert. Do
+  NOT fabricate a success confirmation.
+- Before creating, run
+  `mcp__secondbrain__search(query: "Daily Log - YYYY-MM-DD", limit: 5)`.
+  If today's log already exists, print
+  `WARNING: duplicate detected: [ids]` and stop; do not write again. This
+  replaces the old "more than one row" SQL check - search is the portable
+  way to ask the same question, and it has to run BEFORE the write rather
+  than after it.
+- `read_doc` returns the body you wrote -> success. Capture the id and
+  deeplink and use them in the Step 4 stdout report.
 
 Dispatcher escalates `ERROR:` / `WARNING:` lines via the alerts channel.
 
@@ -150,7 +179,8 @@ empty)` keep their `##` header but leave the body blank.
 
 - [Grouped by feature-shipped. Each item: 1-sentence narrative + PR/issue
   link(s). Include operational bullets: emails sent (from operational_email),
-  SiYuan writing (from siyuan_activity), and any custom-metric-worthy work.]
+  second-brain writing (from second_brain_activity), and any
+  custom-metric-worthy work.]
 
 ## Learnings & Tribal Knowledge
 (skip body if empty)
@@ -198,7 +228,8 @@ in 60 seconds.
 
 Log to stdout (the dispatcher captures this):
 
-- Confirm the SiYuan doc path created + block ID
+- Confirm the doc created: the parent it was written under, plus the id and
+  deeplink `create_doc` returned
 - List section headings that had non-empty bodies
 - One-line summary of the day (for morning briefing context)
 

--- a/chassis/scheduled-tasks/pacman-drain-prompt.md
+++ b/chassis/scheduled-tasks/pacman-drain-prompt.md
@@ -1,12 +1,27 @@
 # Pacman queue drain
 
-The SiYuan `/To Investigate` queue (block `${PACMAN_SIYUAN_QUEUE_BLOCK_ID}`) has unprocessed URL blocks. Drain them via the Pacman 4-gate pipeline.
+The `/To Investigate` queue (SiYuan block `${PACMAN_SIYUAN_QUEUE_BLOCK_ID}`) has unprocessed URL blocks. Drain them via the Pacman 4-gate pipeline.
+
+## Backend support - read this before running
+
+This prompt is only PARTLY backend-neutral, and the split is deliberate rather than an oversight.
+
+- **Queue storage is SiYuan-only.** Pacman stores its queue as SiYuan blocks and uses block IDs as queue-entry handles. Notion and Obsidian have no equivalent - see `docs/pacman-queue-storage.md` for why block IDs do not port and what replaces them. Steps 2 and 4 below therefore still name `mcp__siyuan__*`, and they are the only steps that do.
+- **Everything Pacman writes is backend-neutral.** Proposals and drop records go through `mcp__secondbrain__*` (steps 5 and 6), so they land correctly on whatever backend the install runs.
+
+Concretely: on a Notion or Obsidian install, and on ANY install running `second_brain.mode: adapter` (where `mcp__siyuan__*` is not registered at all), the queue steps cannot run. If `mcp__siyuan__sql_query` is unavailable, do NOT improvise a substitute and do NOT report a clean drain. Print
+
+```
+ERROR: pacman queue drain requires the siyuan MCP server, which is not available on this install. See docs/pacman-queue-storage.md.
+```
+
+to stdout and exit non-zero so the dispatcher alerts. Silently draining nothing is the failure mode this whole Stage 2 pass exists to remove.
 
 ## Steps
 
 1. **Read `chassis/skills/pacman.md` in full** before doing anything else. The skill defines the 4 gates, drop logging, proposal format, approval flow, and queue management. Follow it exactly.
 
-2. **Read the queue.** Use `mcp__siyuan__sql_query` to list all blocks under `/To Investigate` that contain a URL:
+2. **Read the queue.** SiYuan-only, per the backend note above. Use `mcp__siyuan__sql_query` to list all blocks under `/To Investigate` that contain a URL:
    ```sql
    SELECT id, content FROM blocks
    WHERE root_id = '${PACMAN_SIYUAN_QUEUE_BLOCK_ID}'
@@ -20,11 +35,11 @@ The SiYuan `/To Investigate` queue (block `${PACMAN_SIYUAN_QUEUE_BLOCK_ID}`) has
 
 3. **For each block:** extract the URL(s) from the `content` field. A block may contain one or more URLs (use a regex match on `https?://...`). Process each URL through the 4 gates per `chassis/skills/pacman.md`.
 
-4. **After processing each URL** (drop OR proposal — verdict regardless): **delete the source block** from `/To Investigate` via `mcp__siyuan__delete_block`. Non-negotiable rule per the skill — true queue semantics. If a single block had multiple URLs, delete the block only after ALL URLs from it have been processed.
+4. **After processing each URL** (drop OR proposal - verdict regardless): **delete the source block** from `/To Investigate` via `mcp__siyuan__delete_block` (SiYuan-only, per the backend note above). Non-negotiable rule per the skill - true queue semantics. If a single block had multiple URLs, delete the block only after ALL URLs from it have been processed.
 
-5. **Drops** post a 1-line note to the configured Discord channel (`chat_id: ${PACMAN_DISCORD_CHAT_ID}`) AND append a row to `/To Investigate/Dropped` (block `${PACMAN_SIYUAN_DROPPED_BLOCK_ID}`). Format per the skill.
+5. **Drops** post a 1-line note to the configured Discord channel (`chat_id: ${PACMAN_DISCORD_CHAT_ID}`) AND append a row to the Dropped archive via `mcp__secondbrain__append_to_doc(doc_id: "${PACMAN_DROPPED_DOC_ID}", content: ...)`. Format per the skill.
 
-6. **Proposals** write a SiYuan sub-doc under `/To Investigate/YYYY-MM-DD-<slug>` AND post a 4-section TLDR to the configured Discord channel with the SiYuan deeplink. Format per the skill.
+6. **Proposals** write a sub-doc via `mcp__secondbrain__create_doc(parent: "${PACMAN_PROPOSALS_PARENT}", title: "YYYY-MM-DD-<slug>", body: ...)` AND post a 4-section TLDR to the configured Discord channel. Use the `deeplink` that `create_doc` returns - do not construct a URL yourself, the format differs per backend. Format per the skill.
 
 7. **End-of-batch summary** to the configured Discord channel:
    ```
@@ -34,16 +49,16 @@ The SiYuan `/To Investigate` queue (block `${PACMAN_SIYUAN_QUEUE_BLOCK_ID}`) has
 
 ## Hard rules
 
-- Cap `${PACMAN_MAX_BATCH_URLS}` URLs per fire. If queue has more, leave them — the next drain picks them up.
+- Cap `${PACMAN_MAX_BATCH_URLS}` URLs per fire. If queue has more, leave them - the next drain picks them up.
 - Process oldest-first (FIFO).
 - Always delete the source block after processing, even on drops. Otherwise the next drain re-processes the same URLs.
-- Respect `PACMAN_HARD_PAUSE` — if the file exists at `$CHASSIS_HOME/PACMAN_HARD_PAUSE`, post a one-liner to the configured channel confirming the pause and exit without processing.
+- Respect `PACMAN_HARD_PAUSE` - if the file exists at `$CHASSIS_HOME/PACMAN_HARD_PAUSE`, post a one-liner to the configured channel confirming the pause and exit without processing.
 - Don't editorialize in proposal recommendations beyond what the skill specifies. Pacman surfaces evidence; the installer decides.
-- If a URL can't be fetched (404, timeout, paywall, etc.), drop it at gate 0 with reason "fetch failed" and a 1-line note. Don't retry within the same fire — the next drain will re-encounter the URL only if the source block wasn't deleted, which it should have been.
+- If a URL can't be fetched (404, timeout, paywall, etc.), drop it at gate 0 with reason "fetch failed" and a 1-line note. Don't retry within the same fire - the next drain will re-encounter the URL only if the source block wasn't deleted, which it should have been.
 
 ## Logging
 
 Every URL processed (drop OR proposal OR fetch-failure) gets a JSONL entry in `$CHASSIS_HOME/logs/pacman/YYYY-MM-DD.jsonl`:
 ```json
-{"ts": "...", "url": "...", "verdict": "drop|proposal|fetch_failed", "gate": 0|1|2|3|4|null, "siyuan_block_id": "...", "source": "telegram|discord|manual|heartbeat-drain"}
+{"ts": "...", "url": "...", "verdict": "drop|proposal|fetch_failed", "gate": 0|1|2|3|4|null, "doc_id": "...", "source": "telegram|discord|manual|heartbeat-drain"}
 ```

--- a/chassis/scripts/bootstrap-mcp-config.sh
+++ b/chassis/scripts/bootstrap-mcp-config.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# bootstrap-mcp-config.sh — hydrate $CHASSIS_HOME/.mcp.json from the chassis
+# bootstrap-mcp-config.sh - hydrate $CHASSIS_HOME/.mcp.json from the chassis
 # template at install time.
 #
 # Why this exists
@@ -15,24 +15,25 @@
 # Every gather that fires `claude -p` (morning-briefing, github-issue-triage,
 # strava-ingest, daily-log, etc.) fails the dispatcher's circuit-breaker
 # after two retries, and the entire heartbeat cycle goes silent. Confirmed
-# concretely 2026-05-25 in the <v1-reference-install>-mac-mini cutover — see
+# concretely 2026-05-25 in the <v1-reference-install>-mac-mini cutover - see
 # <v1-reference-install>#698 and scrollinondubs/new-jaxity#62.
 #
 # What it does
 # ============
-# 1. Reads `$CHASSIS_HOME/chassis/.mcp.json.template` (canonical template
-#    shipped with chassis).
-# 2. Sources `$CHASSIS_HOME/.env` so the bw / Vaultwarden hydration block
-#    pulls every secret into the environment. (Falls back gracefully when
-#    Vaultwarden isn't reachable — placeholder stays in the output for
-#    Sean to fill manually.)
-# 3. Substitutes each `<PLACEHOLDER>` against the env var of the same name,
-#    plus shell-expands `${CHASSIS_HOME}` literally.
-# 4. Strips the `_README` and other `_*` comment keys (they aren't valid
-#    JSON-Schema fields anyway — Claude Code ignores them but `jq`
-#    consumers would see noise).
-# 5. Validates the result parses as JSON.
-# 6. Atomically writes `$CHASSIS_HOME/.mcp.json` with 0600 perms (file
+# Resolves the canonical template + the customer's config and .env, then hands
+# all of the rendering to `hydrate-mcp-json.py`. This script owns path
+# resolution, the overwrite guard, and file permissions; the hydrator owns the
+# template grammar (`_enable_when`, `_override_when`, `<PLACEHOLDER>`
+# substitution, `_*` metadata stripping, JSON validation). There is exactly one
+# renderer - see the delegation block below for why that matters.
+#
+# 1. Resolves `$CHASSIS_HOME/chassis/.mcp.json.template`.
+# 2. Passes `$CUSTOMER_HOME/chassis.config.yaml` and `$CUSTOMER_HOME/.env` to
+#    the hydrator, which substitutes each `<PLACEHOLDER>` from .env or the
+#    environment. Unresolved CREDENTIAL placeholders are dropped rather than
+#    emitted as literal bearer tokens; unresolved non-credential ones stay put
+#    and exit 2 makes them loud.
+# 3. Writes `$CUSTOMER_HOME/.mcp.json` under `umask 077`, chmod 0600 (file
 #    contains long-lived API tokens).
 #
 # Safety
@@ -41,21 +42,21 @@
 #   --force. The use case is install-time bootstrap, NOT routine refresh.
 #   If you need to rotate a token, edit `.mcp.json` directly or rotate in
 #   Vaultwarden + re-run with --force.
-# - Never logs token values. Logs only WHICH placeholders were filled vs
-#   left as `<PLACEHOLDER>` strings.
+# - Never logs token values. The hydrator names only the placeholders it could
+#   NOT resolve, and the env keys it dropped for that reason.
 # - File written with `umask 077` to land at 0600.
 #
 # Usage
 # =====
-#   bash chassis/scripts/bootstrap-mcp-config.sh              # idempotent — skips if file exists
+#   bash chassis/scripts/bootstrap-mcp-config.sh              # idempotent - skips if file exists
 #   bash chassis/scripts/bootstrap-mcp-config.sh --force      # rewrite even if file exists
 #   bash chassis/scripts/bootstrap-mcp-config.sh --dry-run    # print result to stdout, don't write
 #
 # Related
 # =======
-# - docs/mcp-setup.md — per-MCP install instructions, template walkthrough
-# - chassis/.mcp.json.template — canonical template + placeholder list
-# - <v1-reference-install>#698 — cutover punchlist that motivated this script
+# - docs/mcp-setup.md - per-MCP install instructions, template walkthrough
+# - chassis/.mcp.json.template - canonical template + placeholder list
+# - <v1-reference-install>#698 - cutover punchlist that motivated this script
 
 set -euo pipefail
 
@@ -93,152 +94,67 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ ! -f "$TEMPLATE" ]]; then
-    echo "ERROR: template missing — $TEMPLATE" >&2
+    echo "ERROR: template missing - $TEMPLATE" >&2
     echo "  Is chassis vendored at \$CHASSIS_HOME/chassis/?" >&2
     exit 2
 fi
 
 # ---------------------------------------------------------------------------
-# Delegate to hydrate-mcp-json.py when we can.
+# Delegate to hydrate-mcp-json.py. Always.
 #
-# The sed+jq path below cannot evaluate `_enable_when`: it strips the key and
-# registers the server anyway. That was survivable while the gated servers were
-# things like brave-search, where the worst case is a server nobody calls. It
-# stopped being survivable with the Google entries (#57), which would otherwise
-# get registered on every install that recovers through this script - including
-# installs that never enabled Google and have no OAuth token on disk.
+# This script used to carry a second renderer: a sed+jq pass that ran whenever
+# chassis.config.yaml or PyYAML was missing. It stripped `_enable_when` without
+# evaluating it, so it registered every feature-gated server unconditionally -
+# siyuan AND notion AND secondbrain on one install, plus the Google entries
+# (#57) on installs that never enabled Google and have no OAuth token on disk.
+# A recovery path that produces a config the primary path would never produce
+# is not a fallback, it is a second product with its own bugs.
 #
-# hydrate-mcp-json.py is the renderer bootstrap.sh already uses and the one the
-# test suite covers. Use it here too, so both paths honor one grammar. The sed
-# path stays as the fallback for the case it was written for: a broken install
-# where chassis.config.yaml is missing and .mcp.json must be reconstructed.
+# It is gone. The two conditions that used to select it are handled inside the
+# hydrator instead, where the `_enable_when` grammar and its tests already live:
+#
+#   no PyYAML   -> load_yaml falls back to the minimal parser shipped in
+#                  chassis/second_brain/factory.py.
+#   no config   -> hydrator renders against an empty config, which drops every
+#                  `==`-gated server and keeps the ungated core. Minimal and
+#                  correct beats complete and wrong.
+#
+# Related: PR #58 flagged this file as knowingly broken; this is the Stage 2 fix.
 # ---------------------------------------------------------------------------
 HYDRATOR="$SCRIPT_DIR/hydrate-mcp-json.py"
 CONFIG="$CUSTOMER_HOME/chassis.config.yaml"
 
-if [[ -f "$HYDRATOR" && -f "$CONFIG" ]] && command -v python3 >/dev/null 2>&1 \
-   && python3 -c 'import yaml' 2>/dev/null; then
-    hydrator_args=(--config "$CONFIG" --template "$TEMPLATE")
-    [[ -f "$ENV_FILE" ]] && hydrator_args+=(--env "$ENV_FILE")
-
-    if [[ $DRY_RUN -eq 1 ]]; then
-        python3 "$HYDRATOR" "${hydrator_args[@]}" --output "$TARGET" --dry-run
-        exit 0
-    fi
-
-    if [[ -f "$TARGET" && $FORCE -eq 0 ]]; then
-        echo "skip: $TARGET already exists; pass --force to overwrite" >&2
-        exit 0
-    fi
-
-    rc=0
-    ( umask 077; python3 "$HYDRATOR" "${hydrator_args[@]}" --output "$TARGET" ) || rc=$?
-    # Exit 2 means the file was written with <PLACEHOLDER> tokens still in it.
-    # Loud, not fatal - same contract bootstrap.sh applies.
-    if [[ $rc -eq 0 || $rc -eq 2 ]]; then
-        chmod 600 "$TARGET" 2>/dev/null || true
-        exit "$rc"
-    fi
-    echo "ERROR: hydrate-mcp-json.py exited $rc" >&2
-    exit "$rc"
+if [[ ! -f "$HYDRATOR" ]]; then
+    echo "ERROR: renderer missing - $HYDRATOR" >&2
+    echo "  chassis tree is incomplete; re-pull the subtree or rebuild the image." >&2
+    exit 2
 fi
 
-echo "WARN: falling back to the sed+jq renderer (no chassis.config.yaml, or no" >&2
-echo "      python3+PyYAML). It cannot evaluate _enable_when, so feature-gated" >&2
-echo "      servers are registered unconditionally. Review $TARGET before use." >&2
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: python3 not on PATH - hydrate-mcp-json.py cannot run." >&2
+    exit 2
+fi
 
-if [[ -f "$TARGET" && $FORCE -eq 0 && $DRY_RUN -eq 0 ]]; then
+hydrator_args=(--config "$CONFIG" --template "$TEMPLATE")
+[[ -f "$ENV_FILE" ]] && hydrator_args+=(--env "$ENV_FILE")
+
+if [[ $DRY_RUN -eq 1 ]]; then
+    python3 "$HYDRATOR" "${hydrator_args[@]}" --output "$TARGET" --dry-run
+    exit 0
+fi
+
+if [[ -f "$TARGET" && $FORCE -eq 0 ]]; then
     echo "skip: $TARGET already exists; pass --force to overwrite" >&2
     exit 0
 fi
 
-# Source .env to pull in Vaultwarden-hydrated secrets. Tolerate partial
-# hydration failures — any unset env var becomes a `<PLACEHOLDER>` left in
-# the output, which is louder than failing silently.
-if [[ -f "$ENV_FILE" ]]; then
-    set -a
-    # shellcheck disable=SC1090,SC1091
-    source "$ENV_FILE" 2>/dev/null || true
-    set +a
+rc=0
+( umask 077; python3 "$HYDRATOR" "${hydrator_args[@]}" --output "$TARGET" ) || rc=$?
+# Exit 2 means the file was written with <PLACEHOLDER> tokens still in it.
+# Loud, not fatal - same contract bootstrap.sh applies.
+if [[ $rc -eq 0 || $rc -eq 2 ]]; then
+    chmod 600 "$TARGET" 2>/dev/null || true
+    exit "$rc"
 fi
-
-# Discover placeholders in the template — each `<NAME>` becomes a substitution
-# target. Match only [A-Z_]+ to avoid false hits on the README's `<PLACEHOLDER>`.
-# Avoid `mapfile` (bash 4+ only — macOS ships bash 3.2 at /bin/bash).
-PLACEHOLDERS=()
-while IFS= read -r line; do
-    PLACEHOLDERS+=("$line")
-done < <(grep -oE '<[A-Z_]+>' "$TEMPLATE" | sort -u)
-
-# Build the output via a single sed pass. Skip `<PLACEHOLDER>` (used in the
-# README copy as a literal example, not a real substitution target).
-OUTPUT=$(cat "$TEMPLATE")
-
-filled=()
-unfilled=()
-for ph in "${PLACEHOLDERS[@]}"; do
-    var_name="${ph#<}"
-    var_name="${var_name%>}"
-    [[ "$var_name" == "PLACEHOLDER" ]] && continue
-    value="${!var_name:-}"
-    if [[ -n "$value" ]]; then
-        # Escape the value for sed: backslashes, ampersands, and the chosen
-        # delimiter (|). Tokens never legitimately contain `|` so this is safe.
-        escaped=$(printf '%s' "$value" | sed -e 's/[\\&|]/\\&/g')
-        OUTPUT=$(printf '%s' "$OUTPUT" | sed "s|<$var_name>|$escaped|g")
-        filled+=("$var_name")
-    else
-        unfilled+=("$var_name")
-    fi
-done
-
-# Shell-expand ${CHASSIS_HOME} and ${CUSTOMER_HOME} (kept literal in the
-# template so the file is self-documenting). Only substitute the exact tokens.
-OUTPUT=$(printf '%s' "$OUTPUT" | sed -e "s|\${CHASSIS_HOME}|$CHASSIS_HOME|g" -e "s|\${CUSTOMER_HOME}|$CUSTOMER_HOME|g")
-
-# Strip template-only metadata: the top-level `_README`, every `_*` key inside a
-# server entry, and the `_*` divider entries that are section headers rather than
-# servers. Match on the underscore prefix, not on a hand-maintained list of names -
-# the old `del(._role) | del(._enable_when) | del(._install_note)` form silently
-# leaked every key nobody remembered to add to it.
-if command -v jq >/dev/null 2>&1; then
-    OUTPUT=$(printf '%s' "$OUTPUT" | jq '
-        del(._README)
-        | .mcpServers |= (
-            with_entries(select(.key | startswith("_") | not))
-            | map_values(with_entries(select(.key | startswith("_") | not)))
-        )')
-fi
-
-# Validate the result is parseable JSON before writing.
-if ! printf '%s' "$OUTPUT" | jq empty 2>/dev/null; then
-    echo "ERROR: hydrated output failed JSON validation" >&2
-    echo "  template: $TEMPLATE" >&2
-    echo "  target: $TARGET" >&2
-    echo "  unfilled placeholders: ${unfilled[*]:-none}" >&2
-    exit 3
-fi
-
-if [[ $DRY_RUN -eq 1 ]]; then
-    printf '%s\n' "$OUTPUT"
-    echo "" >&2
-    echo "=== bootstrap-mcp-config dry-run summary ===" >&2
-    echo "  filled:   ${filled[*]:-none}" >&2
-    echo "  unfilled: ${unfilled[*]:-none}" >&2
-    exit 0
-fi
-
-# Atomic write with 0600. The bw-hydrated env may contain API tokens that
-# should never land on disk world-readable.
-umask 077
-TMP="${TARGET}.tmp"
-printf '%s\n' "$OUTPUT" > "$TMP"
-mv "$TMP" "$TARGET"
-chmod 600 "$TARGET"
-
-echo "wrote $TARGET"
-echo "  filled:   ${#filled[@]} placeholders (${filled[*]:-none})"
-if [[ ${#unfilled[@]} -gt 0 ]]; then
-    echo "  unfilled: ${#unfilled[@]} placeholders (${unfilled[*]})"
-    echo "  → these stayed as <NAME> strings; fill manually or hydrate via Vaultwarden + rerun with --force"
-fi
+echo "ERROR: hydrate-mcp-json.py exited $rc" >&2
+exit "$rc"

--- a/chassis/scripts/check-second-brain-backend.py
+++ b/chassis/scripts/check-second-brain-backend.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""check-second-brain-backend.py - one reachability check per second-brain backend.
+
+Called by chassis/scripts/smoke-test.sh. Emits exactly one line on stdout:
+
+    <PASS|FAIL|SKIP>|<message>
+
+and always exits 0 - the caller decides what a status means for the run's exit
+code, the same contract every other `record` line in smoke-test.sh follows.
+
+Why this is a separate file
+===========================
+The check it replaces lived inline in smoke-test.sh and knew only Notion: it
+curled api.notion.com and recorded SKIP for anything else. Two consequences,
+both bad.
+
+1. `chassis.config.yaml` lists `second_brain_read` under
+   `success_criteria.smoke_tests`, but the inline check recorded itself as
+   `notion_read`. The criterion named a check that did not exist, so it could
+   never be satisfied - not on Obsidian, not on SiYuan, not even on Notion.
+2. An Obsidian install SKIPped. A vault path that is missing, is a file, or is
+   root-owned and unreadable by the container user is the single most likely
+   thing to be wrong with an Obsidian install, and the smoke test said nothing
+   about it. Reporting SKIP for the one condition worth checking is worse than
+   having no check, because it reads as "nothing to verify here".
+
+Per-backend semantics
+=====================
+  obsidian - filesystem only, no network. vault_path must exist, be a
+             directory, and be readable (R_OK for listing entries, X_OK for
+             traversing into them - a directory missing either is unusable
+             even though both look like "readable"). Writability must MATCH
+             the declared intent: `read_only: true` says pull-only, so a
+             writable vault is a config/filesystem disagreement worth
+             surfacing, and a read-only vault without the flag is a FAIL
+             because every write will be refused at runtime.
+  siyuan   - POST /api/system/version with the configured token. Chosen over
+             a bare TCP connect because a kernel that is up but rejecting the
+             token answers "Auth failed [session]" on every real call, and
+             that is precisely the failure a smoke test exists to catch.
+  notion   - GET /v1/users/me, unchanged from the inline check.
+
+Missing/unknown backend or missing config is SKIP, not FAIL: a chassis install
+is allowed to run without a second brain.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+# Make `chassis.second_brain` importable regardless of cwd - same resolution
+# mcp_server.py uses, and for the same reason (this runs from the entrypoint,
+# from a shell, and from tests, all with different working directories).
+_PACKAGE_PARENT = Path(__file__).resolve().parents[2]
+if str(_PACKAGE_PARENT) not in sys.path:
+    sys.path.insert(0, str(_PACKAGE_PARENT))
+
+HTTP_TIMEOUT = 10
+
+
+def emit(status: str, message: str) -> int:
+    print(f"{status}|{message}")
+    return 0
+
+
+def load_second_brain_config() -> dict[str, Any]:
+    """Return the `second_brain` block, or {} when it cannot be read."""
+    try:
+        from chassis.second_brain.factory import _load_config
+    except ImportError:
+        return {}
+    try:
+        config = _load_config()
+    except Exception:  # noqa: BLE001 - missing/malformed config is a SKIP, not a crash
+        return {}
+    return config.get("second_brain") or {}
+
+
+def check_obsidian(backend_config: dict[str, Any]) -> tuple[str, str]:
+    raw_path = str(backend_config.get("vault_path") or "").strip()
+    raw_path = os.path.expandvars(raw_path)
+    if not raw_path:
+        return "FAIL", "second_brain.obsidian.vault_path is not set in chassis.config.yaml"
+    vault = Path(raw_path).expanduser()
+    if not vault.exists():
+        return "FAIL", f"Obsidian vault_path does not exist: {vault}"
+    if not vault.is_dir():
+        return "FAIL", f"Obsidian vault_path is not a directory: {vault}"
+    if not os.access(vault, os.R_OK) or not os.access(vault, os.X_OK):
+        return "FAIL", f"Obsidian vault_path is not readable by this user: {vault}"
+
+    declared_read_only = bool(backend_config.get("read_only", False))
+    actually_writable = os.access(vault, os.W_OK)
+    note_count = sum(1 for _ in vault.rglob("*.md"))
+
+    if declared_read_only:
+        # Not a FAIL. The install told us it never writes, and it does not.
+        # A writable vault here is worth saying out loud so a misconfigured
+        # read_only flag is visible, but nothing is broken either way.
+        detail = "writable on disk despite read_only: true" if actually_writable else "read-only as declared"
+        return "PASS", f"Obsidian vault readable at {vault} ({note_count} notes), {detail}"
+    if not actually_writable:
+        return "FAIL", (
+            f"Obsidian vault {vault} is not writable and read_only is not set - "
+            f"every write will be refused at runtime. Fix permissions, or declare "
+            f"second_brain.obsidian.read_only: true."
+        )
+    return "PASS", f"Obsidian vault readable + writable at {vault} ({note_count} notes)"
+
+
+def check_siyuan(backend_config: dict[str, Any]) -> tuple[str, str]:
+    base_url = (
+        str(backend_config.get("base_url") or "").strip()
+        or os.environ.get("SIYUAN_URL", "").strip()
+        or "http://127.0.0.1:6806"
+    )
+    token = (
+        str(backend_config.get("token") or "").strip()
+        or os.environ.get("SIYUAN_TOKEN", "").strip()
+    )
+    if not token:
+        return "SKIP", "SIYUAN_TOKEN not set"
+    req = urllib.request.Request(
+        base_url.rstrip("/") + "/api/system/version",
+        data=b"{}",
+        method="POST",
+    )
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Authorization", f"Token {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError) as e:
+        return "FAIL", f"SiYuan API unreachable at {base_url} ({type(e).__name__}: {e})"
+    except json.JSONDecodeError:
+        return "FAIL", f"SiYuan API at {base_url} returned non-JSON"
+    if body.get("code") != 0:
+        # code -1 with "Auth failed [session]" is the wrong-token case.
+        return "FAIL", f"SiYuan API rejected the call: code={body.get('code')} msg={body.get('msg')}"
+    return "PASS", f"SiYuan API reached at {base_url}, kernel {body.get('data')}"
+
+
+def check_notion(backend_config: dict[str, Any]) -> tuple[str, str]:
+    token = (
+        str(backend_config.get("token") or "").strip()
+        or os.environ.get("NOTION_API_TOKEN", "").strip()
+    )
+    if not token:
+        return "SKIP", "NOTION_API_TOKEN not set"
+    req = urllib.request.Request("https://api.notion.com/v1/users/me")
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Notion-Version", "2022-06-28")
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError) as e:
+        return "FAIL", f"Notion API call failed ({type(e).__name__}: {e})"
+    except json.JSONDecodeError:
+        return "FAIL", "Notion API returned non-JSON"
+    bot_id = body.get("id")
+    if not bot_id:
+        return "FAIL", "Notion API returned no bot id (token wrong / scope issue)"
+    return "PASS", f"Notion API reached, bot id {bot_id}"
+
+
+CHECKS = {
+    "obsidian": check_obsidian,
+    "siyuan": check_siyuan,
+    "notion": check_notion,
+}
+
+
+def main() -> int:
+    sb_config = load_second_brain_config()
+    backend = str(sb_config.get("backend") or "").strip().lower()
+    if not backend:
+        return emit("SKIP", "second_brain.backend not set in chassis.config.yaml")
+    check = CHECKS.get(backend)
+    if check is None:
+        return emit("SKIP", f"no reachability check for second_brain.backend={backend!r}")
+    status, message = check(sb_config.get(backend) or {})
+    return emit(status, message)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/chassis/scripts/daily-log-gather.py
+++ b/chassis/scripts/daily-log-gather.py
@@ -21,7 +21,28 @@ Design goals:
      against bot-authored messages in the last 24h).
   3. Reflection section is prompt-side; this script only supplies raw
      material.
-  4. Operational surfaces scanned: GitHub, Gmail, SiYuan, Discord.
+  4. Operational surfaces scanned: GitHub, Gmail, second brain, Discord.
+
+Second-brain surface (Stage 2, 2026-07-19)
+==========================================
+This script used to talk to SiYuan and only SiYuan, over hardcoded HTTP. That
+made the daily log a no-op on Obsidian and Notion installs: the SiYuan env vars
+are unset there, so the scan was skipped and the prompt narrated a day with no
+writing in it. The second-brain adapter (chassis/second_brain/) already knew how
+to read all three backends, but nothing outside its own package called it.
+
+The backend now decides which path runs:
+
+  - siyuan (and every install where the backend cannot be determined): the
+    original direct-HTTP `gather_siyuan` below, byte-for-byte unchanged. This
+    is deliberate. SiYuan is the backend every existing install runs, and the
+    adapter's `list_recent` is close to but not identical to this query (see
+    the divergence table in docs/second-brain-adapters.md). Routing SiYuan
+    through the adapter would have been a silent behavior change on every live
+    install to buy nothing.
+  - obsidian / notion: `gather_via_adapter`, which calls
+    `get_adapter().notes.list_recent()` and maps the hits into the same item
+    shape the SiYuan path emits.
 
 Env var contract (chassis is generic; customer install sets these):
   CHASSIS_HOME                     - customer install root (required)
@@ -33,6 +54,9 @@ Env var contract (chassis is generic; customer install sets these):
   DAILY_LOG_EXTRA_METRICS_SCRIPT   - path to a customer-side script that emits
                                      JSON under a `custom` metrics key
   DISCORD_TOKEN / DISCORD_BOT_TOKEN - Discord bot token (probes both)
+
+The obsidian / notion paths read their credentials from chassis.config.yaml via
+the adapter factory, so they need no DAILY_LOG_* vars of their own.
 
 Unset env vars degrade gracefully: the corresponding surface is skipped, a
 warning is emitted into the `warnings` array, and the rest of the gather
@@ -380,6 +404,116 @@ def gather_siyuan(url: str, token: str | None, since: datetime, until: datetime,
     return activity, warnings
 
 
+# --- Second-brain backend resolution + adapter surface --------------------
+
+
+def resolve_second_brain_backend(*, verbose: bool = False) -> str:
+    """Return the configured `second_brain.backend`, or 'siyuan' when unknown.
+
+    'siyuan' is the fallback on EVERY failure - no chassis.config.yaml, no
+    PyYAML, an import error, a malformed config. That is not laziness, it is
+    the compatibility guarantee: every install that predates the second-brain
+    adapter runs SiYuan, so an unresolvable config must keep running the exact
+    path it ran yesterday rather than degrade to an empty scan.
+    """
+    package_parent = Path(__file__).resolve().parents[2]
+    if str(package_parent) not in sys.path:
+        sys.path.insert(0, str(package_parent))
+    try:
+        from chassis.second_brain.factory import _load_config
+    except ImportError as e:
+        log(f"second_brain package not importable ({e}) - assuming siyuan", verbose=verbose)
+        return "siyuan"
+    try:
+        config = _load_config()
+    except Exception as e:  # noqa: BLE001 - any config failure means "assume siyuan"
+        log(f"chassis.config.yaml unreadable ({type(e).__name__}: {e}) - assuming siyuan",
+            verbose=verbose)
+        return "siyuan"
+    backend = ((config.get("second_brain") or {}).get("backend") or "siyuan")
+    return str(backend).strip().lower() or "siyuan"
+
+
+def hit_to_activity(hit: Any, backend: str) -> dict:
+    """Map a SearchHit onto the activity item shape the SiYuan path emits.
+
+    The SiYuan path's keys (`id`, `hpath`, `len`, `updated_at`, `excerpt`) are
+    the published contract - the daily-log prompt reads them by name. Rather
+    than emit a second shape for the other two backends and make the prompt
+    branch, each backend fills the same five keys with the closest honest
+    equivalent it has, and `deeplink` is added because the adapter gives it to
+    us for free on all three.
+
+    The per-backend `raw` payloads are documented in each adapter's
+    `list_recent` docstring; the .get() chains below are ordered
+    siyuan-then-obsidian-then-notion and fall through to a safe default,
+    because a hit whose raw shape we do not recognize should still produce a
+    usable row rather than a KeyError that kills the whole gather.
+    """
+    raw = hit.raw or {}
+    return {
+        "id": hit.id,
+        # SiYuan hpath; Obsidian vault-relative path (which IS the id); Notion
+        # has no path concept at all, so the page title stands in for one.
+        "hpath": raw.get("hpath") or (hit.id if backend == "obsidian" else hit.title),
+        "title": hit.title,
+        # body_len (siyuan chars) / size_bytes (obsidian bytes). Notion's search
+        # API returns no size, so fall back to the snippet we do have.
+        "len": raw.get("body_len") or raw.get("size_bytes") or len(hit.snippet or ""),
+        "updated_at": str(
+            raw.get("updated") or raw.get("last_edited_time") or raw.get("mtime") or ""
+        ),
+        "excerpt": (hit.snippet or "")[:300].strip(),
+        "deeplink": hit.deeplink,
+        "backend": backend,
+    }
+
+
+def gather_via_adapter(backend: str, since: datetime, until: datetime,
+                       *, verbose: bool) -> tuple[list[dict], list[str]]:
+    """Second-brain activity for non-SiYuan backends, via get_adapter().
+
+    Naive local datetimes are handed to the adapter, not the UTC-aware ones the
+    rest of this script uses. Obsidian compares against `st_mtime` and SiYuan
+    against a kernel-local clock string, so an aware UTC datetime would shift
+    the window by the host's offset - one hour of missed or double-counted
+    activity in Lisbon, more elsewhere. `list_recent` documents naive input as
+    "local time"; give it exactly that.
+    """
+    warnings: list[str] = []
+    package_parent = Path(__file__).resolve().parents[2]
+    if str(package_parent) not in sys.path:
+        sys.path.insert(0, str(package_parent))
+    try:
+        from chassis.second_brain.factory import get_adapter
+    except ImportError as e:
+        warnings.append(f"second_brain adapter not importable ({e}) - skipped {backend} scan")
+        return [], warnings
+    try:
+        adapter = get_adapter()
+    except Exception as e:  # noqa: BLE001 - factory raises ValueError on bad creds
+        warnings.append(
+            f"{backend} adapter could not be built ({type(e).__name__}: {e}) - "
+            f"skipped second-brain scan"
+        )
+        return [], warnings
+    try:
+        hits = adapter.notes.list_recent(
+            since=since.astimezone().replace(tzinfo=None),
+            until=until.astimezone().replace(tzinfo=None),
+            min_content_len=DEFAULT_SIYUAN_MIN_CONTENT_LEN,
+            limit=DEFAULT_SIYUAN_LIMIT,
+        )
+    except Exception as e:  # noqa: BLE001 - one dead surface must not fail the gather
+        warnings.append(
+            f"{backend} list_recent failed ({type(e).__name__}: {e}) - "
+            f"skipped second-brain scan"
+        )
+        return [], warnings
+    log(f"{backend} adapter returned {len(hits)} hit(s)", verbose=verbose)
+    return [hit_to_activity(hit, backend) for hit in hits], warnings
+
+
 # --- Discord postmortem mining --------------------------------------------
 
 
@@ -571,18 +705,28 @@ def build_output(now: datetime | None = None, *, verbose: bool = False) -> dict:
     else:
         warnings.append("DAILY_LOG_GMAIL_IDENTITY unset - skipped Gmail scan")
 
-    # SiYuan.
-    siyuan_url = (os.environ.get("DAILY_LOG_SIYUAN_URL")
-                  or os.environ.get("SIYUAN_URL") or "").strip()
-    siyuan_token = (os.environ.get("DAILY_LOG_SIYUAN_TOKEN")
-                    or os.environ.get("SIYUAN_TOKEN") or "").strip() or None
-    if siyuan_url:
-        siyuan_activity, siyuan_warn = gather_siyuan(
-            siyuan_url, siyuan_token, since, until, verbose=verbose
-        )
-        warnings.extend(siyuan_warn)
+    # Second brain. SiYuan keeps the direct-HTTP path it has always used; the
+    # other backends go through the adapter. See the module docstring for why
+    # SiYuan is deliberately NOT routed through get_adapter().
+    backend = resolve_second_brain_backend(verbose=verbose)
+    log(f"second-brain backend resolved: {backend}", verbose=verbose)
+    if backend == "siyuan":
+        siyuan_url = (os.environ.get("DAILY_LOG_SIYUAN_URL")
+                      or os.environ.get("SIYUAN_URL") or "").strip()
+        siyuan_token = (os.environ.get("DAILY_LOG_SIYUAN_TOKEN")
+                        or os.environ.get("SIYUAN_TOKEN") or "").strip() or None
+        if siyuan_url:
+            siyuan_activity, siyuan_warn = gather_siyuan(
+                siyuan_url, siyuan_token, since, until, verbose=verbose
+            )
+            warnings.extend(siyuan_warn)
+        else:
+            warnings.append("DAILY_LOG_SIYUAN_URL / SIYUAN_URL unset - skipped SiYuan scan")
     else:
-        warnings.append("DAILY_LOG_SIYUAN_URL / SIYUAN_URL unset - skipped SiYuan scan")
+        siyuan_activity, adapter_warn = gather_via_adapter(
+            backend, since, until, verbose=verbose
+        )
+        warnings.extend(adapter_warn)
 
     # Discord postmortems.
     channel_id = os.environ.get("DAILY_LOG_DISCORD_CHANNEL_ID", "").strip()
@@ -615,6 +759,14 @@ def build_output(now: datetime | None = None, *, verbose: bool = False) -> dict:
         "open_issues_awaiting_input": open_issues,
         "operational_email": operational_email,
         "gmail_scan_deferred": email_deferred,
+        # `second_brain_activity` is the name to read. `siyuan_activity` is the
+        # same list under its old name, kept because customer installs have a
+        # hand-filled daily-log-prompt.md on disk that reads it - bootstrap
+        # copies the template once and never rewrites it, so dropping the key
+        # would blank the "SiYuan writing" bullet on every existing install the
+        # day this ships. Remove it after installs have been migrated.
+        "second_brain_backend": backend,
+        "second_brain_activity": siyuan_activity,
         "siyuan_activity": siyuan_activity,
         "postmortems": postmortems,
         "metrics": metrics,
@@ -651,6 +803,8 @@ def main() -> int:
             "open_issues_awaiting_input": [],
             "operational_email": [],
             "gmail_scan_deferred": False,
+            "second_brain_backend": "unknown",
+            "second_brain_activity": [],
             "siyuan_activity": [],
             "postmortems": [],
             "metrics": {},

--- a/chassis/scripts/hydrate-mcp-json.py
+++ b/chassis/scripts/hydrate-mcp-json.py
@@ -40,14 +40,49 @@ import sys
 
 
 def load_yaml(path):
+    """Parse chassis.config.yaml. PyYAML when available, fallback parser otherwise.
+
+    This used to `sys.exit(1)` when PyYAML was missing, which is what forced
+    bootstrap-mcp-config.sh to keep a second, worse renderer around for the
+    no-PyYAML case: a sed+jq pass that stripped `_enable_when` without
+    evaluating it and therefore registered every gated server at once - siyuan
+    AND notion AND secondbrain on the same install. Two renderers with two
+    different answers is a worse failure than a degraded parser, so the
+    dependency is now soft and there is exactly one renderer.
+
+    The fallback is `chassis.second_brain.factory._parse_yaml_minimal`, already
+    shipped and already tested for exactly this subtree. It does not support
+    lists; `_enable_when` predicates only ever address scalar leaves
+    (`modules.google.gmail == true`, `second_brain.backend == 'siyuan'`), so a
+    list-valued key resolves to None and its clause evaluates False - the same
+    conservative direction the predicate evaluator already takes for a missing
+    key.
+    """
     try:
         import yaml
     except ImportError:
-        print(f'ERROR: PyYAML not installed. apt-get install python3-yaml '
-              f'OR pip install pyyaml', file=sys.stderr)
+        pass
+    else:
+        with open(path) as f:
+            return yaml.safe_load(f) or {}
+
+    package_parent = os.path.dirname(os.path.dirname(os.path.dirname(
+        os.path.abspath(__file__))))
+    if package_parent not in sys.path:
+        sys.path.insert(0, package_parent)
+    try:
+        from chassis.second_brain.factory import _parse_yaml_minimal
+    except ImportError:
+        print('ERROR: PyYAML not installed and chassis.second_brain is not '
+              'importable, so chassis.config.yaml cannot be parsed. '
+              'apt-get install python3-yaml OR pip install pyyaml',
+              file=sys.stderr)
         sys.exit(1)
+    print('WARN: PyYAML not installed - parsing chassis.config.yaml with the '
+          'minimal fallback parser (scalars and nested mappings only).',
+          file=sys.stderr)
     with open(path) as f:
-        return yaml.safe_load(f) or {}
+        return _parse_yaml_minimal(f.read()) or {}
 
 
 def load_json(path):
@@ -328,12 +363,29 @@ def main():
                    help='print hydrated JSON to stdout, do not write')
     args = p.parse_args()
 
-    for path, label in [(args.config, 'config'), (args.template, 'template')]:
-        if not os.path.exists(path):
-            print(f'ERROR: {label} not found: {path}', file=sys.stderr)
-            sys.exit(1)
+    if not os.path.exists(args.template):
+        print(f'ERROR: template not found: {args.template}', file=sys.stderr)
+        sys.exit(1)
 
-    config = load_yaml(args.config)
+    # A missing chassis.config.yaml is the disaster-recovery case
+    # bootstrap-mcp-config.sh's fallback renderer was written for: reconstruct
+    # a usable .mcp.json on an install whose config is gone. Treat it as an
+    # empty config rather than an error, so that path can delegate here too.
+    #
+    # Empty config is the SAFE direction, and only because of how the predicate
+    # evaluator already treats a missing key: `== ` clauses go False (a gated
+    # server is dropped, so no siyuan, no notion, no secondbrain, no Google)
+    # while `!=` clauses go True. The result is core servers only, which is
+    # exactly what a recovery should produce - a minimal working config the
+    # operator widens on purpose, not every server at once.
+    if not os.path.exists(args.config):
+        print(f'WARN: config not found: {args.config} - rendering with an empty '
+              f'config. Feature-gated servers will be OMITTED. Restore '
+              f'chassis.config.yaml and re-run to get the full set.',
+              file=sys.stderr)
+        config = {}
+    else:
+        config = load_yaml(args.config)
     template = load_json(args.template)
     env = load_env(args.env)
 

--- a/chassis/scripts/smoke-test.sh
+++ b/chassis/scripts/smoke-test.sh
@@ -207,20 +207,35 @@ check_slack_intake_helper() {
 }
 
 check_second_brain_backend_reachable() {
-    if [[ -z "${NOTION_API_TOKEN:-}" ]]; then
-        record SKIP notion_read "NOTION_API_TOKEN not set"
+    # Dispatches per configured backend - see check-second-brain-backend.py for
+    # what each one verifies. Two things changed here 2026-07-19 (Stage 2):
+    #
+    #   - the check name is `second_brain_read`, not `notion_read`. That is the
+    #     name chassis.config.yaml already lists under
+    #     success_criteria.smoke_tests, so until now the criterion referenced a
+    #     check that never appeared in the output on ANY backend.
+    #   - Obsidian and SiYuan get real checks instead of a SKIP.
+    #
+    # The logic lives in Python rather than inline here because it has to read
+    # chassis.config.yaml (bash cannot, without a fourth hand-rolled YAML
+    # parser) and because per-backend branches need unit tests.
+    local helper="$CHASSIS_ROOT/scripts/check-second-brain-backend.py"
+    if [[ ! -f "$helper" ]]; then
+        record SKIP second_brain_read "$helper not found"
         return
     fi
-    local resp
-    resp=$(curl -fsS -H "Authorization: Bearer $NOTION_API_TOKEN" -H "Notion-Version: 2022-06-28" \
-        https://api.notion.com/v1/users/me 2>/dev/null || echo "")
-    if echo "$resp" | jq -e .id >/dev/null 2>&1; then
-        local bot_id
-        bot_id=$(echo "$resp" | jq -r .id)
-        record PASS notion_read "Notion API reached, bot id $bot_id"
-    else
-        record FAIL notion_read "Notion API call failed (token wrong / network blocked / scope issue)"
+    local out status msg
+    out=$(python3 "$helper" 2>/dev/null | tail -1)
+    if [[ -z "$out" ]]; then
+        record FAIL second_brain_read "check-second-brain-backend.py produced no output"
+        return
     fi
+    status="${out%%|*}"
+    msg="${out#*|}"
+    case "$status" in
+        PASS|FAIL|SKIP) record "$status" second_brain_read "$msg" ;;
+        *) record FAIL second_brain_read "unparseable helper output: $out" ;;
+    esac
 }
 
 check_discord_webhook_reachable() {

--- a/chassis/second_brain/tests/test_bootstrap_mcp_recovery.py
+++ b/chassis/second_brain/tests/test_bootstrap_mcp_recovery.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""test_bootstrap_mcp_recovery.py - bootstrap-mcp-config.sh recovery path.
+
+bootstrap-mcp-config.sh used to carry a second renderer: a sed+jq pass that ran
+whenever chassis.config.yaml or PyYAML was missing. It stripped `_enable_when`
+without evaluating it, so it registered every feature-gated server at once -
+siyuan AND notion AND secondbrain on one install, plus Google entries on
+installs with no OAuth token on disk. PR #58 flagged it; this is the fix.
+
+Rather than teach the sed path the predicate grammar, the two conditions that
+selected it now resolve inside hydrate-mcp-json.py, and the shell script
+delegates unconditionally. These tests cover exactly those two conditions,
+since they are the ones that used to route around the hydrator:
+
+  no PyYAML -> minimal fallback parser, same servers as PyYAML would give.
+  no config -> empty config, which drops `==`-gated servers and keeps the
+               ungated core.
+
+The second is the one worth stating precisely: "fail closed" here means a
+recovering install gets a MINIMAL .mcp.json, not a maximal one. Registering
+three second-brain servers on a broken install is how you get a Claude session
+that reaches for whichever tool it saw first.
+
+Run:
+    python3 -m pytest chassis/second_brain/tests/test_bootstrap_mcp_recovery.py -v
+"""
+from __future__ import annotations
+
+import builtins
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+TEMPLATE_PATH = REPO_ROOT / "chassis" / ".mcp.json.template"
+HYDRATOR_PATH = REPO_ROOT / "chassis" / "scripts" / "hydrate-mcp-json.py"
+BOOTSTRAP_PATH = REPO_ROOT / "chassis" / "scripts" / "bootstrap-mcp-config.sh"
+
+_spec = importlib.util.spec_from_file_location("hydrate_mcp_json", HYDRATOR_PATH)
+hydrator = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hydrator)
+
+SECOND_BRAIN_SERVERS = {"siyuan", "notion", "secondbrain"}
+
+SAMPLE_CONFIG = """\
+second_brain:
+  backend: siyuan
+  mode: direct
+modules:
+  google:
+    gmail: true
+    calendar: false
+  research:
+    brave: true
+    tavily: false
+"""
+
+
+class NoPyYamlFallbackTest(unittest.TestCase):
+    """`import yaml` failing must not change which servers render."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.config = Path(self._tmp.name) / "chassis.config.yaml"
+        self.config.write_text(SAMPLE_CONFIG, encoding="utf-8")
+        self.addCleanup(self._tmp.cleanup)
+
+    @staticmethod
+    def _without_pyyaml():
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "yaml":
+                raise ImportError("No module named 'yaml'")
+            return real_import(name, *args, **kwargs)
+
+        return mock.patch.object(builtins, "__import__", fake_import)
+
+    def test_fallback_parser_produces_the_same_config(self) -> None:
+        with_pyyaml = hydrator.load_yaml(str(self.config))
+        with self._without_pyyaml():
+            without_pyyaml = hydrator.load_yaml(str(self.config))
+        self.assertEqual(with_pyyaml, without_pyyaml)
+
+    def test_fallback_parser_produces_the_same_servers(self) -> None:
+        template = hydrator.load_json(str(TEMPLATE_PATH))
+        rendered_with, _ = hydrator.hydrate(
+            hydrator.load_yaml(str(self.config)), template, env={}
+        )
+        with self._without_pyyaml():
+            rendered_without, _ = hydrator.hydrate(
+                hydrator.load_yaml(str(self.config)), template, env={}
+            )
+        self.assertEqual(
+            set(rendered_with["mcpServers"]), set(rendered_without["mcpServers"])
+        )
+        # And the gate actually did something - siyuan in, notion + secondbrain out.
+        present = SECOND_BRAIN_SERVERS & set(rendered_without["mcpServers"])
+        self.assertEqual(present, {"siyuan"})
+
+    def test_fallback_still_evaluates_module_gates(self) -> None:
+        with self._without_pyyaml():
+            config = hydrator.load_yaml(str(self.config))
+        template = hydrator.load_json(str(TEMPLATE_PATH))
+        servers = hydrator.hydrate(config, template, env={})[0]["mcpServers"]
+        self.assertIn("gmail", servers)                 # gmail: true
+        self.assertNotIn("google-calendar", servers)    # calendar: false
+        self.assertIn("brave-search", servers)          # brave: true
+        self.assertNotIn("tavily", servers)             # tavily: false
+
+
+class MissingConfigTest(unittest.TestCase):
+    """No chassis.config.yaml renders core-only, never everything."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.output = Path(self._tmp.name) / ".mcp.json"
+        self.addCleanup(self._tmp.cleanup)
+
+    def _render_with_empty_config(self) -> dict:
+        template = hydrator.load_json(str(TEMPLATE_PATH))
+        return hydrator.hydrate({}, template, env={})[0]["mcpServers"]
+
+    def test_no_second_brain_server_is_registered(self) -> None:
+        """The exact bug: three second-brain servers on one install."""
+        servers = self._render_with_empty_config()
+        self.assertEqual(SECOND_BRAIN_SERVERS & set(servers), set())
+
+    def test_no_google_server_is_registered(self) -> None:
+        # These are the entries #57 called out: registered on installs that
+        # never enabled Google and have no OAuth token on disk.
+        servers = self._render_with_empty_config()
+        for name in ("gmail", "google-calendar", "google-sheets"):
+            self.assertNotIn(name, servers)
+
+    def test_ungated_core_servers_survive(self) -> None:
+        # Fail-closed must not mean fail-empty - a recovered install still needs
+        # the servers that were never gated in the first place.
+        servers = self._render_with_empty_config()
+        self.assertIn("memory", servers)
+
+    def test_hydrator_cli_writes_a_file_when_config_is_absent(self) -> None:
+        """End to end through the real CLI, since that is what the shell calls."""
+        result = subprocess.run(
+            [sys.executable, str(HYDRATOR_PATH),
+             "--config", str(Path(self._tmp.name) / "does-not-exist.yaml"),
+             "--template", str(TEMPLATE_PATH),
+             "--output", str(self.output)],
+            capture_output=True, text=True,
+        )
+        self.assertIn(result.returncode, (0, 2))  # 2 = unresolved placeholders
+        self.assertIn("config not found", result.stderr)
+        self.assertTrue(self.output.exists())
+        import json
+        servers = json.loads(self.output.read_text())["mcpServers"]
+        self.assertEqual(SECOND_BRAIN_SERVERS & set(servers), set())
+
+    def test_hydrator_cli_still_errors_on_a_missing_template(self) -> None:
+        # A missing config is recoverable; a missing template is not - there is
+        # nothing to render from.
+        result = subprocess.run(
+            [sys.executable, str(HYDRATOR_PATH),
+             "--config", str(Path(self._tmp.name) / "nope.yaml"),
+             "--template", str(Path(self._tmp.name) / "nope.json"),
+             "--output", str(self.output)],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("template not found", result.stderr)
+
+
+class BootstrapDelegationTest(unittest.TestCase):
+    """The shell script must have no second renderer left to drift."""
+
+    def setUp(self) -> None:
+        self.script = BOOTSTRAP_PATH.read_text(encoding="utf-8")
+
+    def test_script_parses(self) -> None:
+        result = subprocess.run(["bash", "-n", str(BOOTSTRAP_PATH)],
+                                capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_no_sed_or_jq_rendering_remains(self) -> None:
+        for token in ("PLACEHOLDERS=(", "jq empty", "del(._README)", "unfilled"):
+            self.assertNotIn(token, self.script,
+                             f"sed+jq renderer fragment {token!r} still present")
+
+    def test_delegation_is_not_conditional_on_pyyaml_or_config(self) -> None:
+        # The old gate was `[[ -f "$CONFIG" ]] && python3 -c 'import yaml'`.
+        # Both conditions moved into the hydrator; neither may gate here again.
+        self.assertNotIn("import yaml", self.script)
+        self.assertNotIn('-f "$CONFIG"', self.script)
+
+    def test_hydrator_is_invoked(self) -> None:
+        self.assertIn('python3 "$HYDRATOR"', self.script)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/chassis/second_brain/tests/test_check_second_brain_backend.py
+++ b/chassis/second_brain/tests/test_check_second_brain_backend.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""test_check_second_brain_backend.py - per-backend smoke reachability check.
+
+The check this replaces knew only Notion and recorded itself as `notion_read`,
+while chassis.config.yaml lists `second_brain_read` under
+`success_criteria.smoke_tests`. The criterion named a check that never appeared
+in the output, and Obsidian installs got a SKIP for the one thing most likely
+to be wrong with them.
+
+Obsidian gets the most coverage here because it is the only backend whose check
+is pure filesystem, so every branch is reachable in a test without a network
+fake - and because the read_only interaction is the subtle one: config states
+intent, the filesystem states truth, and the check has to react to the
+DISAGREEMENT rather than to either side alone.
+
+Run:
+    python3 -m pytest chassis/second_brain/tests/test_check_second_brain_backend.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+CHECK_PATH = REPO_ROOT / "chassis" / "scripts" / "check-second-brain-backend.py"
+_spec = importlib.util.spec_from_file_location("check_second_brain_backend", CHECK_PATH)
+checker = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(checker)
+
+
+class ObsidianCheckTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.vault = Path(self._tmp.name) / "vault"
+        self.vault.mkdir()
+        (self.vault / "note.md").write_text("# note", encoding="utf-8")
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_healthy_vault_passes_and_counts_notes(self) -> None:
+        status, msg = checker.check_obsidian({"vault_path": str(self.vault)})
+        self.assertEqual(status, "PASS")
+        self.assertIn("readable + writable", msg)
+        self.assertIn("1 notes", msg)
+
+    def test_unset_vault_path_fails(self) -> None:
+        status, msg = checker.check_obsidian({})
+        self.assertEqual(status, "FAIL")
+        self.assertIn("vault_path is not set", msg)
+
+    def test_missing_vault_fails(self) -> None:
+        status, msg = checker.check_obsidian(
+            {"vault_path": str(self.vault / "nope")}
+        )
+        self.assertEqual(status, "FAIL")
+        self.assertIn("does not exist", msg)
+
+    def test_vault_path_pointing_at_a_file_fails(self) -> None:
+        status, msg = checker.check_obsidian(
+            {"vault_path": str(self.vault / "note.md")}
+        )
+        self.assertEqual(status, "FAIL")
+        self.assertIn("not a directory", msg)
+
+    def test_unreadable_vault_fails(self) -> None:
+        with mock.patch.object(checker.os, "access",
+                               lambda p, m: m not in (os.R_OK, os.X_OK)):
+            status, msg = checker.check_obsidian({"vault_path": str(self.vault)})
+        self.assertEqual(status, "FAIL")
+        self.assertIn("not readable", msg)
+
+    def test_unwritable_vault_without_read_only_flag_fails(self) -> None:
+        """The runtime failure this catches: every write refused, no config says so."""
+        with mock.patch.object(checker.os, "access", lambda p, m: m != os.W_OK):
+            status, msg = checker.check_obsidian({"vault_path": str(self.vault)})
+        self.assertEqual(status, "FAIL")
+        self.assertIn("read_only is not set", msg)
+
+    def test_unwritable_vault_with_read_only_flag_passes(self) -> None:
+        with mock.patch.object(checker.os, "access", lambda p, m: m != os.W_OK):
+            status, msg = checker.check_obsidian(
+                {"vault_path": str(self.vault), "read_only": True}
+            )
+        self.assertEqual(status, "PASS")
+        self.assertIn("read-only as declared", msg)
+
+    def test_writable_vault_declared_read_only_passes_but_says_so(self) -> None:
+        # Nothing is broken, but the flag disagrees with the disk - say it out
+        # loud rather than let a stale read_only flag look intentional.
+        status, msg = checker.check_obsidian(
+            {"vault_path": str(self.vault), "read_only": True}
+        )
+        self.assertEqual(status, "PASS")
+        self.assertIn("despite read_only: true", msg)
+
+    def test_vault_path_expands_user_and_env(self) -> None:
+        with mock.patch.dict(os.environ, {"MY_VAULT": str(self.vault)}):
+            status, _ = checker.check_obsidian({"vault_path": "${MY_VAULT}"})
+        self.assertEqual(status, "PASS")
+
+    def test_real_chmod_zero_directory_is_caught(self) -> None:
+        """Belt and braces: the mocked os.access tests above, done for real.
+
+        Skipped for root, which bypasses permission bits entirely.
+        """
+        if os.geteuid() == 0:
+            self.skipTest("running as root - permission bits do not apply")
+        locked = Path(self._tmp.name) / "locked"
+        locked.mkdir()
+        os.chmod(locked, 0o000)
+        self.addCleanup(os.chmod, locked, stat.S_IRWXU)
+        status, msg = checker.check_obsidian({"vault_path": str(locked)})
+        self.assertEqual(status, "FAIL")
+        self.assertIn("not readable", msg)
+
+
+class SiyuanCheckTest(unittest.TestCase):
+    def test_no_token_skips(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            status, msg = checker.check_siyuan({})
+        self.assertEqual(status, "SKIP")
+        self.assertIn("SIYUAN_TOKEN not set", msg)
+
+    def test_reachable_kernel_passes(self) -> None:
+        with mock.patch.object(checker, "urllib") as urllib_mod:
+            resp = mock.MagicMock()
+            resp.read.return_value = b'{"code":0,"msg":"","data":"3.1.10"}'
+            urllib_mod.request.urlopen.return_value.__enter__.return_value = resp
+            status, msg = checker.check_siyuan({"token": "t", "base_url": "http://k:6806"})
+        self.assertEqual(status, "PASS")
+        self.assertIn("3.1.10", msg)
+
+    def test_bad_token_fails_rather_than_passing_on_a_200(self) -> None:
+        """SiYuan answers a wrong token with HTTP 200 and code -1.
+
+        A TCP-connect or status-code check would call this healthy. It is not:
+        every real call comes back "Auth failed [session]".
+        """
+        with mock.patch.object(checker, "urllib") as urllib_mod:
+            resp = mock.MagicMock()
+            resp.read.return_value = b'{"code":-1,"msg":"Auth failed [session]"}'
+            urllib_mod.request.urlopen.return_value.__enter__.return_value = resp
+            status, msg = checker.check_siyuan({"token": "wrong"})
+        self.assertEqual(status, "FAIL")
+        self.assertIn("Auth failed", msg)
+
+    def test_unreachable_kernel_fails(self) -> None:
+        with mock.patch.object(checker.urllib.request, "urlopen",
+                               side_effect=OSError("connection refused")):
+            status, msg = checker.check_siyuan({"token": "t"})
+        self.assertEqual(status, "FAIL")
+        self.assertIn("unreachable", msg)
+
+    def test_token_falls_back_to_env(self) -> None:
+        with mock.patch.dict(os.environ, {"SIYUAN_TOKEN": "from-env"}, clear=True), \
+             mock.patch.object(checker.urllib.request, "urlopen",
+                               side_effect=OSError("refused")):
+            status, _ = checker.check_siyuan({})
+        self.assertEqual(status, "FAIL")  # reached the call, so the token resolved
+
+
+class NotionCheckTest(unittest.TestCase):
+    def test_no_token_skips(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            status, msg = checker.check_notion({})
+        self.assertEqual(status, "SKIP")
+        self.assertIn("NOTION_API_TOKEN not set", msg)
+
+    def test_reachable_api_passes(self) -> None:
+        with mock.patch.object(checker, "urllib") as urllib_mod:
+            resp = mock.MagicMock()
+            resp.read.return_value = b'{"id":"bot-123","type":"bot"}'
+            urllib_mod.request.urlopen.return_value.__enter__.return_value = resp
+            status, msg = checker.check_notion({"token": "secret_x"})
+        self.assertEqual(status, "PASS")
+        self.assertIn("bot-123", msg)
+
+    def test_failed_call_fails(self) -> None:
+        with mock.patch.object(checker.urllib.request, "urlopen",
+                               side_effect=OSError("401")):
+            status, msg = checker.check_notion({"token": "bad"})
+        self.assertEqual(status, "FAIL")
+
+
+class DispatchTest(unittest.TestCase):
+    def _run_main(self, sb_config: dict) -> tuple[str, str]:
+        with mock.patch.object(checker, "load_second_brain_config", return_value=sb_config), \
+             mock.patch("builtins.print") as printer:
+            checker.main()
+        line = printer.call_args[0][0]
+        status, _, msg = line.partition("|")
+        return status, msg
+
+    def test_each_backend_routes_to_its_own_check(self) -> None:
+        for backend in ("siyuan", "notion", "obsidian"):
+            with self.subTest(backend=backend), \
+                 mock.patch.dict(checker.CHECKS,
+                                 {backend: lambda _c: ("PASS", f"ran {backend}")}):
+                status, msg = self._run_main({"backend": backend})
+            self.assertEqual(status, "PASS")
+            self.assertEqual(msg, f"ran {backend}")
+
+    def test_missing_backend_skips(self) -> None:
+        status, msg = self._run_main({})
+        self.assertEqual(status, "SKIP")
+        self.assertIn("second_brain.backend not set", msg)
+
+    def test_unknown_backend_skips_rather_than_failing(self) -> None:
+        # A chassis install is allowed to run without a second brain.
+        status, msg = self._run_main({"backend": "roam"})
+        self.assertEqual(status, "SKIP")
+        self.assertIn("roam", msg)
+
+    def test_output_is_one_parseable_line(self) -> None:
+        with mock.patch.object(checker, "load_second_brain_config", return_value={}), \
+             mock.patch("builtins.print") as printer:
+            rc = checker.main()
+        self.assertEqual(rc, 0)  # always exit 0 - the caller grades the status
+        printer.assert_called_once()
+        self.assertEqual(printer.call_args[0][0].count("|"), 1)
+
+    def test_unreadable_config_skips(self) -> None:
+        with mock.patch("chassis.second_brain.factory._load_config",
+                        side_effect=FileNotFoundError("gone")):
+            self.assertEqual(checker.load_second_brain_config(), {})
+
+
+class SmokeTestWiringTest(unittest.TestCase):
+    """The check name has to match what chassis.config.yaml grades on."""
+
+    def test_smoke_test_records_second_brain_read_not_notion_read(self) -> None:
+        smoke = (REPO_ROOT / "chassis" / "scripts" / "smoke-test.sh").read_text()
+        self.assertIn("record SKIP second_brain_read", smoke)
+        # Match `record` CALLS, not raw substrings - the comment above the check
+        # names the old `notion_read` on purpose, to explain what changed.
+        recorded = {
+            line.split()[2]
+            for line in smoke.splitlines()
+            if line.strip().startswith("record ") and len(line.split()) > 2
+        }
+        self.assertIn("second_brain_read", recorded)
+        self.assertNotIn("notion_read", recorded)
+
+    def test_config_success_criterion_names_a_check_that_is_recorded(self) -> None:
+        config = (REPO_ROOT / "chassis.config.yaml").read_text()
+        self.assertIn("second_brain_read", config)
+        smoke = (REPO_ROOT / "chassis" / "scripts" / "smoke-test.sh").read_text()
+        self.assertIn("second_brain_read", smoke)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/chassis/second_brain/tests/test_daily_log_gather_backends.py
+++ b/chassis/second_brain/tests/test_daily_log_gather_backends.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""test_daily_log_gather_backends.py - daily-log-gather.py routes per backend.
+
+The bug this locks down: daily-log-gather.py talked to SiYuan and only SiYuan,
+so on an Obsidian or Notion install the second-brain section of the daily log
+was silently empty. It now dispatches on `second_brain.backend`.
+
+Two properties matter and they pull in opposite directions, so both are tested
+explicitly rather than one being assumed from the other:
+
+  1. SiYuan installs must be UNCHANGED. The legacy direct-HTTP `gather_siyuan`
+     still runs, and `gather_via_adapter` is never called. Every live install
+     runs SiYuan; a "refactor" that quietly moved them onto the adapter's
+     slightly different query would be a regression dressed as a cleanup.
+  2. Obsidian and Notion installs must actually reach their backend, through
+     `get_adapter().notes.list_recent()`.
+
+Plus the failure modes, because a gather script that raises takes the whole
+heartbeat down: an unresolvable config falls back to SiYuan (what every install
+predating the adapter runs), and an adapter that cannot be built or whose call
+raises degrades to a warning.
+
+Run:
+    python3 -m pytest chassis/second_brain/tests/test_daily_log_gather_backends.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from chassis.second_brain.base import SearchHit  # noqa: E402
+
+GATHER_PATH = REPO_ROOT / "chassis" / "scripts" / "daily-log-gather.py"
+_spec = importlib.util.spec_from_file_location("daily_log_gather", GATHER_PATH)
+gather = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gather)
+
+SINCE = datetime(2026, 7, 18, tzinfo=timezone.utc)
+UNTIL = datetime(2026, 7, 19, tzinfo=timezone.utc)
+
+
+def _config(backend: str | None) -> dict:
+    return {"second_brain": {"backend": backend}} if backend else {}
+
+
+class ResolveBackendTest(unittest.TestCase):
+    def test_reads_backend_from_config(self) -> None:
+        for backend in ("siyuan", "notion", "obsidian"):
+            with self.subTest(backend=backend), \
+                 mock.patch("chassis.second_brain.factory._load_config",
+                            return_value=_config(backend)):
+                self.assertEqual(gather.resolve_second_brain_backend(), backend)
+
+    def test_backend_is_normalized(self) -> None:
+        with mock.patch("chassis.second_brain.factory._load_config",
+                        return_value={"second_brain": {"backend": "  Obsidian "}}):
+            self.assertEqual(gather.resolve_second_brain_backend(), "obsidian")
+
+    def test_missing_config_falls_back_to_siyuan(self) -> None:
+        # The compatibility guarantee: no config must not mean "no scan".
+        with mock.patch("chassis.second_brain.factory._load_config",
+                        side_effect=FileNotFoundError("no chassis.config.yaml")):
+            self.assertEqual(gather.resolve_second_brain_backend(), "siyuan")
+
+    def test_malformed_config_falls_back_to_siyuan(self) -> None:
+        with mock.patch("chassis.second_brain.factory._load_config",
+                        side_effect=ValueError("garbage")):
+            self.assertEqual(gather.resolve_second_brain_backend(), "siyuan")
+
+    def test_config_without_second_brain_block_falls_back_to_siyuan(self) -> None:
+        with mock.patch("chassis.second_brain.factory._load_config", return_value={}):
+            self.assertEqual(gather.resolve_second_brain_backend(), "siyuan")
+
+
+class HitMappingTest(unittest.TestCase):
+    """Every backend fills the same five keys the SiYuan path publishes."""
+
+    def test_siyuan_shaped_raw(self) -> None:
+        hit = SearchHit(
+            id="20260718120000-abc1234",
+            title="Daily Log",
+            snippet="body text",
+            deeplink="siyuan://blocks/20260718120000-abc1234",
+            raw={"hpath": "/Daily Logs/2026-07-18", "body_len": 412,
+                 "updated": "20260718120000"},
+        )
+        item = gather.hit_to_activity(hit, "siyuan")
+        self.assertEqual(item["hpath"], "/Daily Logs/2026-07-18")
+        self.assertEqual(item["len"], 412)
+        self.assertEqual(item["updated_at"], "20260718120000")
+        self.assertEqual(item["backend"], "siyuan")
+
+    def test_obsidian_uses_id_as_path_and_size_as_len(self) -> None:
+        hit = SearchHit(
+            id="Daily Logs/2026-07-18.md",
+            title="2026-07-18",
+            snippet="# Daily Log",
+            deeplink="obsidian://open?vault=v&file=Daily%20Logs/2026-07-18.md",
+            raw={"path": "/vault/Daily Logs/2026-07-18.md", "mtime": 1752800000.0,
+                 "size_bytes": 981},
+        )
+        item = gather.hit_to_activity(hit, "obsidian")
+        self.assertEqual(item["hpath"], "Daily Logs/2026-07-18.md")
+        self.assertEqual(item["len"], 981)
+        self.assertEqual(item["updated_at"], "1752800000.0")
+
+    def test_notion_falls_back_to_title_and_snippet_length(self) -> None:
+        # Notion's search API returns neither a path nor a size.
+        hit = SearchHit(
+            id="1234abcd-5678-90ef-1234-567890abcdef",
+            title="Daily Log 2026-07-18",
+            snippet="",
+            deeplink="https://www.notion.so/1234abcd567890ef1234567890abcdef",
+            raw={"last_edited_time": "2026-07-18T12:00:00.000Z"},
+        )
+        item = gather.hit_to_activity(hit, "notion")
+        self.assertEqual(item["hpath"], "Daily Log 2026-07-18")
+        self.assertEqual(item["len"], 0)
+        self.assertEqual(item["updated_at"], "2026-07-18T12:00:00.000Z")
+
+    def test_unrecognized_raw_shape_still_produces_a_row(self) -> None:
+        hit = SearchHit(id="x", title="T", snippet="s", deeplink="d", raw=None)
+        item = gather.hit_to_activity(hit, "notion")
+        self.assertEqual(item["id"], "x")
+        self.assertEqual(item["updated_at"], "")
+
+
+class AdapterGatherTest(unittest.TestCase):
+    def _adapter_returning(self, hits: list[SearchHit]) -> mock.Mock:
+        adapter = mock.Mock()
+        adapter.notes.list_recent.return_value = hits
+        return adapter
+
+    def test_obsidian_hits_are_mapped(self) -> None:
+        hit = SearchHit(id="a.md", title="a", snippet="body", deeplink="obsidian://a",
+                        raw={"size_bytes": 300, "mtime": 1.0})
+        adapter = self._adapter_returning([hit])
+        with mock.patch("chassis.second_brain.factory.get_adapter", return_value=adapter):
+            activity, warnings = gather.gather_via_adapter(
+                "obsidian", SINCE, UNTIL, verbose=False
+            )
+        self.assertEqual(warnings, [])
+        self.assertEqual(len(activity), 1)
+        self.assertEqual(activity[0]["backend"], "obsidian")
+
+    def test_list_recent_gets_naive_local_datetimes(self) -> None:
+        """Aware UTC datetimes would shift the window by the host's offset.
+
+        Obsidian compares against st_mtime and SiYuan against a kernel-local
+        clock string; both document naive input as local time.
+        """
+        adapter = self._adapter_returning([])
+        with mock.patch("chassis.second_brain.factory.get_adapter", return_value=adapter):
+            gather.gather_via_adapter("obsidian", SINCE, UNTIL, verbose=False)
+        kwargs = adapter.notes.list_recent.call_args.kwargs
+        self.assertIsNone(kwargs["since"].tzinfo)
+        self.assertIsNone(kwargs["until"].tzinfo)
+        self.assertEqual(kwargs["min_content_len"], gather.DEFAULT_SIYUAN_MIN_CONTENT_LEN)
+        self.assertEqual(kwargs["limit"], gather.DEFAULT_SIYUAN_LIMIT)
+
+    def test_unbuildable_adapter_warns_instead_of_raising(self) -> None:
+        # get_adapter raises ValueError on an empty/placeholder credential.
+        with mock.patch("chassis.second_brain.factory.get_adapter",
+                        side_effect=ValueError("Notion adapter has no API token")):
+            activity, warnings = gather.gather_via_adapter(
+                "notion", SINCE, UNTIL, verbose=False
+            )
+        self.assertEqual(activity, [])
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("could not be built", warnings[0])
+
+    def test_failing_list_recent_warns_instead_of_raising(self) -> None:
+        adapter = mock.Mock()
+        adapter.notes.list_recent.side_effect = RuntimeError("vault vanished")
+        with mock.patch("chassis.second_brain.factory.get_adapter", return_value=adapter):
+            activity, warnings = gather.gather_via_adapter(
+                "obsidian", SINCE, UNTIL, verbose=False
+            )
+        self.assertEqual(activity, [])
+        self.assertIn("list_recent failed", warnings[0])
+
+
+class BuildOutputDispatchTest(unittest.TestCase):
+    """The whole point: which code path runs for which backend."""
+
+    def _build(self, backend: str, env: dict[str, str]) -> dict:
+        with mock.patch.object(gather, "resolve_second_brain_backend", return_value=backend), \
+             mock.patch.object(gather, "gather_github", return_value=({}, [], [])), \
+             mock.patch.object(gather, "gather_gmail", return_value=([], False, [])), \
+             mock.patch.object(gather, "gather_discord_postmortems", return_value=([], [])), \
+             mock.patch.object(gather, "gather_metrics", return_value={}), \
+             mock.patch.dict("os.environ", env, clear=True):
+            return gather.build_output(now=UNTIL, verbose=False)
+
+    def test_siyuan_uses_the_legacy_direct_http_path(self) -> None:
+        legacy_rows = [{"id": "20260718-a", "hpath": "/x", "len": 400,
+                        "updated_at": "20260718120000", "excerpt": ""}]
+        with mock.patch.object(gather, "gather_siyuan",
+                               return_value=(legacy_rows, [])) as legacy, \
+             mock.patch.object(gather, "gather_via_adapter") as adapter_path:
+            payload = self._build("siyuan", {"SIYUAN_URL": "http://127.0.0.1:6806",
+                                             "SIYUAN_TOKEN": "t"})
+        legacy.assert_called_once()
+        adapter_path.assert_not_called()
+        self.assertEqual(payload["second_brain_backend"], "siyuan")
+        self.assertEqual(payload["siyuan_activity"], legacy_rows)
+
+    def test_siyuan_without_url_still_warns_exactly_as_before(self) -> None:
+        with mock.patch.object(gather, "gather_siyuan") as legacy, \
+             mock.patch.object(gather, "gather_via_adapter") as adapter_path:
+            payload = self._build("siyuan", {})
+        legacy.assert_not_called()
+        adapter_path.assert_not_called()
+        self.assertIn(
+            "DAILY_LOG_SIYUAN_URL / SIYUAN_URL unset - skipped SiYuan scan",
+            payload["warnings"],
+        )
+
+    def test_obsidian_uses_the_adapter_path(self) -> None:
+        rows = [{"id": "a.md", "hpath": "a.md", "len": 300,
+                 "updated_at": "1.0", "excerpt": "", "backend": "obsidian"}]
+        with mock.patch.object(gather, "gather_siyuan") as legacy, \
+             mock.patch.object(gather, "gather_via_adapter",
+                               return_value=(rows, [])) as adapter_path:
+            payload = self._build("obsidian", {})
+        legacy.assert_not_called()
+        adapter_path.assert_called_once()
+        self.assertEqual(payload["second_brain_backend"], "obsidian")
+        self.assertEqual(payload["second_brain_activity"], rows)
+
+    def test_notion_uses_the_adapter_path(self) -> None:
+        with mock.patch.object(gather, "gather_siyuan") as legacy, \
+             mock.patch.object(gather, "gather_via_adapter",
+                               return_value=([], [])) as adapter_path:
+            payload = self._build("notion", {})
+        legacy.assert_not_called()
+        adapter_path.assert_called_once()
+        self.assertEqual(payload["second_brain_backend"], "notion")
+
+    def test_siyuan_activity_alias_mirrors_the_canonical_key(self) -> None:
+        """Existing installs read `siyuan_activity` from a prompt on disk."""
+        rows = [{"id": "a.md", "hpath": "a.md", "len": 300,
+                 "updated_at": "1.0", "excerpt": "", "backend": "obsidian"}]
+        with mock.patch.object(gather, "gather_via_adapter", return_value=(rows, [])):
+            payload = self._build("obsidian", {})
+        self.assertEqual(payload["siyuan_activity"], payload["second_brain_activity"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/pacman-queue-storage.md
+++ b/docs/pacman-queue-storage.md
@@ -1,0 +1,316 @@
+# Pacman queue storage - design proposal
+
+**Status:** proposal, not ratified. Nothing in this document is implemented.
+**Author:** Jax, 2026-07-19
+**Decision owner:** Sean
+**Context:** Stage 2 of the second-brain adapter work. PR #58 listed "Pacman
+queue to Postgres" as a Stage 2 item; it is the largest piece and it is an
+architecture change rather than a wiring change, so it is written up here
+instead of being built.
+
+The other four Stage 2 items shipped in the same PR as this document. This one
+needs a decision first.
+
+---
+
+## 1. The problem in one paragraph
+
+Pacman stores its work queue as SiYuan blocks, and uses SiYuan block IDs as
+queue-entry handles. SiYuan is one of three supported second brains. On a
+Notion or Obsidian install - and on ANY install running
+`second_brain.mode: adapter`, where the native `mcp__siyuan__*` tools are
+deliberately not registered - the queue cannot be read, written, or drained.
+Pacman is a chassis-core capability, not a plugin, so "it only works on one
+backend" is a defect rather than a limitation.
+
+---
+
+## 2. What the queue actually stores, and what it needs
+
+Reconstructed from the four implementations, not from the docs:
+
+| Script | Operation |
+|---|---|
+| `pacman-queue-add.py` | enqueue: POST an `h2` block containing the URL under `PACMAN_SIYUAN_QUEUE_BLOCK_ID` |
+| `gather-pacman-queue.sh` | depth: `SELECT COUNT(*)` of child blocks whose content matches `%http%` |
+| `pacman-drain-prompt.md` | dequeue: oldest-first (`created ASC`), capped at `PACMAN_MAX_BATCH_URLS` |
+| `pacman.sh` / `skills/pacman.md` | delete after processing; write proposal doc; write drop record |
+| `pacman-process-reactions.py` | enqueue from a Telegram reaction, via `pacman-queue-add.py` |
+
+The functional requirements are modest, and that matters for the choice below:
+
+1. **Append** a URL with a source tag (`telegram-react`, `discord`, `manual`, `heartbeat-drain`).
+2. **Count** pending entries cheaply. This runs every 15 minutes on the
+   dispatcher tick and must stay free - it is the gate that decides whether to
+   spend Claude tokens at all.
+3. **Read oldest N**, FIFO, capped.
+4. **Delete** an entry after processing, exactly once. The skill calls this
+   non-negotiable: an entry that survives processing gets re-processed forever.
+5. Tolerate **several URLs per entry** (one pasted message can carry many); the
+   entry is deleted only once every URL in it is done.
+6. Survive a container restart. The queue is the only record that a URL was
+   ever submitted.
+
+What it explicitly does **not** need: full-text search, hierarchy, rich text,
+human browsability, or concurrent writers. One producer, one consumer.
+
+That last point is the crux. **The queue is not notes.** It was only ever
+stored in the second brain because the second brain was the thing that was
+there. Making it backend-neutral by pushing it through the notes adapter would
+carry the coupling forward into a new abstraction.
+
+---
+
+## 3. Why block IDs do not port
+
+A SiYuan block ID (`20260718120000-abc1234`) is doing four jobs at once:
+
+1. **Primary key** for the entry.
+2. **Creation timestamp**, encoded in the first 14 characters. This is what
+   makes `ORDER BY created ASC` free, and it is why FIFO ordering needs no
+   extra column.
+3. **Deletion handle** - `delete_block(id)` is the dequeue.
+4. **User-facing approval token.** `chassis/skills/pacman.md` line 161 matches
+   installer replies against `^(approve|reject|defer)\s+(\d{14}-\w{7})...$`.
+
+Neither of the other backends provides anything with those properties:
+
+- **Notion** page ids are 32-char UUIDv4. No embedded timestamp, so ordering
+  needs a real property. There is no sub-page-level addressable unit at all -
+  a queue of URLs would have to become a database of rows, at which point it is
+  a database and not notes.
+- **Obsidian** ids are vault-relative file paths. Ordering is filesystem mtime,
+  which `docs/second-brain-adapters.md` already documents as unreliable: a git
+  pull or an iCloud resync rewrites mtime and would silently reorder the queue.
+  Deleting an entry means deleting a file, and a sync conflict resurrects it.
+
+Item 4 is the one that is easy to miss and expensive to get wrong. Even if the
+queue moved to Postgres tomorrow, **the approval regex is independently
+SiYuan-shaped** and would still reject a Notion or Obsidian proposal id. Any
+queue migration must change that regex in the same pass, or approvals break on
+exactly the installs the migration was meant to serve. See "Out of scope but
+coupled" below.
+
+---
+
+## 4. Options
+
+### Option A - Postgres (`chassis_pacman_queue` table)
+
+Add a `chassis/db/migrations/` table alongside the existing plugin migrations.
+
+**For:**
+- Already present and already required. `docker-compose.yml` boots Postgres
+  before chassis with `condition: service_healthy`, so the queue cannot be read
+  before the DB is up. `psycopg[binary]==3.2.3` is already in
+  `requirements.txt` and baked into the image.
+- **Backed up for free.** `chassis/scripts/pg-backup.sh` already runs a nightly
+  `pg_dump` with GFS retention and S3 upload. A queue in Postgres inherits a
+  tested backup and restore path on day one. Neither alternative below gets
+  this without new work, and an unbacked-up queue loses in-flight URLs on any
+  disk event.
+- Genuinely backend-neutral: identical behavior on all three second brains, and
+  on an install with no second brain at all.
+- FIFO, atomic dequeue, and cheap counts are what the tool is for.
+  `SELECT ... FOR UPDATE SKIP LOCKED` makes the dequeue safe if drains ever
+  overlap, which the current design cannot express at all.
+- Precedent exists: `plugins/dating/db/migrations/001_dating_state.sql` moved
+  file-backed state into Postgres for the same reason.
+
+**Against:**
+- **Chassis core has no DB module yet.** This is the real cost and it should
+  not be waved past. `plugins/dating/scripts/_chassis_db.py` says so in its own
+  docstring: "Chassis V1 has no shared DB abstraction yet - each plugin that
+  touches a DB carries its own selector until the chassis grows one." Pacman is
+  core, not a plugin. Doing this properly means promoting a `chassis-db` module
+  to core, which is a bigger change than the queue itself and drags the
+  migration-runner question (who applies `chassis/db/migrations/*.sql`, and
+  when?) into scope.
+- Adds a hard Postgres dependency to a core capability. Today an install with a
+  broken Postgres still drains Pacman.
+- The queue becomes invisible to the installer. Today Sean can open
+  `/To Investigate` and see what is pending. That is a real feature being
+  traded away, and it should be replaced by a Discord `pacman queue` command
+  rather than silently dropped.
+
+### Option B - SQLite (`$CUSTOMER_HOME/data/pacman-queue.db`)
+
+**For:**
+- Zero new infrastructure; `sqlite3` is in the Python stdlib. No dependency on
+  the Postgres container being healthy.
+- Same ordering and atomic-delete guarantees as Postgres for a single-writer
+  workload, which this is.
+- A file in the bind-mounted customer-state directory is trivially portable
+  between hosts.
+
+**Against:**
+- **Splits the state story.** The chassis already decided Postgres is canonical
+  ("Sean's 'Postgres from start' call", `docker-compose.yml` line 9). Adding a
+  second durable store for one feature means two backup paths, two restore
+  procedures, and a standing question of which store new features use.
+- Not covered by `pg-backup.sh`. Needs its own backup wiring, or it is a silent
+  data-loss hole on restore.
+- SQLite over a bind mount is a known-bad combination if the mount is ever
+  network-backed. Fine on the Mac Mini today; a foot-gun on a future install.
+
+### Option C - File-backed JSONL directory
+
+One append-only `queue.jsonl`, or one file per entry under
+`$CUSTOMER_HOME/state/pacman-queue/`.
+
+**For:**
+- Simplest thing that works. Inspectable with `cat`. No dependency at all.
+- Matches the existing gather-script contract - several already read and write
+  JSON state files.
+
+**Against:**
+- Deletion is the whole problem. Append-only JSONL means dequeue is a
+  rewrite-the-file operation, which is not atomic against a concurrent append
+  and will eventually lose a URL. One-file-per-entry fixes deletion but
+  reintroduces exactly the mtime-ordering fragility that disqualifies Obsidian
+  in section 3.
+- Requirement 4 (delete exactly once) is the one the skill calls
+  non-negotiable, and this is the option least able to guarantee it.
+
+### Option D - Keep it in the second brain, via the notes adapter
+
+Store the queue as notes and reach it through `get_adapter().notes`.
+
+**For:**
+- No new storage. Preserves installer visibility of the queue.
+
+**Against:**
+- The adapter has no delete operation, and adding one to `NotesAdapter` for the
+  sake of a queue is the tail wagging the dog.
+- Ordering would rest on Obsidian mtime, which section 3 already rules out.
+- It encodes "a work queue is a kind of note", which is the original mistake.
+  Rejected.
+
+---
+
+## 5. Recommendation
+
+**Option A, Postgres** - with one explicit condition attached.
+
+The reasoning is not primarily "Postgres is already there", because SQLite is
+equally already there. It is:
+
+1. **Backups.** `pg-backup.sh` exists, runs nightly, uploads to S3, and has a
+   documented restore path. The queue holds URLs that exist nowhere else once
+   the source Discord or Telegram message scrolls away. Option B and Option C
+   both need new backup wiring to reach parity, and both will get it later
+   rather than sooner.
+2. **One durable store.** The chassis already made this call. Two stores is a
+   decision that pays interest forever.
+3. **The workload is exactly relational** - ordered, transactional, deleted
+   once. Requirement 4 is free in Postgres and hard-won in Option C.
+
+The condition: **do not ship a per-feature DB selector.** The honest cost of
+Option A is that chassis core needs a `chassis-db` module first - the one the
+dating plugin's docstring already says is missing. Building Pacman's queue on a
+copy-pasted `_chassis_db.py` would make three copies of that file and guarantee
+they drift. Sequence it as:
+
+- **A1.** Promote a `chassis/db/` module to core: connection helper, migration
+  runner, `chassis/db/migrations/`. Small, and unblocks more than Pacman.
+- **A2.** Add `001_pacman_queue.sql` and port the four scripts.
+- **A3.** Fix the approval regex (section 6) in the same PR as A2, not later.
+
+If Sean wants Pacman portable before committing to A1, **Option B is the
+correct interim** - SQLite behind a narrow `pacman_queue.py` interface with the
+storage backend as an implementation detail, so A2 becomes a swap of one module
+rather than a rewrite of four scripts. That is a deliberate two-step, not
+indecision, and it is worth taking only if the portability is needed sooner
+than the DB module.
+
+Sketch, for concreteness:
+
+```sql
+CREATE TABLE IF NOT EXISTS chassis_pacman_queue (
+    id            BIGSERIAL PRIMARY KEY,
+    url           TEXT        NOT NULL,
+    source        TEXT        NOT NULL DEFAULT 'manual',
+    source_ref    TEXT,                    -- discord/telegram message id, for audit
+    entry_group   UUID,                    -- URLs pasted in one message share this;
+                                           -- requirement 5 (delete once all are done)
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    claimed_at    TIMESTAMPTZ,             -- set at dequeue; a crashed drain is
+                                           -- visible as a stale claim rather than
+                                           -- a silently vanished URL
+    processed_at  TIMESTAMPTZ,
+    verdict       TEXT,                    -- drop | proposal | fetch_failed
+    gate          SMALLINT,
+    proposal_doc_id TEXT                   -- opaque adapter id, NOT a block id
+);
+
+CREATE INDEX IF NOT EXISTS ix_pacman_queue_pending
+    ON chassis_pacman_queue (created_at) WHERE processed_at IS NULL;
+```
+
+Two notes on that shape. `claimed_at` exists because the current design has no
+way to distinguish "being processed" from "pending", so a drain that dies
+mid-batch either loses URLs or reprocesses them. `proposal_doc_id` is TEXT and
+explicitly opaque - it holds whatever `mcp__secondbrain__create_doc` returned,
+which is a block id, a UUID, or a path depending on the install.
+
+---
+
+## 6. Out of scope but coupled - the approval regex
+
+`chassis/skills/pacman.md` matches approvals against
+`^(approve|reject|defer)\s+(\d{14}-\w{7})(?:\s+(.+))?$`. That pattern is a
+SiYuan block ID and nothing else. A Notion UUID and an Obsidian path both fail
+it.
+
+This is independent of where the queue lives, and it will not be caught by
+testing the queue migration. Whichever option is chosen, the same PR must
+either widen the token to `(\S+)` and validate against stored proposal ids, or
+issue short opaque approval tokens (`approve a7f3`) mapped to
+`proposal_doc_id` - the second is better, because a Notion UUID is unpleasant
+to retype on a phone and Sean approves from his phone.
+
+---
+
+## 7. Migration path for the live queue
+
+Nothing in flight may be lost. Sean's install is the only one with a populated
+queue, so this runs once.
+
+1. **Freeze.** `touch $CHASSIS_HOME/PACMAN_HARD_PAUSE`. Both
+   `gather-pacman-queue.sh` and `pacman.sh` already honor this and exit 0
+   without touching the queue - the mechanism exists and needs no new code.
+2. **Snapshot.** Dump the queue to a file before touching anything:
+   `SELECT id, content, created FROM blocks WHERE root_id = '<queue-block-id>' AND content LIKE '%http%' ORDER BY created ASC`
+   Keep the JSON. It is the rollback.
+3. **Backfill.** Insert one row per extracted URL, preserving order:
+   `created_at` from the block ID's leading 14 digits (a lossless conversion -
+   this is the one time the encoded timestamp is useful), `source` =
+   `'siyuan-migration'`, `entry_group` shared across URLs from the same block.
+4. **Verify before deleting anything.** Row count must equal the URL count from
+   step 2, and the oldest and newest three rows must match by URL. The failure
+   this guards against is a block containing two URLs being counted as one
+   entry.
+5. **Drain once, in dry-run**, and diff the batch it selects against what the
+   SiYuan queue would have selected. Same URLs, same order, or stop.
+6. **Cut over** the four scripts. Leave the SiYuan `/To Investigate` blocks in
+   place - do not delete them in the same step. Disk is cheap; an unrecoverable
+   queue is not.
+7. **Unfreeze.** Remove `PACMAN_HARD_PAUSE`, watch one real drain end to end.
+8. **Clean up** the SiYuan blocks only after a full drain cycle has run clean,
+   and only once `PACMAN_SIYUAN_QUEUE_BLOCK_ID` is gone from every script.
+
+Rollback at any point before step 8: re-set the pause flag, revert the scripts,
+delete the Postgres rows. The SiYuan queue is still intact because step 6 did
+not touch it.
+
+---
+
+## 8. Decisions needed from Sean
+
+1. Option A (Postgres) or Option B (SQLite interim)? The recommendation is A,
+   sequenced behind a core `chassis/db/` module.
+2. Is promoting `chassis-db` to core in scope now, or does Pacman wait for it?
+3. Replace the lost installer visibility with a Discord `pacman queue` command,
+   or accept that the queue becomes opaque?
+4. Approval tokens: widen the regex, or issue short opaque tokens? (Short
+   tokens recommended - phone ergonomics.)


### PR DESCRIPTION
Delivers the Stage 2 work PR #58 committed to and never opened a PR for: *"Pacman queue to Postgres, `daily-log-gather.py` adapter branch, prompt rewrites, smoke-test backend dispatch"*.

## The gap this closes

The adapter (`chassis/second_brain/`) supports SiYuan, Obsidian and Notion behind a common `NotesAdapter`, and `get_adapter()` resolves the right one. But a repo-wide grep for `get_adapter` returned hits only in the package's own modules, its tests, `mcp_server.py`, and docs, while 12 chassis scripts talked to SiYuan directly and hardcoded.

Net effect: an Obsidian or Notion install got a working `secondbrain` MCP surface for ad-hoc Claude calls, and every scheduled workflow silently assumed SiYuan and no-opped.

Everything here is a no-op for SiYuan installs. That is enforced, not asserted - see "How the SiYuan path was proven unchanged".

---

## 1. `daily-log-gather.py` on `get_adapter()`

Dispatches on `second_brain.backend`:

- **siyuan** - the original direct-HTTP `gather_siyuan`, unchanged. Deliberate: every live install runs SiYuan, and the adapter's `list_recent` is close to but not identical to this query. Routing SiYuan through the adapter would be a silent behavior change on every live install to buy nothing.
- **obsidian / notion** - new `gather_via_adapter`, calling `get_adapter().notes.list_recent()`.
- **unresolvable config** (no file, no PyYAML, import error) - falls back to siyuan, because every install predating the adapter runs it.

Output gains `second_brain_backend` and `second_brain_activity`. `siyuan_activity` is kept as an alias holding the same list: bootstrap copies the daily-log prompt to disk once and never rewrites it, so dropping the key would blank the writing bullet on every existing install the day this ships.

Naive local datetimes are passed to `list_recent`, not the UTC-aware ones the rest of the script uses - Obsidian compares against `st_mtime` and SiYuan against a kernel-local clock, so aware UTC would shift the window by the host offset.

## 2. Smoke-test backend dispatch

New `chassis/scripts/check-second-brain-backend.py`, called by `smoke-test.sh`.

**Also fixes a latent bug:** `chassis.config.yaml` lists `second_brain_read` under `success_criteria.smoke_tests`, but the check recorded itself as `notion_read`. The criterion named a check that never appeared in the output on *any* backend, including Notion.

| Backend | Check |
|---|---|
| obsidian | vault path exists, is a directory, is readable (`R_OK`+`X_OK`), and writability matches declared `read_only` |
| siyuan | `POST /api/system/version` with the token, asserting `code == 0` |
| notion | `GET /v1/users/me` (unchanged) |
| missing / unknown | SKIP - an install may legitimately have no second brain |

SiYuan answers a wrong token with HTTP 200 and `code: -1`, so a TCP-connect or status-code check would call a broken install healthy. Test covers that specifically.

## 3. Backend-neutral prompts

`daily-log-prompt.md.template` moves to `mcp__secondbrain__*`. The post-create verification was a SQL `SELECT` against the SiYuan `blocks` table, which is why it only worked on one backend; it is now `read_doc` on the returned id, plus a pre-write `search` for the duplicate check (which has to move *before* the write to stay portable). The `{{ CUSTOMER_DAILY_LOG_NOTEBOOK_ID }}` + `{{ CUSTOMER_DAILY_LOG_PARENT_ID }}` pair collapses to one `{{ CUSTOMER_DAILY_LOG_PARENT }}`.

`pacman-drain-prompt.md` is **partly** neutral, and says so explicitly rather than pretending. Writes (proposals, drop records) go through `mcp__secondbrain__*`. Queue read/delete stay SiYuan-only because they are block-ID-addressed - pending the design note. On a backend where `mcp__siyuan__sql_query` is unavailable the prompt is now instructed to error out loudly instead of reporting a clean drain of nothing.

## 4. `bootstrap-mcp-config.sh` recovery path

Its sed+jq path stripped `_enable_when` without evaluating it. Measured on this branch, old vs new, same empty-config recovery:

```
before: 19 servers - amplitude, brave-search, context7, frame0, github, gmail,
        google-calendar, google-sheets, loom, memory, n8n, notion, oura,
        playwright, remarkable, secondbrain, siyuan, tavily, turso
after:   4 servers - context7, github, memory, playwright
```

siyuan + notion + secondbrain registered simultaneously, plus the Google entries #57 called out on installs with no OAuth token on disk.

Rather than teach the sed path the predicate grammar, the two conditions that selected it now resolve inside the hydrator, and the shell delegates unconditionally:

- **no PyYAML** - `load_yaml` falls back to `_parse_yaml_minimal`, already shipped and tested in `factory.py`.
- **no config** - renders against `{}`, which drops every `==`-gated server and keeps the ungated core. Fail-closed here means *minimal*, not maximal.

A missing template is still a hard error; there is nothing to render from.

---

## NOT built: the Pacman queue migration

Design proposal at **`docs/pacman-queue-storage.md`** (chose a repo doc over an issue so it versions with the code it describes).

**Recommendation: Postgres**, but on evidence rather than assumption. The deciding argument is not "already present" - SQLite is equally already present. It is that `pg-backup.sh` already runs a nightly `pg_dump` with GFS retention to S3, so the queue inherits a tested backup and restore path on day one. The queue holds URLs that exist nowhere else once the source message scrolls away. SQLite and file-backed both need new backup wiring to reach parity.

The doc covers all four options (Postgres / SQLite / file-backed JSONL / keep-in-second-brain) with the case against each, and attaches an honest condition to the recommendation: **chassis core has no DB module yet.** The dating plugin's own `_chassis_db.py` docstring says so. Pacman is core, not a plugin, so doing this right means promoting a `chassis/db/` module first - a bigger change than the queue. If portability is needed sooner, SQLite behind a narrow interface is the correct interim.

**Finding that falls outside the queue question:** `skills/pacman.md` matches approvals against `^(approve|reject|defer)\s+(\d{14}-\w{7})$`. That is a SiYuan block ID and nothing else - a Notion UUID and an Obsidian path both fail it. It is independent of where the queue lives and will not be caught by testing a queue migration, so any migration PR must fix it in the same pass.

---

## How the SiYuan path was proven unchanged

AST-comparing every top-level function in `daily-log-gather.py` against `main`:

```
siyuan_post                      IDENTICAL
gather_siyuan                    IDENTICAL
gather_github                    IDENTICAL
gather_gmail                     IDENTICAL
gather_metrics                   IDENTICAL
gather_discord_postmortems       IDENTICAL
today_yesterday                  IDENTICAL
added:   gather_via_adapter, hit_to_activity, resolve_second_brain_backend
removed: (none)
```

Only `build_output` changed. Plus a test asserting that on `backend=siyuan` the legacy path is called and `gather_via_adapter` is *not*, and that an unset `SIYUAN_URL` still produces the identical warning string.

## Test plan

- [x] `pytest chassis/second_brain/tests/` - **177 passed** (122 baseline after PR 77, +55 new). No regressions.
- [x] `bash chassis/scripts/test-daily-log-gather.sh` - 6 passed, 0 failed.
- [x] `bash -n` on both modified shell scripts.
- [x] **Live Obsidian vault, end to end.** Real vault at `/tmp/sb-live/vault`, real `chassis.config.yaml`. `daily-log-gather.py` returned the 612-byte note with a correct `obsidian://` deeplink and correctly filtered the 5-byte note below `min_content_len`; `siyuan_activity` alias matched `second_brain_activity`.
- [x] **Live backend-check branches**, real filesystem and sockets: healthy vault → `PASS`; missing vault → `FAIL does not exist`; vault_path pointing at a file → `FAIL not a directory`; `chmod 000` dir → `FAIL not readable`; siyuan no token → `SKIP`; siyuan unreachable port → `FAIL unreachable`; no config → `SKIP`.
- [x] **Live bootstrap recovery**, both paths: no config → 4 core servers; siyuan config → siyuan + brave only. Old script re-run from `main` for the 19-server before-number quoted above.
- [x] Every backend branch added has a test. Grep for a config key without a consumer: none added.
- [x] Diff scanned for credentials - clean. No em dashes in any changed file.

## Constraints honored

- `chassis/VERSION` untouched - bump is a separate PR Sean approves.
- No CHANGELOG entry for an unreleased version; detail is in this body for folding into v0.2.0.
- No files under a vendored `chassis/` subtree in a customer repo were touched; this is the chassis repo itself.

**Do not merge** - for Sean's ratification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
