### PR TITLE
feat(pacman): move the queue to Postgres and genericize the approval id

### DIFF
--- a/chassis/db/__init__.py
+++ b/chassis/db/__init__.py
@@ -1,0 +1,29 @@
+"""chassis.db - Postgres access for chassis-core code.
+
+Small on purpose. Three things: resolve a DSN, open a connection, apply
+migrations. Anything richer belongs in the module that needs it.
+
+See chassis/db/connection.py for the DSN resolution order and the reasoning
+about failure modes, and docs/pacman-queue-storage.md section 5 for why this
+module had to exist before the Pacman queue could move.
+"""
+
+from chassis.db.connection import (
+    DSN_ENV_VARS,
+    ChassisDBUnavailable,
+    connect,
+    get_dsn,
+    is_configured,
+)
+from chassis.db.migrate import MIGRATIONS_DIR, apply_migrations, discover_migrations
+
+__all__ = [
+    "DSN_ENV_VARS",
+    "ChassisDBUnavailable",
+    "MIGRATIONS_DIR",
+    "apply_migrations",
+    "connect",
+    "discover_migrations",
+    "get_dsn",
+    "is_configured",
+]

--- a/chassis/db/connection.py
+++ b/chassis/db/connection.py
@@ -1,0 +1,119 @@
+"""Chassis-core Postgres connection handling.
+
+This is the module `plugins/dating/scripts/_chassis_db.py` says is missing:
+"Chassis V1 has no shared DB abstraction yet - each plugin that touches a DB
+carries its own selector until the chassis grows one." Pacman is chassis-core,
+not a plugin, so it cannot carry a third copy of that selector.
+
+Deliberately NOT an ORM and deliberately not a backend selector. The chassis
+already decided Postgres is canonical (Sean's "Postgres from start" call,
+docker-compose.yml line 9). The dating plugin's selector exists because BFL
+predates that call and still has a SQLite mirror to keep alive; core code has
+no such history and should not inherit the branch.
+
+What this module owns:
+  - DSN resolution, one order, documented below.
+  - A connection helper that turns every reachability failure into one
+    exception type with an actionable message.
+  - Nothing else. Migrations live in chassis/db/migrate.py.
+
+DSN resolution order (first non-empty wins):
+  1. CHASSIS_PG_DSN      - set by docker-compose for the chassis container.
+  2. BEHALFBOT_PG_DSN    - the name the dating plugin's selector reads first,
+                           accepted here so an install that set only that one
+                           does not need a second variable.
+  3. JAX_PG_DSN          - host-side legacy fallback, per the reference
+                           install's docs/jax-db.md. Present so host-run
+                           scripts (migrations, one-off drains) work outside
+                           the container without re-exporting.
+
+Failure mode is the point of this module. A queue that cannot reach Postgres
+must fail loudly: the Pacman queue holds URLs that exist nowhere else once the
+source Discord or Telegram message scrolls out of reach, so "degrade to zero
+results" is data loss wearing a green checkmark. Every path here raises
+ChassisDBUnavailable rather than returning an empty result.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+# Ordered by preference. Kept as a module constant so the error message below
+# and the resolution logic cannot drift apart.
+DSN_ENV_VARS: tuple[str, ...] = ("CHASSIS_PG_DSN", "BEHALFBOT_PG_DSN", "JAX_PG_DSN")
+
+
+class ChassisDBUnavailable(RuntimeError):
+    """Postgres is not configured, not installed, or not reachable.
+
+    One exception type for all three because every caller does the same thing
+    with them: report loudly and stop. Callers that want to distinguish can
+    read `.reason` ('unconfigured' | 'driver_missing' | 'unreachable').
+    """
+
+    def __init__(self, message: str, *, reason: str) -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
+def get_dsn(env: dict[str, str] | None = None) -> str:
+    """Resolve the Postgres DSN, or raise ChassisDBUnavailable."""
+    source = env if env is not None else os.environ
+    for var in DSN_ENV_VARS:
+        value = (source.get(var) or "").strip()
+        if value:
+            return value
+    raise ChassisDBUnavailable(
+        "No Postgres DSN configured. Set one of "
+        + ", ".join(DSN_ENV_VARS)
+        + " (format: postgresql://user:PASSWORD@host:5432/dbname). "
+        "In a container install this is set by docker-compose; if it is empty "
+        "there, check that .env.baked was generated - see docs/credential-bake.md.",
+        reason="unconfigured",
+    )
+
+
+def is_configured(env: dict[str, str] | None = None) -> bool:
+    """True when a DSN is set. Does not open a connection or prove reachability."""
+    try:
+        get_dsn(env)
+    except ChassisDBUnavailable:
+        return False
+    return True
+
+
+def connect(*, dict_rows: bool = False, autocommit: bool = False, dsn: str | None = None) -> Any:
+    """Open a Postgres connection, or raise ChassisDBUnavailable.
+
+    Tuple rows by default to match sqlite3 and the dating plugin's helper, so
+    `row[0]` means the same thing everywhere in this codebase. Pass
+    dict_rows=True where column names carry the meaning.
+    """
+    resolved = dsn or get_dsn()
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - psycopg is baked into the image
+        raise ChassisDBUnavailable(
+            "psycopg is not installed. It is pinned in requirements.txt and baked "
+            "into the chassis image; if you are running on the host, "
+            "pip install 'psycopg[binary]'.",
+            reason="driver_missing",
+        ) from exc
+
+    kwargs: dict[str, Any] = {"autocommit": autocommit}
+    if dict_rows:
+        from psycopg.rows import dict_row
+
+        kwargs["row_factory"] = dict_row
+
+    try:
+        return psycopg.connect(resolved, **kwargs)
+    except Exception as exc:
+        raise ChassisDBUnavailable(
+            f"Could not connect to Postgres: {exc}. "
+            "Check the postgres service is healthy (docker compose ps postgres) "
+            "and that the DSN host resolves from where this is running - the "
+            "container reaches it as 'postgres:5432', the host as 'localhost'.",
+            reason="unreachable",
+        ) from exc

--- a/chassis/db/migrate.py
+++ b/chassis/db/migrate.py
@@ -1,0 +1,128 @@
+"""Chassis-core migration runner.
+
+Applies `chassis/db/migrations/*.sql` in lexical filename order and records
+each in a ledger table so re-running is a no-op. Deliberately the smallest
+thing that is safe:
+
+  - No down-migrations. Rolling back a chassis release rolls back code, not
+    schema; every migration here must be additive or the release is wrong.
+  - No checksums. A migration file that changes after being applied is an
+    operator error the ledger cannot fix, and pretending otherwise invites
+    "just delete the ledger row" as a workaround.
+  - A session-level advisory lock so two containers booting at once cannot
+    both apply 001. The lock id is an arbitrary fixed constant, namespaced to
+    this runner.
+
+Ordering note: files sort lexically, which is why they are numbered with a
+fixed-width prefix (001_, 002_). A file named `10_foo.sql` would sort before
+`2_foo.sql` and apply out of order; the runner rejects filenames that do not
+match the expected prefix rather than silently mis-ordering them.
+
+Usage:
+    python3 -m chassis.db.migrate            # apply pending, print what ran
+    python3 -m chassis.db.migrate --dry-run  # list pending, touch nothing
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from chassis.db.connection import ChassisDBUnavailable, connect
+
+MIGRATIONS_DIR = Path(__file__).resolve().parent / "migrations"
+
+# Arbitrary but fixed. Two chassis containers booting simultaneously serialize
+# on this rather than racing to CREATE TABLE.
+ADVISORY_LOCK_ID = 8_140_251_193
+
+LEDGER_DDL = """
+CREATE TABLE IF NOT EXISTS chassis_schema_migrations (
+    name        TEXT        PRIMARY KEY,
+    applied_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)
+"""
+
+MIGRATION_NAME_RE = re.compile(r"^\d{3}_[a-z0-9_]+\.sql$")
+
+
+def discover_migrations(migrations_dir: Path | None = None) -> list[Path]:
+    """Return migration files in apply order, rejecting mis-numbered names."""
+    directory = migrations_dir or MIGRATIONS_DIR
+    if not directory.is_dir():
+        return []
+    files = sorted(p for p in directory.iterdir() if p.suffix == ".sql")
+    bad = [p.name for p in files if not MIGRATION_NAME_RE.match(p.name)]
+    if bad:
+        raise ValueError(
+            "Migration filenames must match NNN_lower_snake.sql so lexical sort "
+            f"equals apply order. Offending: {', '.join(bad)}"
+        )
+    return files
+
+
+def applied_migrations(conn) -> set[str]:
+    cur = conn.cursor()
+    cur.execute(LEDGER_DDL)
+    cur.execute("SELECT name FROM chassis_schema_migrations")
+    return {row[0] for row in cur.fetchall()}
+
+
+def apply_migrations(conn=None, migrations_dir: Path | None = None, *, dry_run: bool = False) -> list[str]:
+    """Apply pending migrations. Returns the names applied (or pending, if dry_run).
+
+    Passing `conn` is how the tests drive this without a live database; the
+    caller owns the connection's lifetime in that case.
+    """
+    owns_connection = conn is None
+    if owns_connection:
+        conn = connect()
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT pg_advisory_lock(%s)", (ADVISORY_LOCK_ID,))
+        try:
+            done = applied_migrations(conn)
+            pending = [p for p in discover_migrations(migrations_dir) if p.name not in done]
+            if dry_run:
+                return [p.name for p in pending]
+            ran: list[str] = []
+            for path in pending:
+                cur.execute(path.read_text(encoding="utf-8"))
+                cur.execute(
+                    "INSERT INTO chassis_schema_migrations (name) VALUES (%s)",
+                    (path.name,),
+                )
+                conn.commit()
+                ran.append(path.name)
+            return ran
+        finally:
+            cur.execute("SELECT pg_advisory_unlock(%s)", (ADVISORY_LOCK_ID,))
+            conn.commit()
+    finally:
+        if owns_connection:
+            conn.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Apply chassis-core Postgres migrations.")
+    parser.add_argument("--dry-run", action="store_true", help="List pending migrations without applying them.")
+    args = parser.parse_args(argv)
+
+    try:
+        names = apply_migrations(dry_run=args.dry_run)
+    except ChassisDBUnavailable as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if not names:
+        print("chassis migrations: up to date")
+        return 0
+    verb = "pending" if args.dry_run else "applied"
+    print(f"chassis migrations {verb}: {', '.join(names)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/chassis/db/migrations/001_pacman_queue.sql
+++ b/chassis/db/migrations/001_pacman_queue.sql
@@ -1,0 +1,72 @@
+-- 001_pacman_queue.sql - Pacman's work queue, moved out of SiYuan.
+--
+-- Why this table exists: Pacman stored its queue as SiYuan blocks and used
+-- SiYuan block IDs as queue handles. SiYuan is one of three supported second
+-- brains, so Pacman was broken on Notion and Obsidian installs, and broken on
+-- ANY install running second_brain.mode: adapter (where mcp__siyuan__* is
+-- deliberately not registered). PR #78 made that fail loudly; this is the fix.
+-- Full reasoning: docs/pacman-queue-storage.md.
+--
+-- One row per URL, not per submitted message. A pasted message carrying four
+-- URLs becomes four rows sharing an entry_group, because the 4-gate pipeline
+-- runs per URL and each URL gets its own verdict.
+
+CREATE TABLE IF NOT EXISTS chassis_pacman_queue (
+    id               BIGSERIAL   PRIMARY KEY,
+
+    -- Short opaque approval token. This replaces the SiYuan block ID as the
+    -- thing the installer types in Discord ("approve qhtnbz"). Generated at
+    -- enqueue so a row has one stable handle for its whole life. Alphabet is
+    -- vowel-free lowercase letters with no digits - see chassis/pacman/tokens.py
+    -- for why that alphabet and not a UUID.
+    token            TEXT        NOT NULL UNIQUE,
+
+    url              TEXT        NOT NULL,
+
+    -- 'manual' | 'discord' | 'telegram-react-<chat>' | 'heartbeat-drain' |
+    -- 'siyuan-migration'. Free text rather than an enum: sources are added by
+    -- installs, and a CHECK constraint here would mean a migration every time
+    -- someone wires a new intake.
+    source           TEXT        NOT NULL DEFAULT 'manual',
+
+    -- Discord/Telegram message id the URL came from, for audit. Nullable
+    -- because manual CLI submissions have no message behind them.
+    source_ref       TEXT,
+
+    -- URLs submitted together share this. Requirement 5 in the design note:
+    -- an entry is only fully done once every URL in it is done.
+    entry_group      UUID        NOT NULL,
+
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Set at dequeue. A drain that dies mid-batch leaves a stale claim, which
+    -- is visible and reclaimable, rather than a URL that silently vanished.
+    -- The old design could not express "being processed" at all.
+    claimed_at       TIMESTAMPTZ,
+
+    processed_at     TIMESTAMPTZ,
+    verdict          TEXT,       -- drop | proposal | fetch_failed
+    gate             SMALLINT,   -- gate number that dropped it, NULL on proposals
+
+    -- Whatever mcp__secondbrain__create_doc returned: a SiYuan block id, a
+    -- Notion UUID, or an Obsidian vault path depending on the install.
+    -- Deliberately opaque TEXT - core code never parses this.
+    proposal_doc_id  TEXT,
+
+    -- Set only by the one-time SiYuan backfill. Doubles as the idempotency key
+    -- so re-running the migration cannot duplicate rows.
+    legacy_block_id  TEXT
+);
+
+-- The gather script runs this predicate every dispatcher tick and must stay
+-- cheap - it is the gate that decides whether to spend Claude tokens at all.
+CREATE INDEX IF NOT EXISTS ix_pacman_queue_pending
+    ON chassis_pacman_queue (created_at)
+    WHERE processed_at IS NULL;
+
+-- Migration idempotency. A SiYuan block holding two URLs becomes two rows, so
+-- the key is (block, url) and not the block alone. Partial index because rows
+-- created normally have no legacy block and must not collide with each other.
+CREATE UNIQUE INDEX IF NOT EXISTS ux_pacman_queue_legacy_block_url
+    ON chassis_pacman_queue (legacy_block_id, url)
+    WHERE legacy_block_id IS NOT NULL;

--- a/chassis/db/tests/test_connection.py
+++ b/chassis/db/tests/test_connection.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""test_connection.py - DSN resolution and the loud-failure contract.
+
+The property under test is not "it connects" - it is "it never quietly
+degrades". A Pacman queue that returns zero rows because Postgres is
+unreachable is indistinguishable from an empty queue, and the queue is the
+only durable record that a URL was ever submitted. Every failure path here has
+to raise, and the message has to say what to do about it.
+
+Run:
+    python3 -m pytest chassis/db/tests/test_connection.py -v
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from chassis.db.connection import (  # noqa: E402
+    DSN_ENV_VARS,
+    ChassisDBUnavailable,
+    connect,
+    get_dsn,
+    is_configured,
+)
+
+DSN = "postgresql://u:p@postgres:5432/chassis"
+
+
+class TestDsnResolution(unittest.TestCase):
+    def test_prefers_chassis_pg_dsn(self):
+        env = {"CHASSIS_PG_DSN": DSN, "BEHALFBOT_PG_DSN": "postgresql://wrong", "JAX_PG_DSN": "postgresql://wrong"}
+        self.assertEqual(get_dsn(env), DSN)
+
+    def test_falls_back_to_behalfbot_pg_dsn(self):
+        """The name the dating plugin's selector reads first."""
+        self.assertEqual(get_dsn({"BEHALFBOT_PG_DSN": DSN}), DSN)
+
+    def test_falls_back_to_jax_pg_dsn(self):
+        """Host-side legacy fallback, per the reference install's docs/jax-db.md."""
+        self.assertEqual(get_dsn({"JAX_PG_DSN": DSN}), DSN)
+
+    def test_resolution_order_matches_the_documented_constant(self):
+        self.assertEqual(DSN_ENV_VARS, ("CHASSIS_PG_DSN", "BEHALFBOT_PG_DSN", "JAX_PG_DSN"))
+        for index, var in enumerate(DSN_ENV_VARS):
+            env = {v: f"postgresql://{v}" for v in DSN_ENV_VARS[index:]}
+            self.assertEqual(get_dsn(env), f"postgresql://{var}")
+
+    def test_whitespace_only_values_are_treated_as_unset(self):
+        """A trailing-whitespace env var has bitten this stack before."""
+        self.assertEqual(get_dsn({"CHASSIS_PG_DSN": "   ", "BEHALFBOT_PG_DSN": DSN}), DSN)
+
+    def test_values_are_stripped(self):
+        self.assertEqual(get_dsn({"CHASSIS_PG_DSN": f"  {DSN}  "}), DSN)
+
+
+class TestUnconfiguredFailure(unittest.TestCase):
+    def test_raises_rather_than_returning_none(self):
+        with self.assertRaises(ChassisDBUnavailable):
+            get_dsn({})
+
+    def test_reason_is_machine_readable(self):
+        with self.assertRaises(ChassisDBUnavailable) as ctx:
+            get_dsn({})
+        self.assertEqual(ctx.exception.reason, "unconfigured")
+
+    def test_message_names_every_accepted_variable(self):
+        """An operator reading this must not have to grep for the var name."""
+        with self.assertRaises(ChassisDBUnavailable) as ctx:
+            get_dsn({})
+        for var in DSN_ENV_VARS:
+            self.assertIn(var, str(ctx.exception))
+
+    def test_message_gives_the_dsn_format(self):
+        with self.assertRaises(ChassisDBUnavailable) as ctx:
+            get_dsn({})
+        self.assertIn("postgresql://", str(ctx.exception))
+
+
+class TestIsConfigured(unittest.TestCase):
+    def test_true_when_set(self):
+        self.assertTrue(is_configured({"CHASSIS_PG_DSN": DSN}))
+
+    def test_false_when_unset(self):
+        self.assertFalse(is_configured({}))
+
+    def test_does_not_raise(self):
+        is_configured({})
+
+
+class TestConnectFailure(unittest.TestCase):
+    def test_unreachable_host_raises_chassis_db_unavailable(self):
+        """psycopg's own exception is wrapped so callers catch one type."""
+        with self.assertRaises(ChassisDBUnavailable) as ctx:
+            connect(dsn="postgresql://u:p@127.0.0.1:1/definitely_not_here")
+        self.assertEqual(ctx.exception.reason, "unreachable")
+
+    def test_unreachable_message_tells_the_operator_where_to_look(self):
+        with self.assertRaises(ChassisDBUnavailable) as ctx:
+            connect(dsn="postgresql://u:p@127.0.0.1:1/definitely_not_here")
+        message = str(ctx.exception)
+        self.assertIn("docker compose ps postgres", message)
+        self.assertIn("postgres:5432", message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/chassis/db/tests/test_migrate.py
+++ b/chassis/db/tests/test_migrate.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""test_migrate.py - the migration runner, and the shipped migration's shape.
+
+Two things get asserted and they fail in different ways:
+
+  1. The runner is idempotent, ordered, and locked. A second boot must not
+     re-apply 001, and two containers starting together must not race.
+  2. The shipped 001_pacman_queue.sql actually declares the columns the queue
+     code writes to. Config promising more than code delivers is the recurring
+     failure in this codebase; a schema that has drifted from the INSERT
+     statements is the same failure wearing a different hat.
+
+Run:
+    python3 -m pytest chassis/db/tests/test_migrate.py -v
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from chassis.db.migrate import (  # noqa: E402
+    ADVISORY_LOCK_ID,
+    MIGRATIONS_DIR,
+    apply_migrations,
+    discover_migrations,
+)
+
+
+class FakeCursor:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def execute(self, sql, params=()):
+        self._conn.executed.append((" ".join(sql.split()), params))
+        return self
+
+    def fetchall(self):
+        return [(name,) for name in self._conn.already_applied]
+
+
+class FakeConnection:
+    def __init__(self, already_applied: set[str] | None = None):
+        self.executed: list[tuple[str, object]] = []
+        self.commits = 0
+        self.already_applied = already_applied or set()
+
+    def cursor(self):
+        return FakeCursor(self)
+
+    def commit(self):
+        self.commits += 1
+
+    @property
+    def sql_log(self) -> list[str]:
+        return [sql for sql, _ in self.executed]
+
+
+class TestDiscovery(unittest.TestCase):
+    def test_finds_the_pacman_migration(self):
+        names = [p.name for p in discover_migrations()]
+        self.assertIn("001_pacman_queue.sql", names)
+
+    def test_returns_files_in_lexical_order(self):
+        names = [p.name for p in discover_migrations()]
+        self.assertEqual(names, sorted(names))
+
+    def test_rejects_filenames_that_would_sort_out_of_apply_order(self):
+        """`10_x.sql` sorts before `2_x.sql`. Reject rather than mis-order."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / "2_thing.sql").write_text("SELECT 1")
+            (directory / "10_thing.sql").write_text("SELECT 1")
+            with self.assertRaises(ValueError):
+                discover_migrations(directory)
+
+    def test_ignores_non_sql_files(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / "001_ok.sql").write_text("SELECT 1")
+            (directory / "README.md").write_text("notes")
+            self.assertEqual([p.name for p in discover_migrations(directory)], ["001_ok.sql"])
+
+    def test_missing_directory_is_empty_not_an_error(self):
+        self.assertEqual(discover_migrations(Path("/nonexistent/migrations")), [])
+
+
+class TestApply(unittest.TestCase):
+    def test_applies_pending_migrations(self):
+        conn = FakeConnection()
+        self.assertEqual(apply_migrations(conn), ["001_pacman_queue.sql"])
+
+    def test_is_idempotent(self):
+        """Migrations run on every container boot. The second boot is a no-op."""
+        conn = FakeConnection(already_applied={"001_pacman_queue.sql"})
+        self.assertEqual(apply_migrations(conn), [])
+
+    def test_creates_the_ledger_table_before_reading_it(self):
+        conn = FakeConnection()
+        apply_migrations(conn)
+        ledger_index = next(i for i, s in enumerate(conn.sql_log) if "CREATE TABLE IF NOT EXISTS chassis_schema_migrations" in s)
+        select_index = next(i for i, s in enumerate(conn.sql_log) if "SELECT name FROM chassis_schema_migrations" in s)
+        self.assertLess(ledger_index, select_index)
+
+    def test_records_each_applied_migration_in_the_ledger(self):
+        conn = FakeConnection()
+        apply_migrations(conn)
+        inserts = [params for sql, params in conn.executed if "INSERT INTO chassis_schema_migrations" in sql]
+        self.assertEqual(inserts, [("001_pacman_queue.sql",)])
+
+    def test_takes_and_releases_the_advisory_lock(self):
+        """Two containers booting together serialize instead of racing."""
+        conn = FakeConnection()
+        apply_migrations(conn)
+        self.assertIn(("SELECT pg_advisory_lock(%s)", (ADVISORY_LOCK_ID,)), conn.executed)
+        self.assertIn(("SELECT pg_advisory_unlock(%s)", (ADVISORY_LOCK_ID,)), conn.executed)
+
+    def test_releases_the_lock_even_when_a_migration_raises(self):
+        class Exploding(FakeConnection):
+            def cursor(self):
+                outer = self
+
+                class Cur(FakeCursor):
+                    def execute(self, sql, params=()):
+                        outer.executed.append((" ".join(sql.split()), params))
+                        if "CREATE TABLE IF NOT EXISTS chassis_pacman_queue" in sql:
+                            raise RuntimeError("boom")
+                        return self
+
+                return Cur(self)
+
+        conn = Exploding()
+        with self.assertRaises(RuntimeError):
+            apply_migrations(conn)
+        self.assertIn(("SELECT pg_advisory_unlock(%s)", (ADVISORY_LOCK_ID,)), conn.executed)
+
+    def test_dry_run_lists_without_applying(self):
+        conn = FakeConnection()
+        self.assertEqual(apply_migrations(conn, dry_run=True), ["001_pacman_queue.sql"])
+        self.assertFalse(any("CREATE TABLE IF NOT EXISTS chassis_pacman_queue" in s for s in conn.sql_log))
+        self.assertFalse(any("INSERT INTO chassis_schema_migrations" in s for s in conn.sql_log))
+
+
+class TestPacmanQueueSchema(unittest.TestCase):
+    """The shipped DDL must declare what chassis/pacman/queue.py writes."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sql = (MIGRATIONS_DIR / "001_pacman_queue.sql").read_text(encoding="utf-8")
+
+    def test_declares_every_column_the_queue_code_uses(self):
+        for column in (
+            "token",
+            "url",
+            "source",
+            "source_ref",
+            "entry_group",
+            "created_at",
+            "claimed_at",
+            "processed_at",
+            "verdict",
+            "gate",
+            "proposal_doc_id",
+            "legacy_block_id",
+        ):
+            self.assertIn(column, self.sql, column)
+
+    def test_token_is_unique(self):
+        """The approval token is a handle a human types. Two rows cannot share one."""
+        self.assertRegex(self.sql, r"token\s+TEXT\s+NOT NULL UNIQUE")
+
+    def test_pending_rows_are_indexed(self):
+        """The gather script runs this predicate every dispatcher tick."""
+        self.assertIn("ix_pacman_queue_pending", self.sql)
+        self.assertIn("WHERE processed_at IS NULL", self.sql)
+
+    def test_migration_idempotency_key_is_block_plus_url(self):
+        """A block holding two URLs becomes two rows, so the block alone is not a key."""
+        self.assertIn("ux_pacman_queue_legacy_block_url", self.sql)
+        self.assertIn("(legacy_block_id, url)", self.sql)
+
+    def test_is_rerunnable(self):
+        """Every statement guarded, so a partially-applied migration can be retried."""
+        self.assertNotIn("CREATE TABLE chassis_pacman_queue", self.sql)
+        self.assertIn("CREATE TABLE IF NOT EXISTS chassis_pacman_queue", self.sql)
+        for index in ("ix_pacman_queue_pending", "ux_pacman_queue_legacy_block_url"):
+            self.assertIn(f"IF NOT EXISTS {index}", self.sql)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/chassis/pacman/__init__.py
+++ b/chassis/pacman/__init__.py
@@ -1,0 +1,8 @@
+"""chassis.pacman - the Pacman queue and its approval-token scheme.
+
+Pacman is chassis-core, so this lives under chassis/ rather than plugins/.
+The 4-gate pipeline itself is prose, not code - it lives in
+chassis/skills/pacman.md. What is here is the durable state the prose depends
+on: the Postgres-backed queue and the backend-independent approval token that
+replaced SiYuan block IDs.
+"""

--- a/chassis/pacman/queue.py
+++ b/chassis/pacman/queue.py
@@ -1,0 +1,317 @@
+"""Pacman queue operations against Postgres.
+
+Replaces the SiYuan-block-backed queue. Every operation here is one round
+trip and none of them touch a second brain - see docs/pacman-queue-storage.md
+for why the queue is not notes.
+
+The whole surface, in the order the pipeline uses it:
+
+    add(url, source=...)        enqueue, returns the approval token
+    pending_count()             cheap gate for the dispatcher tick
+    claim(limit)                dequeue oldest-first, marks claimed_at
+    complete(token, verdict)    exactly-once removal from the pending set
+    release(token)              hand a claimed row back, for a drain that bailed
+    pending(limit)              read-only listing, for the installer
+
+Two predicates matter and they must agree: `pending_count` must count exactly
+the rows `claim` would hand out, or the dispatcher fires Claude for work that
+does not exist (wasted tokens) or skips work that does (a stuck queue). They
+share PENDING_PREDICATE below for that reason, and a test asserts both SQL
+strings contain it.
+
+Stale claims: a drain that dies mid-batch leaves rows with claimed_at set and
+processed_at null. Those become claimable again after PACMAN_CLAIM_TIMEOUT_MINUTES
+(default 60) rather than being stranded forever. The old SiYuan design could
+not express "being processed" at all, so a dead drain either lost URLs or
+reprocessed them; this is the fix for that.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any, Iterable
+
+from chassis.db import ChassisDBUnavailable, connect
+from chassis.pacman.tokens import new_token
+
+TABLE = "chassis_pacman_queue"
+
+VALID_VERDICTS = ("drop", "proposal", "fetch_failed")
+
+DEFAULT_CLAIM_TIMEOUT_MINUTES = 60
+
+# A row is available for work when it has not been processed AND it is not
+# currently claimed by a live drain. `%(stale)s` is the reclaim cutoff in
+# minutes; it is a parameter rather than a literal so count and claim get the
+# same value from the same helper.
+PENDING_PREDICATE = (
+    "processed_at IS NULL "
+    "AND (claimed_at IS NULL OR claimed_at < NOW() - (%(stale)s || ' minutes')::interval)"
+)
+
+# Insert retries on token collision. 19**6 against a queue of tens means a
+# collision is vanishingly unlikely, but the UNIQUE constraint is the authority
+# and this loop is what respects it.
+TOKEN_INSERT_ATTEMPTS = 5
+
+
+class QueueError(RuntimeError):
+    """A queue operation failed for a reason that is not DB reachability."""
+
+
+def claim_timeout_minutes(env: dict[str, str] | None = None) -> int:
+    """Minutes after which a claimed-but-unprocessed row is reclaimable."""
+    source = env if env is not None else os.environ
+    raw = (source.get("PACMAN_CLAIM_TIMEOUT_MINUTES") or "").strip()
+    if not raw:
+        return DEFAULT_CLAIM_TIMEOUT_MINUTES
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_CLAIM_TIMEOUT_MINUTES
+    return value if value > 0 else DEFAULT_CLAIM_TIMEOUT_MINUTES
+
+
+def _connection(conn: Any | None):
+    """Use a caller-supplied connection, or open one. Tests supply their own."""
+    if conn is not None:
+        return conn, False
+    return connect(), True
+
+
+def add(
+    url: str,
+    *,
+    source: str = "manual",
+    source_ref: str | None = None,
+    entry_group: str | None = None,
+    conn: Any | None = None,
+) -> str:
+    """Enqueue one URL. Returns its approval token.
+
+    Raises on failure rather than swallowing it. The previous SiYuan helper was
+    explicitly "designed to fail silently (caller continues if URL append
+    fails)", which was survivable when the URL was also sitting in a Discord
+    message the installer could scroll back to. It is not survivable now: the
+    queue row is the only durable record, so the write has to succeed before
+    anything acknowledges the submission.
+    """
+    if not url.lower().startswith(("http://", "https://")):
+        raise QueueError(f"not an http(s) URL: {url[:200]}")
+
+    group = entry_group or str(uuid.uuid4())
+    connection, owned = _connection(conn)
+    try:
+        cur = connection.cursor()
+        last_exc: Exception | None = None
+        for _ in range(TOKEN_INSERT_ATTEMPTS):
+            token = new_token()
+            try:
+                cur.execute(
+                    f"INSERT INTO {TABLE} (token, url, source, source_ref, entry_group) "
+                    "VALUES (%s, %s, %s, %s, %s) RETURNING token",
+                    (token, url, source, source_ref, group),
+                )
+                row = cur.fetchone()
+                connection.commit()
+                return row[0] if row else token
+            except Exception as exc:  # token collision or a real error
+                connection.rollback()
+                last_exc = exc
+                if "token" not in str(exc).lower():
+                    raise
+        raise QueueError(f"could not allocate a unique approval token: {last_exc}")
+    finally:
+        if owned:
+            connection.close()
+
+
+def add_many(
+    urls: Iterable[str],
+    *,
+    source: str = "manual",
+    source_ref: str | None = None,
+    conn: Any | None = None,
+) -> list[str]:
+    """Enqueue several URLs as one entry group. Returns tokens in input order.
+
+    Requirement 5 from the design note: URLs pasted in one message belong
+    together, and the group is only fully done once every URL in it is done.
+    """
+    group = str(uuid.uuid4())
+    connection, owned = _connection(conn)
+    try:
+        return [
+            add(u, source=source, source_ref=source_ref, entry_group=group, conn=connection)
+            for u in urls
+        ]
+    finally:
+        if owned:
+            connection.close()
+
+
+def pending_count(*, conn: Any | None = None, env: dict[str, str] | None = None) -> int:
+    """Count rows a drain could pick up right now. Runs every dispatcher tick."""
+    connection, owned = _connection(conn)
+    try:
+        cur = connection.cursor()
+        cur.execute(
+            f"SELECT COUNT(*) FROM {TABLE} WHERE {PENDING_PREDICATE}",
+            {"stale": claim_timeout_minutes(env)},
+        )
+        row = cur.fetchone()
+        return int(row[0]) if row else 0
+    finally:
+        if owned:
+            connection.close()
+
+
+def pending(
+    limit: int = 25, *, conn: Any | None = None, env: dict[str, str] | None = None
+) -> list[dict[str, Any]]:
+    """List pending rows without claiming them.
+
+    This is what replaces the installer's ability to open /To Investigate and
+    see what is queued. The design note flags that visibility as a real feature
+    being traded away; this is the trade being paid back.
+    """
+    connection, owned = _connection(conn)
+    try:
+        cur = connection.cursor()
+        cur.execute(
+            f"SELECT token, url, source, created_at, claimed_at FROM {TABLE} "
+            f"WHERE {PENDING_PREDICATE} ORDER BY created_at ASC, id ASC LIMIT %(limit)s",
+            {"stale": claim_timeout_minutes(env), "limit": limit},
+        )
+        return [
+            {
+                "token": r[0],
+                "url": r[1],
+                "source": r[2],
+                "created_at": r[3].isoformat() if hasattr(r[3], "isoformat") else r[3],
+                "claimed_at": r[4].isoformat() if hasattr(r[4], "isoformat") else r[4],
+            }
+            for r in cur.fetchall()
+        ]
+    finally:
+        if owned:
+            connection.close()
+
+
+def claim(
+    limit: int = 10, *, conn: Any | None = None, env: dict[str, str] | None = None
+) -> list[dict[str, Any]]:
+    """Dequeue up to `limit` rows oldest-first and mark them claimed.
+
+    FOR UPDATE SKIP LOCKED makes two concurrent drains safe - they take
+    disjoint batches instead of both taking the same one. The SiYuan design
+    could not express this at all, so overlapping drains double-processed.
+
+    Two ordering subtleties, both found by the live-Postgres test in
+    tests/test_queue.py and neither visible to a fake connection:
+
+    1. `UPDATE ... RETURNING` does NOT preserve the inner subquery's ORDER BY.
+       Rows come back in update order, which is unspecified. The first version
+       of this returned a rotated batch, so the drain processed out of FIFO
+       order while every non-DB test passed. Hence the CTE: the ordering that
+       the caller sees has to be applied in an outer SELECT.
+    2. `created_at` alone is not a total order. `add_many` inserts a pasted
+       batch in a tight loop, and two rows can land in the same microsecond;
+       the tie then breaks arbitrarily. `id` is BIGSERIAL and monotonic, so it
+       is the real insertion order and the correct tiebreak.
+    """
+    connection, owned = _connection(conn)
+    try:
+        cur = connection.cursor()
+        cur.execute(
+            "WITH claimed AS ("
+            f"  UPDATE {TABLE} SET claimed_at = NOW() WHERE id IN ("
+            f"    SELECT id FROM {TABLE} WHERE {PENDING_PREDICATE}"
+            "     ORDER BY created_at ASC, id ASC LIMIT %(limit)s FOR UPDATE SKIP LOCKED"
+            "  ) RETURNING id, token, url, source, entry_group, created_at"
+            ") SELECT token, url, source, entry_group, created_at FROM claimed "
+            "ORDER BY created_at ASC, id ASC",
+            {"stale": claim_timeout_minutes(env), "limit": limit},
+        )
+        rows = cur.fetchall()
+        connection.commit()
+        return [
+            {
+                "token": r[0],
+                "url": r[1],
+                "source": r[2],
+                "entry_group": str(r[3]),
+                "created_at": r[4].isoformat() if hasattr(r[4], "isoformat") else r[4],
+            }
+            for r in rows
+        ]
+    finally:
+        if owned:
+            connection.close()
+
+
+def complete(
+    token: str,
+    verdict: str,
+    *,
+    gate: int | None = None,
+    proposal_doc_id: str | None = None,
+    conn: Any | None = None,
+) -> bool:
+    """Mark a row processed. Returns False if the token was already processed.
+
+    This is the operation the skill calls non-negotiable: an entry that
+    survives processing gets re-processed forever. `processed_at IS NULL` in
+    the WHERE clause is what makes it exactly-once - a second call for the same
+    token updates zero rows and returns False rather than resetting the verdict.
+    """
+    if verdict not in VALID_VERDICTS:
+        raise QueueError(f"verdict must be one of {VALID_VERDICTS}, got {verdict!r}")
+
+    connection, owned = _connection(conn)
+    try:
+        cur = connection.cursor()
+        cur.execute(
+            f"UPDATE {TABLE} SET processed_at = NOW(), verdict = %s, gate = %s, "
+            "proposal_doc_id = %s WHERE token = %s AND processed_at IS NULL",
+            (verdict, gate, proposal_doc_id, token),
+        )
+        changed = cur.rowcount
+        connection.commit()
+        return changed > 0
+    finally:
+        if owned:
+            connection.close()
+
+
+def release(token: str, *, conn: Any | None = None) -> bool:
+    """Un-claim a row so the next drain picks it up. For a drain that bailed."""
+    connection, owned = _connection(conn)
+    try:
+        cur = connection.cursor()
+        cur.execute(
+            f"UPDATE {TABLE} SET claimed_at = NULL WHERE token = %s AND processed_at IS NULL",
+            (token,),
+        )
+        changed = cur.rowcount
+        connection.commit()
+        return changed > 0
+    finally:
+        if owned:
+            connection.close()
+
+
+__all__ = [
+    "ChassisDBUnavailable",
+    "PENDING_PREDICATE",
+    "QueueError",
+    "add",
+    "add_many",
+    "claim",
+    "claim_timeout_minutes",
+    "complete",
+    "pending",
+    "pending_count",
+    "release",
+]

--- a/chassis/pacman/tests/test_backend_neutrality.py
+++ b/chassis/pacman/tests/test_backend_neutrality.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""test_backend_neutrality.py - Pacman behaves identically on all three backends.
+
+Pacman used to have a backend branch, and it was invisible: the queue lived in
+SiYuan blocks, so on Obsidian, Notion, or any install running
+`second_brain.mode: adapter` the drain reached for `mcp__siyuan__*`, found
+nothing registered, and reported a clean run over an empty queue.
+
+The fix removed the branch rather than adding cases to it. That makes the
+strongest available assertion a negative one: no Pacman code path, prompt, or
+skill instruction may name a backend-specific tool or a SiYuan-shaped
+identifier. If one reappears, the branch is back and one of the three backends
+is silently broken again.
+
+These are string assertions over shipped prose, which is unusual, but the
+prompt and skill ARE the implementation for a model-driven pipeline - a
+`mcp__siyuan__delete_block` in the drain prompt is executable code, and this
+file is the only thing that can fail when it drifts.
+
+Run:
+    python3 -m pytest chassis/pacman/tests/test_backend_neutrality.py -v
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+SKILL = REPO_ROOT / "chassis" / "skills" / "pacman.md"
+DRAIN_PROMPT = REPO_ROOT / "chassis" / "scheduled-tasks" / "pacman-drain-prompt.md"
+PACMAN_SH = REPO_ROOT / "chassis" / "scripts" / "pacman.sh"
+GATHER_SH = REPO_ROOT / "chassis" / "scripts" / "gather-pacman-queue.sh"
+QUEUE_ADD = REPO_ROOT / "chassis" / "scripts" / "pacman-queue-add.py"
+REACTIONS = REPO_ROOT / "chassis" / "scripts" / "pacman-process-reactions.py"
+QUEUE_CLI = REPO_ROOT / "chassis" / "scripts" / "pacman-queue.py"
+
+# The one file allowed to be SiYuan-specific: it exists to read the old SiYuan
+# queue once and never runs again.
+MIGRATION_SCRIPT = REPO_ROOT / "chassis" / "scripts" / "pacman-migrate-siyuan-queue.py"
+
+RUNTIME_FILES = [SKILL, DRAIN_PROMPT, PACMAN_SH, GATHER_SH, QUEUE_ADD, REACTIONS, QUEUE_CLI]
+
+
+class TestNoSiyuanToolCallsRemain(unittest.TestCase):
+    def test_no_runtime_file_calls_a_siyuan_mcp_tool(self):
+        for path in RUNTIME_FILES:
+            text = path.read_text(encoding="utf-8")
+            for tool in (
+                "mcp__siyuan__delete_block",
+                "mcp__siyuan__create_doc",
+                "mcp__siyuan__append_block",
+                "mcp__siyuan__sql_query",
+            ):
+                self.assertNotIn(tool, text, f"{path.name} still calls {tool}")
+
+    def test_no_runtime_file_reads_the_siyuan_queue_block_id(self):
+        """That variable is the SiYuan coupling in env-var form."""
+        for path in RUNTIME_FILES:
+            self.assertNotIn(
+                "${PACMAN_SIYUAN_QUEUE_BLOCK_ID}",
+                path.read_text(encoding="utf-8"),
+                f"{path.name} still expands PACMAN_SIYUAN_QUEUE_BLOCK_ID",
+            )
+
+    def test_pacman_sh_no_longer_requires_the_siyuan_block_vars(self):
+        """It used to hard-fail without them, which broke non-SiYuan installs at launch."""
+        text = PACMAN_SH.read_text(encoding="utf-8")
+        self.assertNotIn(': "${PACMAN_SIYUAN_QUEUE_BLOCK_ID:?', text)
+        self.assertNotIn(': "${PACMAN_SIYUAN_DROPPED_BLOCK_ID:?', text)
+
+    def test_the_backfill_script_is_the_only_siyuan_reader(self):
+        """Deliberately exempt - it reads the old queue once, then never runs."""
+        self.assertIn("PACMAN_SIYUAN_QUEUE_BLOCK_ID", MIGRATION_SCRIPT.read_text(encoding="utf-8"))
+
+
+class TestWritesGoThroughTheAdapter(unittest.TestCase):
+    def test_drain_prompt_creates_proposals_via_the_adapter(self):
+        text = DRAIN_PROMPT.read_text(encoding="utf-8")
+        self.assertIn("mcp__secondbrain__create_doc", text)
+        self.assertIn("mcp__secondbrain__append_to_doc", text)
+
+    def test_skill_creates_proposals_via_the_adapter(self):
+        text = SKILL.read_text(encoding="utf-8")
+        self.assertIn("mcp__secondbrain__create_doc", text)
+        self.assertIn("mcp__secondbrain__append_to_doc", text)
+
+    def test_deeplinks_are_taken_from_the_adapter_not_constructed(self):
+        """The URL scheme differs per backend; a hand-built one is wrong on two of three."""
+        for path in (SKILL, DRAIN_PROMPT):
+            text = path.read_text(encoding="utf-8")
+            self.assertIn("deeplink", text, path.name)
+        self.assertNotIn("Read the expanded proposal: [SiYuan sub-doc](siyuan://", SKILL.read_text(encoding="utf-8"))
+
+    def test_proposal_doc_id_is_treated_as_opaque(self):
+        """It is a block id, a UUID, or a path. Core code must never parse it."""
+        self.assertIn("opaque", SKILL.read_text(encoding="utf-8").lower())
+
+
+class TestQueueReadsAndWritesGoThroughPostgres(unittest.TestCase):
+    def test_drain_prompt_claims_through_the_queue_cli(self):
+        text = DRAIN_PROMPT.read_text(encoding="utf-8")
+        self.assertIn("pacman-queue.py", text)
+        self.assertIn("claim --limit", text)
+
+    def test_drain_prompt_completes_rows_rather_than_deleting_blocks(self):
+        text = DRAIN_PROMPT.read_text(encoding="utf-8")
+        self.assertIn("complete <token>", text)
+
+    def test_gather_script_delegates_the_count_rather_than_reimplementing_it(self):
+        """A second copy of the predicate would drift from the claim path."""
+        text = GATHER_SH.read_text(encoding="utf-8")
+        self.assertIn("pacman-queue.py", text)
+        self.assertNotIn("SELECT COUNT", text)
+
+
+class TestDrainPromptFailsLoudly(unittest.TestCase):
+    def test_it_forbids_reporting_a_clean_drain_on_error(self):
+        """PR #78's Stage 2 property: a silent no-op drain is the failure mode."""
+        text = DRAIN_PROMPT.read_text(encoding="utf-8")
+        self.assertIn("do NOT report a clean drain", text)
+        self.assertIn("do NOT improvise", text)
+
+    def test_pacman_sh_checks_the_queue_before_spending_a_claude_invocation(self):
+        text = PACMAN_SH.read_text(encoding="utf-8")
+        self.assertIn("pacman-queue.py", text)
+        self.assertIn("count", text)
+
+
+class TestQueueCliContract(unittest.TestCase):
+    """The drain prompt names these subcommands; they must exist and parse."""
+
+    def _run(self, *args) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(QUEUE_CLI), *args],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env={"PATH": "/usr/bin:/bin"},
+        )
+
+    def test_every_subcommand_the_prompt_uses_exists(self):
+        prompt = DRAIN_PROMPT.read_text(encoding="utf-8")
+        for subcommand in ("claim", "complete", "release"):
+            self.assertIn(f"pacman-queue.py\" {subcommand}", prompt)
+            result = self._run(subcommand, "--help")
+            self.assertEqual(result.returncode, 0, f"{subcommand} --help failed: {result.stderr}")
+
+    def test_count_subcommand_exists(self):
+        self.assertEqual(self._run("count", "--help").returncode, 0)
+
+    def test_pending_subcommand_exists(self):
+        self.assertEqual(self._run("pending", "--help").returncode, 0)
+
+    def test_unconfigured_postgres_exits_nonzero_rather_than_printing_count_zero(self):
+        """The whole point. An unreachable queue must not look like an empty one."""
+        result = self._run("count")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertNotIn('"count": 0', result.stdout)
+        self.assertIn("ERROR", result.stderr)
+
+    def test_the_error_names_the_env_var_to_set(self):
+        result = self._run("count")
+        self.assertIn("CHASSIS_PG_DSN", result.stderr)
+
+    def test_complete_rejects_an_undocumented_verdict(self):
+        result = self._run("complete", "qhtnbz", "--verdict", "maybe")
+        self.assertNotEqual(result.returncode, 0)
+
+
+class TestGatherScriptContract(unittest.TestCase):
+    def _run(self, env: dict) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["bash", str(GATHER_SH)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env={"PATH": "/usr/bin:/bin", **env},
+        )
+
+    def test_hard_pause_short_circuits_before_touching_the_database(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pause = Path(tmp) / "PACMAN_HARD_PAUSE"
+            pause.touch()
+            result = self._run({"PACMAN_HARD_PAUSE": str(pause), "CHASSIS_HOME": tmp})
+            self.assertEqual(result.returncode, 0)
+            self.assertIn('"count": 0', result.stdout)
+            self.assertIn("PACMAN_HARD_PAUSE", result.stdout)
+
+    def test_unreachable_database_exits_nonzero(self):
+        """The dispatcher records this as gather_failed and alerts, per its own logic."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self._run({
+                "CHASSIS_HOME": tmp,
+                "CHASSIS_PG_DSN": "postgresql://u:p@127.0.0.1:1/nope",
+            })
+            self.assertNotEqual(result.returncode, 0)
+            self.assertNotIn('"count": 0', result.stdout)
+
+    def test_unconfigured_database_exits_nonzero(self):
+        """Previously this printed count=0 and exited 0 - a permanently silent queue."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self._run({"CHASSIS_HOME": tmp})
+            self.assertNotEqual(result.returncode, 0)
+
+
+class TestReactionProcessorReportsFailures(unittest.TestCase):
+    def test_a_failed_enqueue_logs_the_url_verbatim(self):
+        """Telegram reactions are the intake where a lost URL is unrecoverable."""
+        text = REACTIONS.read_text(encoding="utf-8")
+        self.assertIn("queue_failed_urls", text)
+
+    def test_it_distinguishes_a_db_outage_from_a_rejected_url(self):
+        text = REACTIONS.read_text(encoding="utf-8")
+        self.assertIn("db_unavailable", text)
+
+    def test_it_records_the_approval_token_it_got_back(self):
+        text = REACTIONS.read_text(encoding="utf-8")
+        self.assertIn('"token": token', text)
+
+
+class TestQueueAddIsDurableBeforeAck(unittest.TestCase):
+    def test_it_no_longer_advertises_silent_failure(self):
+        text = QUEUE_ADD.read_text(encoding="utf-8")
+        self.assertNotIn("Designed to fail silently", text)
+
+    def test_it_documents_a_distinct_exit_code_for_an_unreachable_database(self):
+        text = QUEUE_ADD.read_text(encoding="utf-8")
+        self.assertIn("2  Postgres unconfigured or unreachable", text)
+
+    def test_an_unreachable_database_exits_two_and_prints_no_token(self):
+        result = subprocess.run(
+            [sys.executable, str(QUEUE_ADD), "https://example.com/a"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env={"PATH": "/usr/bin:/bin", "CHASSIS_HOME": "/tmp"},
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(result.stdout.strip(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/chassis/pacman/tests/test_queue.py
+++ b/chassis/pacman/tests/test_queue.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""test_queue.py - queue operations, without requiring a live Postgres.
+
+Two layers, because neither alone is enough:
+
+  1. A recording fake connection. It proves the code path runs, that the SQL
+     each operation emits has the properties that matter (FIFO ordering, the
+     exactly-once WHERE clause, SKIP LOCKED on the claim), and that count and
+     claim share one predicate. It does not prove the SQL is valid Postgres.
+  2. An opt-in integration test against a real database, skipped with a clear
+     message when CHASSIS_TEST_PG_DSN is unset. That layer is what proves the
+     SQL is valid and the semantics hold. CI does not need a database to run
+     this file; a developer with one gets the stronger check for free.
+
+The properties asserted in layer 1 are the ones with a known failure mode
+behind them, not incidental string matches:
+
+  - count and claim must use the same predicate, or the dispatcher fires
+    Claude for work that does not exist or skips work that does.
+  - complete must carry `processed_at IS NULL`, or a retried call resets a
+    verdict that was already recorded.
+  - claim must order oldest-first, or FIFO silently becomes arbitrary.
+
+Run:
+    python3 -m pytest chassis/pacman/tests/test_queue.py -v
+    CHASSIS_TEST_PG_DSN=postgresql://... python3 -m pytest chassis/pacman/tests/test_queue.py -v
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from chassis.pacman import queue  # noqa: E402
+from chassis.pacman.tokens import is_token  # noqa: E402
+
+
+class FakeCursor:
+    def __init__(self, conn):
+        self._conn = conn
+        self.rowcount = 0
+
+    def execute(self, sql, params=()):
+        self._conn.executed.append((" ".join(sql.split()), params))
+        self.rowcount = self._conn.next_rowcount
+        return self
+
+    def fetchone(self):
+        return self._conn.next_fetchone
+
+    def fetchall(self):
+        return self._conn.next_fetchall
+
+
+class FakeConnection:
+    """Records SQL and hands back canned rows. Not a database."""
+
+    def __init__(self):
+        self.executed: list[tuple[str, object]] = []
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.next_fetchone = None
+        self.next_fetchall: list = []
+        self.next_rowcount = 1
+
+    def cursor(self):
+        return FakeCursor(self)
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def close(self):
+        self.closed = True
+
+    @property
+    def last_sql(self) -> str:
+        return self.executed[-1][0]
+
+    @property
+    def last_params(self):
+        return self.executed[-1][1]
+
+
+class TestAdd(unittest.TestCase):
+    def test_returns_a_well_formed_token(self):
+        conn = FakeConnection()
+        conn.next_fetchone = ("qhtnbz",)
+        token = queue.add("https://example.com/a", conn=conn)
+        self.assertEqual(token, "qhtnbz")
+
+    def test_generates_a_token_when_the_db_returns_none(self):
+        conn = FakeConnection()
+        conn.next_fetchone = None
+        self.assertTrue(is_token(queue.add("https://example.com/a", conn=conn)))
+
+    def test_commits_before_returning(self):
+        """Durable before the caller acks. The whole point of the rewrite."""
+        conn = FakeConnection()
+        conn.next_fetchone = ("qhtnbz",)
+        queue.add("https://example.com/a", conn=conn)
+        self.assertEqual(conn.commits, 1)
+
+    def test_rejects_non_http_urls(self):
+        conn = FakeConnection()
+        for bad in ("ftp://example.com", "example.com", "javascript:alert(1)", ""):
+            with self.assertRaises(queue.QueueError):
+                queue.add(bad, conn=conn)
+        self.assertEqual(conn.executed, [])
+
+    def test_stores_source_and_source_ref(self):
+        conn = FakeConnection()
+        conn.next_fetchone = ("qhtnbz",)
+        queue.add("https://example.com/a", source="telegram-react-99", source_ref="99:12", conn=conn)
+        params = conn.last_params
+        self.assertIn("telegram-react-99", params)
+        self.assertIn("99:12", params)
+
+    def test_does_not_close_a_caller_supplied_connection(self):
+        conn = FakeConnection()
+        conn.next_fetchone = ("qhtnbz",)
+        queue.add("https://example.com/a", conn=conn)
+        self.assertFalse(conn.closed)
+
+    def test_retries_on_a_token_collision_then_succeeds(self):
+        class CollideOnce(FakeConnection):
+            def __init__(self):
+                super().__init__()
+                self.attempts = 0
+
+            def cursor(self):
+                outer = self
+
+                class Cur(FakeCursor):
+                    def execute(self, sql, params=()):
+                        outer.attempts += 1
+                        outer.executed.append((" ".join(sql.split()), params))
+                        if outer.attempts == 1:
+                            raise RuntimeError('duplicate key value violates unique constraint "chassis_pacman_queue_token_key"')
+                        return self
+
+                return Cur(self)
+
+        conn = CollideOnce()
+        conn.next_fetchone = ("qhtnbz",)
+        self.assertEqual(queue.add("https://example.com/a", conn=conn), "qhtnbz")
+        self.assertEqual(conn.attempts, 2)
+        self.assertEqual(conn.rollbacks, 1)
+
+    def test_reraises_errors_that_are_not_token_collisions(self):
+        class AlwaysFails(FakeConnection):
+            def cursor(self):
+                outer = self
+
+                class Cur(FakeCursor):
+                    def execute(self, sql, params=()):
+                        outer.executed.append((" ".join(sql.split()), params))
+                        raise RuntimeError('relation "chassis_pacman_queue" does not exist')
+
+                return Cur(self)
+
+        with self.assertRaises(RuntimeError):
+            queue.add("https://example.com/a", conn=AlwaysFails())
+
+
+class TestAddMany(unittest.TestCase):
+    def test_urls_from_one_message_share_an_entry_group(self):
+        """Requirement 5: a pasted batch is one entry until every URL is done."""
+        conn = FakeConnection()
+        conn.next_fetchone = ("qhtnbz",)
+        queue.add_many(["https://a.example", "https://b.example"], conn=conn)
+        groups = {params[4] for _, params in conn.executed}
+        self.assertEqual(len(groups), 1)
+
+    def test_inserts_one_row_per_url(self):
+        conn = FakeConnection()
+        conn.next_fetchone = ("qhtnbz",)
+        queue.add_many(["https://a.example", "https://b.example", "https://c.example"], conn=conn)
+        self.assertEqual(len(conn.executed), 3)
+
+
+class TestPendingCount(unittest.TestCase):
+    def test_uses_the_shared_pending_predicate(self):
+        conn = FakeConnection()
+        conn.next_fetchone = (7,)
+        self.assertEqual(queue.pending_count(conn=conn), 7)
+        self.assertIn(" ".join(queue.PENDING_PREDICATE.split()), conn.last_sql)
+
+    def test_returns_zero_when_the_query_returns_nothing(self):
+        conn = FakeConnection()
+        conn.next_fetchone = None
+        self.assertEqual(queue.pending_count(conn=conn), 0)
+
+    def test_honours_the_claim_timeout_env_var(self):
+        conn = FakeConnection()
+        conn.next_fetchone = (0,)
+        queue.pending_count(conn=conn, env={"PACMAN_CLAIM_TIMEOUT_MINUTES": "15"})
+        self.assertEqual(conn.last_params["stale"], 15)
+
+
+class TestClaim(unittest.TestCase):
+    def test_orders_oldest_first(self):
+        conn = FakeConnection()
+        queue.claim(conn=conn)
+        self.assertIn("ORDER BY created_at ASC", conn.last_sql)
+
+    def test_the_returned_batch_is_ordered_by_an_outer_select(self):
+        """Regression: `UPDATE ... RETURNING` does not preserve the inner ORDER BY.
+
+        The first version of claim() ordered only inside the id-selection
+        subquery, so Postgres returned the batch in update order and the drain
+        processed out of FIFO order. Every fake-connection test still passed;
+        only the live-Postgres test caught it. This asserts the CTE shape that
+        fixes it, so the regression cannot return without a database present.
+        """
+        conn = FakeConnection()
+        queue.claim(conn=conn)
+        sql = conn.last_sql
+        self.assertIn("WITH claimed AS", sql)
+        self.assertTrue(
+            sql.rstrip().endswith("ORDER BY created_at ASC, id ASC"),
+            f"claim must apply its final ordering in the outer SELECT: {sql}",
+        )
+
+    def test_ordering_has_a_total_order_tiebreak(self):
+        """created_at ties are real: add_many inserts a batch in a tight loop."""
+        conn = FakeConnection()
+        queue.claim(conn=conn)
+        self.assertIn("ORDER BY created_at ASC, id ASC", conn.last_sql)
+
+    def test_pending_listing_uses_the_same_total_order(self):
+        conn = FakeConnection()
+        queue.pending(conn=conn)
+        self.assertIn("ORDER BY created_at ASC, id ASC", conn.last_sql)
+
+    def test_uses_skip_locked_so_overlapping_drains_do_not_collide(self):
+        conn = FakeConnection()
+        queue.claim(conn=conn)
+        self.assertIn("FOR UPDATE SKIP LOCKED", conn.last_sql)
+
+    def test_sets_claimed_at(self):
+        conn = FakeConnection()
+        queue.claim(conn=conn)
+        self.assertIn("SET claimed_at = NOW()", conn.last_sql)
+
+    def test_respects_the_limit(self):
+        conn = FakeConnection()
+        queue.claim(limit=3, conn=conn)
+        self.assertEqual(conn.last_params["limit"], 3)
+
+    def test_shapes_rows_for_the_drain_prompt(self):
+        conn = FakeConnection()
+        conn.next_fetchall = [("qhtnbz", "https://a.example", "discord", "grp", "2026-07-19T10:00:00")]
+        rows = queue.claim(conn=conn)
+        self.assertEqual(rows[0]["token"], "qhtnbz")
+        self.assertEqual(rows[0]["url"], "https://a.example")
+
+    def test_empty_queue_yields_an_empty_list(self):
+        conn = FakeConnection()
+        conn.next_fetchall = []
+        self.assertEqual(queue.claim(conn=conn), [])
+
+
+class TestCountAndClaimAgree(unittest.TestCase):
+    """The dispatcher gate and the drain must see the same queue.
+
+    If these drift, the heartbeat either burns Claude tokens on an empty queue
+    or leaves real work permanently unclaimed. Sharing one predicate constant
+    is the mechanism; this is the test that the mechanism is actually used.
+    """
+
+    def test_both_statements_embed_the_shared_predicate(self):
+        normalized = " ".join(queue.PENDING_PREDICATE.split())
+
+        count_conn = FakeConnection()
+        count_conn.next_fetchone = (0,)
+        queue.pending_count(conn=count_conn)
+
+        claim_conn = FakeConnection()
+        queue.claim(conn=claim_conn)
+
+        pending_conn = FakeConnection()
+        queue.pending(conn=pending_conn)
+
+        for conn in (count_conn, claim_conn, pending_conn):
+            self.assertIn(normalized, conn.last_sql)
+
+    def test_both_pass_the_same_stale_window(self):
+        env = {"PACMAN_CLAIM_TIMEOUT_MINUTES": "45"}
+        count_conn = FakeConnection()
+        count_conn.next_fetchone = (0,)
+        queue.pending_count(conn=count_conn, env=env)
+        claim_conn = FakeConnection()
+        queue.claim(conn=claim_conn, env=env)
+        self.assertEqual(count_conn.last_params["stale"], claim_conn.last_params["stale"])
+
+
+class TestComplete(unittest.TestCase):
+    def test_is_exactly_once(self):
+        """`processed_at IS NULL` is what stops a retry rewriting a verdict."""
+        conn = FakeConnection()
+        queue.complete("qhtnbz", "drop", gate=2, conn=conn)
+        self.assertIn("processed_at IS NULL", conn.last_sql)
+
+    def test_returns_false_when_the_row_was_already_processed(self):
+        conn = FakeConnection()
+        conn.next_rowcount = 0
+        self.assertFalse(queue.complete("qhtnbz", "drop", conn=conn))
+
+    def test_returns_true_on_first_completion(self):
+        conn = FakeConnection()
+        conn.next_rowcount = 1
+        self.assertTrue(queue.complete("qhtnbz", "proposal", conn=conn))
+
+    def test_rejects_an_unknown_verdict(self):
+        conn = FakeConnection()
+        with self.assertRaises(queue.QueueError):
+            queue.complete("qhtnbz", "maybe", conn=conn)
+        self.assertEqual(conn.executed, [])
+
+    def test_accepts_every_documented_verdict(self):
+        for verdict in queue.VALID_VERDICTS:
+            conn = FakeConnection()
+            queue.complete("qhtnbz", verdict, conn=conn)
+            self.assertIn(verdict, conn.last_params)
+
+    def test_stores_the_opaque_proposal_doc_id(self):
+        """Whatever create_doc returned, unparsed. Block id, UUID, or path."""
+        for doc_id in ("20260719120000-abc1234", "1f2e3d4c5b6a798899001122", "To Investigate/x.md"):
+            conn = FakeConnection()
+            queue.complete("qhtnbz", "proposal", proposal_doc_id=doc_id, conn=conn)
+            self.assertIn(doc_id, conn.last_params)
+
+
+class TestRelease(unittest.TestCase):
+    def test_clears_the_claim_without_marking_processed(self):
+        conn = FakeConnection()
+        queue.release("qhtnbz", conn=conn)
+        self.assertIn("SET claimed_at = NULL", conn.last_sql)
+        self.assertIn("processed_at IS NULL", conn.last_sql)
+
+
+class TestClaimTimeout(unittest.TestCase):
+    def test_default(self):
+        self.assertEqual(queue.claim_timeout_minutes(env={}), queue.DEFAULT_CLAIM_TIMEOUT_MINUTES)
+
+    def test_override(self):
+        self.assertEqual(queue.claim_timeout_minutes(env={"PACMAN_CLAIM_TIMEOUT_MINUTES": "5"}), 5)
+
+    def test_garbage_and_nonpositive_values_fall_back_to_the_default(self):
+        for bad in ("", "abc", "0", "-10"):
+            self.assertEqual(
+                queue.claim_timeout_minutes(env={"PACMAN_CLAIM_TIMEOUT_MINUTES": bad}),
+                queue.DEFAULT_CLAIM_TIMEOUT_MINUTES,
+                bad,
+            )
+
+
+@unittest.skipUnless(
+    os.environ.get("CHASSIS_TEST_PG_DSN"),
+    "CHASSIS_TEST_PG_DSN is not set - skipping the live-Postgres queue tests. "
+    "These are the ones that prove the SQL is valid and the semantics hold. "
+    "Set CHASSIS_TEST_PG_DSN to a throwaway database to run them.",
+)
+class TestAgainstRealPostgres(unittest.TestCase):
+    """The layer that proves the SQL actually runs. Opt-in, never required in CI."""
+
+    @classmethod
+    def setUpClass(cls):
+        from chassis.db import apply_migrations, connect
+
+        cls.conn = connect(dsn=os.environ["CHASSIS_TEST_PG_DSN"])
+        apply_migrations(cls.conn)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.conn.close()
+
+    def setUp(self):
+        cur = self.conn.cursor()
+        cur.execute("DELETE FROM chassis_pacman_queue")
+        self.conn.commit()
+
+    def test_add_then_count_then_claim_then_complete(self):
+        token = queue.add("https://example.com/first", source="discord", conn=self.conn)
+        self.assertTrue(is_token(token))
+        self.assertEqual(queue.pending_count(conn=self.conn), 1)
+
+        claimed = queue.claim(limit=10, conn=self.conn)
+        self.assertEqual([r["token"] for r in claimed], [token])
+
+        # Claimed rows are no longer claimable, so the gate reads zero.
+        self.assertEqual(queue.pending_count(conn=self.conn), 0)
+
+        self.assertTrue(queue.complete(token, "drop", gate=2, conn=self.conn))
+        self.assertFalse(queue.complete(token, "drop", gate=2, conn=self.conn))
+        self.assertEqual(queue.pending_count(conn=self.conn), 0)
+
+    def test_claim_is_fifo(self):
+        first = queue.add("https://example.com/1", conn=self.conn)
+        second = queue.add("https://example.com/2", conn=self.conn)
+        third = queue.add("https://example.com/3", conn=self.conn)
+        claimed = [r["token"] for r in queue.claim(limit=10, conn=self.conn)]
+        self.assertEqual(claimed, [first, second, third])
+
+    def test_claim_respects_the_batch_cap(self):
+        for i in range(5):
+            queue.add(f"https://example.com/{i}", conn=self.conn)
+        self.assertEqual(len(queue.claim(limit=2, conn=self.conn)), 2)
+
+    def test_release_returns_a_row_to_the_pending_set(self):
+        token = queue.add("https://example.com/x", conn=self.conn)
+        queue.claim(limit=1, conn=self.conn)
+        self.assertEqual(queue.pending_count(conn=self.conn), 0)
+        self.assertTrue(queue.release(token, conn=self.conn))
+        self.assertEqual(queue.pending_count(conn=self.conn), 1)
+
+    def test_stale_claims_become_claimable_again(self):
+        """A drain that died mid-batch must not strand its rows forever."""
+        token = queue.add("https://example.com/stale", conn=self.conn)
+        queue.claim(limit=1, conn=self.conn)
+        cur = self.conn.cursor()
+        cur.execute(
+            "UPDATE chassis_pacman_queue SET claimed_at = NOW() - INTERVAL '2 hours' WHERE token = %s",
+            (token,),
+        )
+        self.conn.commit()
+        self.assertEqual(queue.pending_count(conn=self.conn), 1)
+        self.assertEqual([r["token"] for r in queue.claim(limit=1, conn=self.conn)], [token])
+
+    def test_tokens_are_unique_across_many_inserts(self):
+        tokens = {queue.add(f"https://example.com/u{i}", conn=self.conn) for i in range(200)}
+        self.assertEqual(len(tokens), 200)
+
+    def test_a_pasted_batch_keeps_its_order(self):
+        """add_many inserts in a tight loop, so created_at ties are likely here."""
+        tokens = queue.add_many(
+            [f"https://example.com/batch{i}" for i in range(12)],
+            source="discord",
+            conn=self.conn,
+        )
+        claimed = [r["token"] for r in queue.claim(limit=50, conn=self.conn)]
+        self.assertEqual(claimed, tokens)
+
+    def test_migrations_are_idempotent_against_a_real_database(self):
+        from chassis.db import apply_migrations
+
+        self.assertEqual(apply_migrations(self.conn), [])
+
+    def test_pending_lists_without_claiming(self):
+        queue.add("https://example.com/p", conn=self.conn)
+        listed = queue.pending(conn=self.conn)
+        self.assertEqual(len(listed), 1)
+        self.assertEqual(queue.pending_count(conn=self.conn), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/chassis/pacman/tests/test_siyuan_migration.py
+++ b/chassis/pacman/tests/test_siyuan_migration.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""test_siyuan_migration.py - the one-time SiYuan backfill's planning stage.
+
+This runs once, against a real queue, and gets one chance. The failure the
+design note names explicitly is "a block containing two URLs being counted as
+one entry" - a silent halving of the queue that nothing downstream would ever
+notice, because the missing URLs exist nowhere else once the source Discord or
+Telegram message has scrolled away.
+
+So the planning stage is tested hard and separately from the insert: given the
+blocks SiYuan returns, does it produce exactly the right rows, in the right
+order, and does it REPORT rather than DROP anything it cannot handle?
+
+The insert stage is tested against a live database in test_queue.py's opt-in
+class. Splitting them means the part with all the reasoning in it is covered
+with no database at all.
+
+Run:
+    python3 -m pytest chassis/pacman/tests/test_siyuan_migration.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+_spec = importlib.util.spec_from_file_location(
+    "pacman_migrate_siyuan_queue",
+    REPO_ROOT / "chassis" / "scripts" / "pacman-migrate-siyuan-queue.py",
+)
+migrate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(migrate)
+
+
+def block(block_id: str, content: str, created: str | None = None) -> dict:
+    return {"id": block_id, "content": content, "created": created}
+
+
+class TestUrlExtraction(unittest.TestCase):
+    def test_one_url_becomes_one_row(self):
+        rows, problems = migrate.plan([block("20260718120000-abc1234", "https://example.com/a")])
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["url"], "https://example.com/a")
+        self.assertEqual(problems, [])
+
+    def test_two_urls_in_one_block_become_two_rows(self):
+        """The exact failure the design note's verification step guards against."""
+        rows, _ = migrate.plan([
+            block("20260718120000-abc1234", "https://example.com/a and https://example.com/b")
+        ])
+        self.assertEqual([r["url"] for r in rows], ["https://example.com/a", "https://example.com/b"])
+
+    def test_urls_from_one_block_share_an_entry_group(self):
+        rows, _ = migrate.plan([
+            block("20260718120000-abc1234", "https://example.com/a https://example.com/b")
+        ])
+        self.assertEqual(len({r["entry_group"] for r in rows}), 1)
+
+    def test_urls_from_different_blocks_do_not_share_an_entry_group(self):
+        rows, _ = migrate.plan([
+            block("20260718120000-abc1234", "https://example.com/a"),
+            block("20260718130000-def5678", "https://example.com/b"),
+        ])
+        self.assertEqual(len({r["entry_group"] for r in rows}), 2)
+
+    def test_duplicate_urls_within_one_block_collapse(self):
+        rows, _ = migrate.plan([
+            block("20260718120000-abc1234", "https://example.com/a https://example.com/a")
+        ])
+        self.assertEqual(len(rows), 1)
+
+    def test_strips_trailing_punctuation(self):
+        rows, _ = migrate.plan([block("20260718120000-abc1234", "see https://example.com/a.")])
+        self.assertEqual(rows[0]["url"], "https://example.com/a")
+
+    def test_extracts_from_markdown_link_syntax(self):
+        rows, _ = migrate.plan([block("20260718120000-abc1234", "[title](https://example.com/a)")])
+        self.assertEqual(rows[0]["url"], "https://example.com/a")
+
+
+class TestNothingIsDroppedSilently(unittest.TestCase):
+    def test_a_block_with_no_parseable_url_is_reported(self):
+        """It matched '%http%' but yielded nothing. That must surface."""
+        rows, problems = migrate.plan([block("20260718120000-abc1234", "mentions http but has no link")])
+        self.assertEqual(rows, [])
+        self.assertEqual(len(problems), 1)
+        self.assertIn("no parseable URL", problems[0]["reason"])
+        self.assertEqual(problems[0]["block_id"], "20260718120000-abc1234")
+
+    def test_a_problem_carries_enough_context_to_recover_by_hand(self):
+        rows, problems = migrate.plan([block("20260718120000-abc1234", "mentions http somewhere")])
+        self.assertIn("mentions http somewhere", problems[0]["content"])
+
+    def test_an_unparseable_block_id_is_reported_not_guessed(self):
+        rows, problems = migrate.plan([block("not-a-siyuan-id", "https://example.com/a")])
+        self.assertEqual(rows, [])
+        self.assertEqual(len(problems), 1)
+        self.assertIn("unparseable timestamp", problems[0]["reason"])
+
+    def test_good_blocks_still_migrate_when_a_sibling_is_broken(self):
+        """One bad block must not abort the batch, only be reported alongside it."""
+        rows, problems = migrate.plan([
+            block("20260718120000-abc1234", "https://example.com/good"),
+            block("bad-id", "https://example.com/orphan"),
+        ])
+        self.assertEqual([r["url"] for r in rows], ["https://example.com/good"])
+        self.assertEqual(len(problems), 1)
+
+
+class TestTimestampReconstruction(unittest.TestCase):
+    def test_created_at_comes_from_the_block_id_prefix(self):
+        """The one time SiYuan's encoded timestamp is genuinely useful."""
+        iso, used_fallback = migrate.created_at_from_block_id("20260718120000-abc1234", None)
+        self.assertEqual(iso, "2026-07-18T12:00:00")
+        self.assertFalse(used_fallback)
+
+    def test_fifo_order_survives_the_move(self):
+        rows, _ = migrate.plan([
+            block("20260718120000-aaa1111", "https://example.com/first"),
+            block("20260718130000-bbb2222", "https://example.com/second"),
+            block("20260719090000-ccc3333", "https://example.com/third"),
+        ])
+        timestamps = [r["created_at"] for r in rows]
+        self.assertEqual(timestamps, sorted(timestamps))
+
+    def test_falls_back_to_the_siyuan_created_column_and_flags_it(self):
+        rows, problems = migrate.plan([block("bad-id", "https://example.com/a", created="20260718120000")])
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["created_at"], "2026-07-18T12:00:00")
+        self.assertTrue(any("SiYuan created column" in p["reason"] for p in problems))
+
+    def test_an_impossible_date_is_not_silently_accepted(self):
+        iso, _ = migrate.created_at_from_block_id("20261345990000-abc1234", None)
+        self.assertIsNone(iso)
+
+
+class TestRowShape(unittest.TestCase):
+    def test_every_row_carries_its_legacy_block_id(self):
+        """That column is the idempotency key. Without it a re-run duplicates."""
+        rows, _ = migrate.plan([block("20260718120000-abc1234", "https://example.com/a")])
+        self.assertEqual(rows[0]["legacy_block_id"], "20260718120000-abc1234")
+
+    def test_rows_carry_exactly_the_fields_the_insert_binds(self):
+        rows, _ = migrate.plan([block("20260718120000-abc1234", "https://example.com/a")])
+        self.assertEqual(set(rows[0]), {"url", "legacy_block_id", "entry_group", "created_at"})
+
+    def test_migration_source_tag_is_distinguishable(self):
+        """Migrated rows must be tellable from natively-enqueued ones afterwards."""
+        self.assertEqual(migrate.MIGRATION_SOURCE, "siyuan-migration")
+
+    def test_an_empty_queue_plans_nothing_and_reports_nothing(self):
+        self.assertEqual(migrate.plan([]), ([], []))
+
+
+class TestInsertIsIdempotent(unittest.TestCase):
+    def test_insert_uses_on_conflict_do_nothing_against_the_block_url_key(self):
+        """Re-running after a partial failure is the intended recovery path."""
+        class Cur:
+            def __init__(self):
+                self.sql = []
+
+            def execute(self, sql, params=()):
+                self.sql.append(" ".join(sql.split()))
+
+            def fetchone(self):
+                return ("qhtnbz",)
+
+        class Conn:
+            def __init__(self):
+                self.cur = Cur()
+                self.commits = 0
+
+            def cursor(self):
+                return self.cur
+
+            def commit(self):
+                self.commits += 1
+
+        conn = Conn()
+        rows, _ = migrate.plan([block("20260718120000-abc1234", "https://example.com/a")])
+        inserted, skipped = migrate.insert_rows(conn, rows)
+        self.assertEqual((inserted, skipped), (1, 0))
+        self.assertIn("ON CONFLICT (legacy_block_id, url)", conn.cur.sql[0])
+        self.assertIn("DO NOTHING", conn.cur.sql[0])
+
+    def test_a_row_that_already_exists_counts_as_skipped_not_inserted(self):
+        class Cur:
+            def execute(self, sql, params=()):
+                pass
+
+            def fetchone(self):
+                return None  # ON CONFLICT DO NOTHING returned no row
+
+        class Conn:
+            def cursor(self):
+                return Cur()
+
+            def commit(self):
+                pass
+
+        rows, _ = migrate.plan([block("20260718120000-abc1234", "https://example.com/a")])
+        self.assertEqual(migrate.insert_rows(Conn(), rows), (0, 1))
+
+
+@unittest.skipUnless(
+    __import__("os").environ.get("CHASSIS_TEST_PG_DSN"),
+    "CHASSIS_TEST_PG_DSN is not set - skipping the live-Postgres backfill tests. "
+    "These prove the ON CONFLICT idempotency key actually works. "
+    "Set CHASSIS_TEST_PG_DSN to a throwaway database to run them.",
+)
+class TestBackfillAgainstRealPostgres(unittest.TestCase):
+    """Idempotency is the property the operator relies on to retry a partial run."""
+
+    @classmethod
+    def setUpClass(cls):
+        import os
+
+        from chassis.db import apply_migrations, connect
+
+        cls.conn = connect(dsn=os.environ["CHASSIS_TEST_PG_DSN"])
+        apply_migrations(cls.conn)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.conn.close()
+
+    def setUp(self):
+        cur = self.conn.cursor()
+        cur.execute("DELETE FROM chassis_pacman_queue")
+        self.conn.commit()
+
+    def test_a_second_run_inserts_nothing(self):
+        rows, _ = migrate.plan([
+            block("20260718120000-abc1234", "https://example.com/a https://example.com/b"),
+            block("20260718130000-def5678", "https://example.com/c"),
+        ])
+        self.assertEqual(migrate.insert_rows(self.conn, rows), (3, 0))
+        self.assertEqual(migrate.insert_rows(self.conn, rows), (0, 3))
+
+    def test_migrated_rows_are_immediately_claimable_in_original_order(self):
+        from chassis.pacman import queue
+
+        rows, _ = migrate.plan([
+            block("20260718120000-aaa1111", "https://example.com/first"),
+            block("20260718130000-bbb2222", "https://example.com/second"),
+        ])
+        migrate.insert_rows(self.conn, rows)
+        claimed = [r["url"] for r in queue.claim(limit=10, conn=self.conn)]
+        self.assertEqual(claimed, ["https://example.com/first", "https://example.com/second"])
+
+    def test_natively_enqueued_rows_do_not_collide_with_each_other(self):
+        """The partial index must only constrain migrated rows, not normal ones."""
+        from chassis.pacman import queue
+
+        queue.add("https://example.com/same", conn=self.conn)
+        queue.add("https://example.com/same", conn=self.conn)
+        self.assertEqual(queue.pending_count(conn=self.conn), 2)
+
+
+class TestMigrationScriptDoesNotDelete(unittest.TestCase):
+    """Rollback depends on the SiYuan blocks surviving the backfill untouched."""
+
+    def test_no_delete_call_anywhere_in_the_script(self):
+        source = (REPO_ROOT / "chassis" / "scripts" / "pacman-migrate-siyuan-queue.py").read_text(encoding="utf-8")
+        for forbidden in ("removeDoc", "deleteBlock", "delete_block", "DELETE FROM"):
+            self.assertNotIn(forbidden, source, forbidden)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/chassis/pacman/tests/test_tokens.py
+++ b/chassis/pacman/tests/test_tokens.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""test_tokens.py - the approval token cannot collide with `approve N`.
+
+The bug this locks down is the one the design note called out as easy to miss
+and expensive to get wrong: `chassis/skills/pacman.md` matched approvals
+against a 14-digit SiYuan block ID, which a Notion UUID and an Obsidian path
+both fail. Moving the queue to Postgres does not fix that on its own, and a
+queue-migration test would never have caught it, so it gets its own file.
+
+The collision constraint is the sharp one. The outreach flow uses `approve 1 3 5`
+to approve drafts by list position. If a Pacman token could be read as a number,
+an approval would route into the wrong handler. That is prevented structurally
+rather than probabilistically - the token alphabet contains no digits - and this
+file proves it in both directions rather than asserting it once.
+
+Run:
+    python3 -m pytest chassis/pacman/tests/test_tokens.py -v
+"""
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from chassis.pacman.tokens import (  # noqa: E402
+    APPROVAL_RE,
+    TOKEN_ALPHABET,
+    TOKEN_LENGTH,
+    is_token,
+    new_token,
+    parse_approval,
+)
+
+# The outreach flow's pattern, reproduced here rather than imported: it lives in
+# the customer repo (skills/triggers/outreach-approval.md), and the point of
+# this file is to prove the two grammars are disjoint even though neither side
+# can see the other.
+OUTREACH_APPROVE_RE = re.compile(r"^approve\s+(\d+(?:\s+\d+)*)$", re.IGNORECASE)
+
+SAMPLE_SIZE = 20_000
+
+
+class TestTokenShape(unittest.TestCase):
+    def test_alphabet_has_no_digits(self):
+        """The structural guarantee everything else rests on."""
+        self.assertFalse(any(c.isdigit() for c in TOKEN_ALPHABET))
+
+    def test_alphabet_has_no_vowels(self):
+        """No vowels and no y means a token cannot spell an English word."""
+        for vowel in "aeiouy":
+            self.assertNotIn(vowel, TOKEN_ALPHABET)
+
+    def test_alphabet_excludes_visually_ambiguous_characters(self):
+        """Sean retypes these on a phone. i/l/1 and o/0 must not appear."""
+        for ambiguous in "ilo":
+            self.assertNotIn(ambiguous, TOKEN_ALPHABET)
+
+    def test_generated_tokens_are_well_formed(self):
+        for _ in range(1000):
+            token = new_token()
+            self.assertEqual(len(token), TOKEN_LENGTH)
+            self.assertTrue(is_token(token))
+            self.assertTrue(set(token) <= set(TOKEN_ALPHABET))
+
+
+class TestNoCollisionWithNumericApprove(unittest.TestCase):
+    """Both directions. Either one alone would leave the other unproven."""
+
+    def test_no_generated_token_is_numeric(self):
+        for _ in range(SAMPLE_SIZE):
+            token = new_token()
+            self.assertFalse(token.isdigit())
+            with self.assertRaises(ValueError):
+                int(token)
+
+    def test_no_generated_token_matches_the_outreach_pattern(self):
+        for _ in range(SAMPLE_SIZE):
+            self.assertIsNone(OUTREACH_APPROVE_RE.match(f"approve {new_token()}"))
+
+    def test_numeric_approvals_are_not_parsed_as_pacman_approvals(self):
+        """`approve 1 3 5` belongs to the outreach handler and must stay there."""
+        for message in ("approve 1", "approve 3 5", "approve 1 3 5", "approve 42", "approve 007"):
+            self.assertIsNone(parse_approval(message), message)
+            self.assertIsNotNone(OUTREACH_APPROVE_RE.match(message), message)
+
+    def test_the_two_grammars_are_disjoint_over_a_shared_input_set(self):
+        """No single message may be accepted by both handlers."""
+        messages = [f"approve {new_token()}" for _ in range(2000)]
+        messages += ["approve 1", "approve 12", "approve 1 2 3"]
+        for message in messages:
+            pacman = parse_approval(message) is not None
+            outreach = OUTREACH_APPROVE_RE.match(message) is not None
+            self.assertFalse(pacman and outreach, f"both handlers claim: {message}")
+
+
+class TestNoWordCollision(unittest.TestCase):
+    def test_common_trailing_words_are_not_tokens(self):
+        """`approve later` must not be read as a token and silently approved."""
+        for word in ("all", "later", "yes", "now", "please", "this", "rhythm", "flight"):
+            self.assertFalse(is_token(word), word)
+
+    def test_generated_tokens_contain_no_vowel(self):
+        for _ in range(5000):
+            self.assertFalse(set(new_token()) & set("aeiouy"))
+
+
+class TestApprovalParsing(unittest.TestCase):
+    def test_parses_action_and_token(self):
+        parsed = parse_approval("approve qhtnbz")
+        self.assertEqual(parsed["action"], "approve")
+        self.assertEqual(parsed["id"], "qhtnbz")
+        self.assertIsNone(parsed["trailer"])
+        self.assertEqual(parsed["legacy"], "false")
+
+    def test_parses_reject_and_defer(self):
+        for action in ("reject", "defer"):
+            parsed = parse_approval(f"{action} qhtnbz")
+            self.assertEqual(parsed["action"], action)
+
+    def test_captures_the_caveat_trailer(self):
+        parsed = parse_approval("approve qhtnbz but scope it to the gather script only")
+        self.assertEqual(parsed["id"], "qhtnbz")
+        self.assertEqual(parsed["trailer"], "but scope it to the gather script only")
+
+    def test_case_insensitive_action(self):
+        self.assertEqual(parse_approval("APPROVE qhtnbz")["action"], "approve")
+
+    def test_legacy_block_id_still_parses_and_is_flagged(self):
+        """In-flight proposals posted before the cutover must remain approvable.
+
+        Flagged rather than silently accepted so the handler knows to resolve it
+        via proposal_doc_id instead of by token.
+        """
+        parsed = parse_approval("approve 20260718120000-abc1234")
+        self.assertEqual(parsed["id"], "20260718120000-abc1234")
+        self.assertEqual(parsed["legacy"], "true")
+        self.assertFalse(is_token("20260718120000-abc1234"))
+
+    def test_rejects_a_notion_uuid_and_an_obsidian_path(self):
+        """Neither should ever have been an approval handle. Both stay rejected.
+
+        The fix is not "widen the regex until UUIDs pass" - it is that the
+        approval handle stopped being a document id at all.
+        """
+        self.assertIsNone(parse_approval("approve 1f2e3d4c5b6a7988990011223344556677"))
+        self.assertIsNone(parse_approval("approve To Investigate/2026-07-19-thing.md"))
+
+    def test_rejects_wrong_length_tokens(self):
+        self.assertIsNone(parse_approval("approve qhtnb"))
+        self.assertIsNone(parse_approval("approve qhtnbzz"))
+
+    def test_rejects_unrelated_messages(self):
+        for message in ("Pacman https://example.com", "approve", "hello qhtnbz", ""):
+            self.assertIsNone(parse_approval(message), message)
+
+    def test_module_regex_and_parse_helper_agree(self):
+        """Callers copying APPROVAL_RE must get the same answer as parse_approval."""
+        for message in ("approve qhtnbz", "approve 1", "defer 20260718120000-abc1234", "nope"):
+            self.assertEqual(
+                APPROVAL_RE.match(message) is not None,
+                parse_approval(message) is not None,
+                message,
+            )
+
+
+class TestSkillDocumentsTheSamePattern(unittest.TestCase):
+    """The skill is prose the model follows, so a drifted regex there is a live bug.
+
+    Config promising more than code delivers is the recurring failure in this
+    codebase; this asserts the documented pattern is the implemented one.
+    """
+
+    def test_skill_quotes_the_current_alphabet_and_length(self):
+        skill = (Path(__file__).resolve().parents[2] / "skills" / "pacman.md").read_text(encoding="utf-8")
+        self.assertIn(f"[{TOKEN_ALPHABET}]{{{TOKEN_LENGTH}}}", skill)
+
+    def test_skill_no_longer_names_the_siyuan_queue_block(self):
+        skill = (Path(__file__).resolve().parents[2] / "skills" / "pacman.md").read_text(encoding="utf-8")
+        # One surviving mention is allowed: the note pointing at the one-time
+        # backfill script, which genuinely still reads it.
+        self.assertNotIn("mcp__siyuan__delete_block", skill)
+        self.assertNotIn("mcp__siyuan__create_doc", skill)
+        self.assertNotIn("mcp__siyuan__sql_query", skill)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/chassis/pacman/tokens.py
+++ b/chassis/pacman/tokens.py
@@ -1,0 +1,110 @@
+"""Pacman approval tokens - the backend-independent replacement for block IDs.
+
+## The problem being solved
+
+`chassis/skills/pacman.md` used to match installer approvals against
+`^(approve|reject|defer)\\s+(\\d{14}-\\w{7})...$`. That pattern is a SiYuan
+block ID and nothing else. A Notion UUID fails it, an Obsidian vault path
+fails it, and moving the queue to Postgres does not fix it on its own - it is
+an independently SiYuan-shaped assumption sitting in the approval path, which
+is exactly why a queue-migration test would never have caught it.
+
+Once the queue row is the durable record, the approval handle should be the
+queue row's own identifier and not a second brain's identifier at all. Nothing
+about approving a proposal needs to know where the proposal document was
+filed; `proposal_doc_id` already holds that, opaquely, for the one step that
+does. So the token is ours, it is stable across every backend, and it is the
+same string whether the install runs SiYuan, Obsidian, Notion, or no second
+brain.
+
+## Why this alphabet
+
+    bcdfghjkmnpqrstvwxz   19 characters, exactly 6 of them per token
+
+Three constraints drove it, in order of how expensive they are to get wrong:
+
+1. **It must never collide with the numeric `approve N` form.** The outreach
+   flow uses `approve 1 3 5` to approve drafts by list position. A Pacman
+   token that could be read as a number would route an approval into the wrong
+   handler. Excluding all ten digits makes this a structural guarantee rather
+   than a probability: `int(token)` cannot succeed on a string containing no
+   digits, so no token in this space is ever a valid `approve N` argument.
+   This is proved by test, both directions, in tests/test_tokens.py.
+
+2. **It must not accidentally spell a word.** Dropping the vowels (and `y`,
+   which acts as one) means a token cannot be an English word - English has no
+   six-letter vowel-free words, and near-misses like "rhythm" need the `y`
+   this alphabet does not have. That keeps `approve later` and similar from
+   ever being read as a token, and keeps generated tokens from being obscene
+   or confusing.
+
+3. **Sean approves from his phone.** Six characters, one case, no digits to
+   confuse with letters, and no visually ambiguous pairs - the alphabet has no
+   `i`/`l`/`1`, no `o`/`0`. A 32-character Notion UUID fails this badly enough
+   that the design note called it out by name.
+
+19**6 is 47 million, against a queue that holds tens of live items. Collisions
+are handled by retry at insert against the UNIQUE constraint rather than
+assumed away.
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+
+# No vowels (a, e, i, o, u), no y, no digits. See module docstring for why
+# each of those exclusions is load-bearing.
+TOKEN_ALPHABET = "bcdfghjkmnpqrstvwxz"
+TOKEN_LENGTH = 6
+
+TOKEN_RE = re.compile(rf"^[{TOKEN_ALPHABET}]{{{TOKEN_LENGTH}}}$")
+
+# Legacy SiYuan block ID, still accepted by the approval matcher so proposals
+# posted to Discord before the cutover can still be approved. Deprecated: the
+# skill stops emitting these the moment this ships, and this alternative can be
+# dropped once no pre-cutover proposal is outstanding.
+LEGACY_BLOCK_ID_RE = re.compile(r"^\d{14}-\w{7}$")
+
+# The full approval matcher the skill and any Discord handler should use.
+# The numeric `approve N` form used by the outreach flow does not match this
+# pattern, because neither alternative in the id group admits a bare number.
+APPROVAL_RE = re.compile(
+    r"^(?P<action>approve|reject|defer)\s+"
+    rf"(?P<id>[{TOKEN_ALPHABET}]{{{TOKEN_LENGTH}}}|\d{{14}}-\w{{7}})"
+    r"(?:\s+(?P<trailer>.+))?$",
+    re.IGNORECASE,
+)
+
+
+def new_token() -> str:
+    """Generate one approval token. Uniqueness is enforced by the DB, not here."""
+    return "".join(secrets.choice(TOKEN_ALPHABET) for _ in range(TOKEN_LENGTH))
+
+
+def is_token(candidate: str) -> bool:
+    """True for a well-formed current-format token. False for legacy block IDs."""
+    return bool(TOKEN_RE.match(candidate))
+
+
+def parse_approval(message: str) -> dict[str, str | None] | None:
+    """Parse an installer approval message, or return None if it is not one.
+
+    Returns {'action', 'id', 'trailer', 'legacy'}. `legacy` is 'true' when the
+    id matched the deprecated SiYuan block-ID form, so callers can log that a
+    pre-cutover proposal was approved and know to look it up by
+    proposal_doc_id rather than by token.
+
+    Returns None for the numeric `approve N` outreach form, which is the whole
+    point - that message belongs to a different handler.
+    """
+    match = APPROVAL_RE.match(message.strip())
+    if not match:
+        return None
+    identifier = match.group("id")
+    return {
+        "action": match.group("action").lower(),
+        "id": identifier,
+        "trailer": match.group("trailer"),
+        "legacy": "true" if LEGACY_BLOCK_ID_RE.match(identifier) else "false",
+    }

--- a/chassis/scheduled-tasks/pacman-drain-prompt.md
+++ b/chassis/scheduled-tasks/pacman-drain-prompt.md
@@ -1,45 +1,75 @@
 # Pacman queue drain
 
-The `/To Investigate` queue (SiYuan block `${PACMAN_SIYUAN_QUEUE_BLOCK_ID}`) has unprocessed URL blocks. Drain them via the Pacman 4-gate pipeline.
+The Pacman queue has unprocessed URLs. Drain them via the 4-gate pipeline.
 
-## Backend support - read this before running
+## Backend support
 
-This prompt is only PARTLY backend-neutral, and the split is deliberate rather than an oversight.
+This prompt is backend-neutral end to end, as of the queue move to Postgres
+(2026-07-19, `docs/pacman-queue-storage.md`). It runs identically on SiYuan,
+Obsidian, Notion, and on an install running `second_brain.mode: adapter`.
 
-- **Queue storage is SiYuan-only.** Pacman stores its queue as SiYuan blocks and uses block IDs as queue-entry handles. Notion and Obsidian have no equivalent - see `docs/pacman-queue-storage.md` for why block IDs do not port and what replaces them. Steps 2 and 4 below therefore still name `mcp__siyuan__*`, and they are the only steps that do.
-- **Everything Pacman writes is backend-neutral.** Proposals and drop records go through `mcp__secondbrain__*` (steps 5 and 6), so they land correctly on whatever backend the install runs.
+- **Queue storage is Postgres**, reached through `chassis/scripts/pacman-queue.py`.
+  No SiYuan MCP tool is named anywhere in this prompt. That was the defect: the
+  queue used SiYuan block IDs as handles, so on adapter-mode installs - where
+  the native SiYuan MCP server is deliberately not registered - the drain
+  silently did nothing.
+- **Everything Pacman writes goes through `mcp__secondbrain__*`**, so proposals
+  and drop records land on whatever backend the install runs.
 
-Concretely: on a Notion or Obsidian install, and on ANY install running `second_brain.mode: adapter` (where `mcp__siyuan__*` is not registered at all), the queue steps cannot run. If `mcp__siyuan__sql_query` is unavailable, do NOT improvise a substitute and do NOT report a clean drain. Print
-
-```
-ERROR: pacman queue drain requires the siyuan MCP server, which is not available on this install. See docs/pacman-queue-storage.md.
-```
-
-to stdout and exit non-zero so the dispatcher alerts. Silently draining nothing is the failure mode this whole Stage 2 pass exists to remove.
+If `pacman-queue.py` exits non-zero, do NOT improvise a substitute and do NOT report a clean drain. Print its stderr and stop. Silently draining nothing is
+the failure mode this whole line of work exists to remove.
 
 ## Steps
 
-1. **Read `chassis/skills/pacman.md` in full** before doing anything else. The skill defines the 4 gates, drop logging, proposal format, approval flow, and queue management. Follow it exactly.
+1. **Read `chassis/skills/pacman.md` in full** before doing anything else. The
+   skill defines the 4 gates, drop logging, proposal format, approval flow, and
+   queue management. Follow it exactly.
 
-2. **Read the queue.** SiYuan-only, per the backend note above. Use `mcp__siyuan__sql_query` to list all blocks under `/To Investigate` that contain a URL:
-   ```sql
-   SELECT id, content FROM blocks
-   WHERE root_id = '${PACMAN_SIYUAN_QUEUE_BLOCK_ID}'
-     AND id != '${PACMAN_SIYUAN_QUEUE_BLOCK_ID}'
-     AND type IN ('h', 'p', 'l', 'i')
-     AND content LIKE '%http%'
-   ORDER BY created ASC
-   LIMIT ${PACMAN_MAX_BATCH_URLS}
+2. **Claim a batch.** Oldest-first, capped:
+   ```bash
+   python3 "$CHASSIS_ROOT/scripts/pacman-queue.py" claim --limit ${PACMAN_MAX_BATCH_URLS}
    ```
-   Cap at `${PACMAN_MAX_BATCH_URLS}` URLs per fire (default 10). The `created ASC` order means oldest queued URL is processed first (FIFO).
+   This returns a JSON array of `{token, url, source, entry_group, created_at}`
+   and marks those rows claimed so a concurrent drain cannot take them. An empty
+   array means no work - stop here and post nothing.
 
-3. **For each block:** extract the URL(s) from the `content` field. A block may contain one or more URLs (use a regex match on `https?://...`). Process each URL through the 4 gates per `chassis/skills/pacman.md`.
+   `token` is the row's approval token: six lowercase letters, e.g. `qhtnbz`.
+   It is what the installer types to approve. Do not invent one, do not use a
+   document id, and do not use a SiYuan block ID.
 
-4. **After processing each URL** (drop OR proposal - verdict regardless): **delete the source block** from `/To Investigate` via `mcp__siyuan__delete_block` (SiYuan-only, per the backend note above). Non-negotiable rule per the skill - true queue semantics. If a single block had multiple URLs, delete the block only after ALL URLs from it have been processed.
+3. **For each claimed row:** run the URL through the 4 gates per
+   `chassis/skills/pacman.md`. One row is one URL, so there is no per-block URL
+   extraction to do any more.
 
-5. **Drops** post a 1-line note to the configured Discord channel (`chat_id: ${PACMAN_DISCORD_CHAT_ID}`) AND append a row to the Dropped archive via `mcp__secondbrain__append_to_doc(doc_id: "${PACMAN_DROPPED_DOC_ID}", content: ...)`. Format per the skill.
+4. **After processing each URL** (drop OR proposal - verdict regardless), mark
+   the row done:
+   ```bash
+   python3 "$CHASSIS_ROOT/scripts/pacman-queue.py" complete <token> --verdict <drop|proposal|fetch_failed> [--gate N] [--doc-id <adapter-doc-id>]
+   ```
+   Non-negotiable per the skill - a row that survives processing gets
+   re-processed forever. `complete` is exactly-once: calling it twice for the
+   same token is a harmless no-op that reports `"changed": false`, so retrying
+   a step is safe.
 
-6. **Proposals** write a sub-doc via `mcp__secondbrain__create_doc(parent: "${PACMAN_PROPOSALS_PARENT}", title: "YYYY-MM-DD-<slug>", body: ...)` AND post a 4-section TLDR to the configured Discord channel. Use the `deeplink` that `create_doc` returns - do not construct a URL yourself, the format differs per backend. Format per the skill.
+   If you cannot finish a claimed row (you ran out of context, a tool failed),
+   hand it back instead of leaving it claimed:
+   ```bash
+   python3 "$CHASSIS_ROOT/scripts/pacman-queue.py" release <token>
+   ```
+
+5. **Drops** post a 1-line note to the configured Discord channel
+   (`chat_id: ${PACMAN_DISCORD_CHAT_ID}`) AND append a row to the Dropped
+   archive via `mcp__secondbrain__append_to_doc(doc_id: "${PACMAN_DROPPED_DOC_ID}", content: ...)`.
+   Format per the skill. Then `complete <token> --verdict drop --gate N`.
+
+6. **Proposals** write a sub-doc via
+   `mcp__secondbrain__create_doc(parent: "${PACMAN_PROPOSALS_PARENT}", title: "YYYY-MM-DD-<slug>", body: ...)`
+   AND post a 4-section TLDR to the configured Discord channel quoting the
+   row's `token` in the approve/reject/defer line. Use the `deeplink` that
+   `create_doc` returns - do not construct a URL yourself, the format differs
+   per backend. Then
+   `complete <token> --verdict proposal --doc-id <the id create_doc returned>`,
+   which is what lets the approval step later find the document from the token.
 
 7. **End-of-batch summary** to the configured Discord channel:
    ```
@@ -49,16 +79,24 @@ to stdout and exit non-zero so the dispatcher alerts. Silently draining nothing 
 
 ## Hard rules
 
-- Cap `${PACMAN_MAX_BATCH_URLS}` URLs per fire. If queue has more, leave them - the next drain picks them up.
-- Process oldest-first (FIFO).
-- Always delete the source block after processing, even on drops. Otherwise the next drain re-processes the same URLs.
-- Respect `PACMAN_HARD_PAUSE` - if the file exists at `$CHASSIS_HOME/PACMAN_HARD_PAUSE`, post a one-liner to the configured channel confirming the pause and exit without processing.
-- Don't editorialize in proposal recommendations beyond what the skill specifies. Pacman surfaces evidence; the installer decides.
-- If a URL can't be fetched (404, timeout, paywall, etc.), drop it at gate 0 with reason "fetch failed" and a 1-line note. Don't retry within the same fire - the next drain will re-encounter the URL only if the source block wasn't deleted, which it should have been.
+- Cap `${PACMAN_MAX_BATCH_URLS}` URLs per fire. `claim --limit` enforces this;
+  if the queue has more, leave them and the next drain picks them up.
+- Process oldest-first (FIFO). `claim` already orders by `created_at ASC`.
+- Always `complete` a row after processing, even on drops.
+- Respect `PACMAN_HARD_PAUSE` - if the file exists at
+  `$CHASSIS_HOME/PACMAN_HARD_PAUSE`, post a one-liner to the configured channel
+  confirming the pause and exit without processing or claiming.
+- Don't editorialize in proposal recommendations beyond what the skill
+  specifies. Pacman surfaces evidence; the installer decides.
+- If a URL can't be fetched (404, timeout, paywall), drop it at gate 0 with
+  reason "fetch failed" and a 1-line note, then
+  `complete <token> --verdict fetch_failed --gate 0`. Don't retry within the
+  same fire.
 
 ## Logging
 
-Every URL processed (drop OR proposal OR fetch-failure) gets a JSONL entry in `$CHASSIS_HOME/logs/pacman/YYYY-MM-DD.jsonl`:
+Every URL processed (drop OR proposal OR fetch-failure) gets a JSONL entry in
+`$CHASSIS_HOME/logs/pacman/YYYY-MM-DD.jsonl`:
 ```json
-{"ts": "...", "url": "...", "verdict": "drop|proposal|fetch_failed", "gate": 0|1|2|3|4|null, "doc_id": "...", "source": "telegram|discord|manual|heartbeat-drain"}
+{"ts": "...", "token": "...", "url": "...", "verdict": "drop|proposal|fetch_failed", "gate": 0|1|2|3|4|null, "doc_id": "...", "source": "telegram|discord|manual|heartbeat-drain"}
 ```

--- a/chassis/scripts/gather-pacman-queue.sh
+++ b/chassis/scripts/gather-pacman-queue.sh
@@ -1,31 +1,46 @@
 #!/usr/bin/env bash
-# gather-pacman-queue.sh — Count unprocessed URL blocks in the SiYuan
-# /To Investigate queue (Pacman's inbound). Called by the heartbeat
-# dispatcher (cadence per the installer's `pacman-drain` heartbeat entry,
-# typically every 4h). Outputs JSON `{"count": N}` where N is the number
-# of blocks under the queue parent that contain http/https URLs.
+# gather-pacman-queue.sh - Count claimable URLs in the Pacman queue.
 #
-# Output contract: JSON object with `count` field, per dispatcher
-# threshold-condition logic. The dispatcher only fires Claude when N > 0,
-# so the steady-state cost is zero Claude tokens.
+# Called by the heartbeat dispatcher (cadence per the installer's
+# `pacman-drain` heartbeat entry, typically every 4h). Outputs JSON
+# `{"count": N}` where N is the number of queue rows a drain could pick up
+# right now.
 #
-# Required env (chassis bootstrap hydrates from chassis.config.yaml or
-# the installer's .env; see chassis/skills/pacman.md for the contract):
-#   SIYUAN_TOKEN                    SiYuan API token
-#   PACMAN_SIYUAN_QUEUE_BLOCK_ID    /To Investigate queue parent block ID
-#                                   (format: YYYYMMDDHHMMSS-XXXXXXX)
+# Output contract: JSON object with a `count` field, per the dispatcher's
+# threshold-condition logic. The dispatcher only fires Claude when N > 0, so
+# the steady-state cost is zero Claude tokens.
+#
+# What changed (2026-07-19, docs/pacman-queue-storage.md): this used to run a
+# SiYuan SQL query counting blocks under PACMAN_SIYUAN_QUEUE_BLOCK_ID, which
+# meant the count was always zero on Obsidian, Notion, and adapter-mode
+# installs. It now reads chassis_pacman_queue via chassis/scripts/pacman-queue.py.
+#
+# The count predicate is NOT reimplemented here. It lives in
+# chassis/pacman/queue.py (PENDING_PREDICATE) and is shared with the claim
+# path, because a count that disagrees with what a drain actually picks up
+# either burns Claude tokens on an empty queue or leaves a queue stuck.
+#
+# Failure behaviour changed too, deliberately. The old script printed
+# `{"count": 0, "reason": "..."}` and exited 0 on every failure, so an
+# unreachable backend looked exactly like an empty queue - the silent-drain
+# failure mode PR #78 exists to remove. A DB error now exits non-zero, which
+# the dispatcher records as `gather_failed` and alerts on.
+#
+# Required env:
+#   CHASSIS_PG_DSN (or BEHALFBOT_PG_DSN / JAX_PG_DSN)  Postgres DSN
 #
 # Optional env:
-#   SIYUAN_URL                      SiYuan API endpoint (default: http://localhost:6806)
-#   CHASSIS_HOME / CHASSIS_HOME         Install root (for .env source + pause file)
-#   PACMAN_HARD_PAUSE               File path to a pause sentinel; if it
-#                                   exists, the script returns count=0
-#                                   without querying. Default:
-#                                   $CHASSIS_HOME/PACMAN_HARD_PAUSE
+#   CHASSIS_HOME / CUSTOMER_HOME  Install root (for .env source + pause file)
+#   PACMAN_HARD_PAUSE             Pause sentinel path; if the file exists the
+#                                 script returns count=0 without querying.
+#                                 Default: $CHASSIS_HOME/PACMAN_HARD_PAUSE
+#   PACMAN_CLAIM_TIMEOUT_MINUTES  Minutes before a claimed-but-unprocessed row
+#                                 becomes claimable again (default 60)
 
 set -euo pipefail
 
-CHASSIS_ROOT="${CHASSIS_HOME:-${CHASSIS_HOME:-$(cd "$(dirname "$0")/../.." && pwd)}}"
+CHASSIS_ROOT="${CHASSIS_HOME:-${CUSTOMER_HOME:-$(cd "$(dirname "$0")/../.." && pwd)}}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 PAUSE_FILE="${PACMAN_HARD_PAUSE:-$CHASSIS_ROOT/PACMAN_HARD_PAUSE}"
 if [[ -f "$PAUSE_FILE" ]]; then
@@ -39,39 +54,9 @@ set -f
 [[ -f "$CHASSIS_ROOT/.env" ]] && source "$CHASSIS_ROOT/.env" 2>/dev/null || true
 set +f
 
-if [[ -z "${SIYUAN_TOKEN:-}" ]]; then
-  echo '{"count": 0, "reason": "SIYUAN_TOKEN not set"}'
-  exit 0
+if ! OUTPUT=$(python3 "$SCRIPT_DIR/pacman-queue.py" count 2>&1); then
+  echo "gather-pacman-queue: $OUTPUT" >&2
+  exit 1
 fi
 
-if [[ -z "${PACMAN_SIYUAN_QUEUE_BLOCK_ID:-}" ]]; then
-  echo '{"count": 0, "reason": "PACMAN_SIYUAN_QUEUE_BLOCK_ID not set"}'
-  exit 0
-fi
-
-SIYUAN_URL="${SIYUAN_URL:-http://localhost:6806}"
-TO_INVESTIGATE_ID="$PACMAN_SIYUAN_QUEUE_BLOCK_ID"
-
-# Query: count blocks under the queue parent that contain a URL (http/https)
-# and are not the parent doc itself.
-SQL='SELECT COUNT(*) AS n FROM blocks WHERE root_id = '"'"'${TO_INVESTIGATE_ID}'"'"' AND id != '"'"'${TO_INVESTIGATE_ID}'"'"' AND type IN ('"'"'h'"'"', '"'"'p'"'"', '"'"'l'"'"', '"'"'i'"'"') AND content LIKE '"'"'%http%'"'"''
-SQL_EXPANDED="${SQL//\$\{TO_INVESTIGATE_ID\}/$TO_INVESTIGATE_ID}"
-
-PAYLOAD=$(jq -nc --arg stmt "$SQL_EXPANDED" '{stmt: $stmt}')
-
-RESP=$(curl -sf -X POST \
-  -H "Authorization: Token ${SIYUAN_TOKEN}" \
-  -H "Content-Type: application/json" \
-  --data "$PAYLOAD" \
-  "${SIYUAN_URL}/api/query/sql" 2>/dev/null || echo '{"code":-1}')
-
-CODE=$(echo "$RESP" | jq -r '.code // -1')
-
-if [[ "$CODE" != "0" ]]; then
-  echo '{"count": 0, "reason": "siyuan query failed"}'
-  exit 0
-fi
-
-COUNT=$(echo "$RESP" | jq -r '.data[0].n // 0')
-
-echo "{\"count\": $COUNT}"
+echo "$OUTPUT"

--- a/chassis/scripts/pacman-migrate-siyuan-queue.py
+++ b/chassis/scripts/pacman-migrate-siyuan-queue.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""pacman-migrate-siyuan-queue.py - One-time backfill of the live SiYuan queue.
+
+Reads the URL blocks under the SiYuan /To Investigate parent and writes one
+chassis_pacman_queue row per URL. Runs once per install; Sean's is the only
+install with a populated queue.
+
+Idempotent. Every row it writes carries `legacy_block_id`, and the partial
+unique index ux_pacman_queue_legacy_block_url on (legacy_block_id, url) makes
+a re-run a no-op rather than a duplicate. Re-running after a partial failure is
+the intended recovery, not a hazard.
+
+Nothing is deleted. The SiYuan blocks are left exactly where they are - this
+script only reads them. Cleaning them up is a separate, later, manual step
+once a full drain cycle has run clean against Postgres. Disk is cheap; an
+unrecoverable queue is not.
+
+Nothing is dropped silently. A block whose URL cannot be extracted, or whose
+row fails to insert, is reported on stderr and counted in the summary, and the
+script exits non-zero. Read the summary before you unfreeze Pacman.
+
+Ordering: created_at is reconstructed from the leading 14 digits of the SiYuan
+block ID (YYYYMMDDHHMMSS, install-local time). This is the one place that
+encoded timestamp is genuinely useful, and it is why FIFO order survives the
+move. Blocks with an unparseable ID prefix fall back to the SiYuan `created`
+column, and are reported.
+
+Usage:
+    # 1. Freeze first. Both gather-pacman-queue.sh and pacman.sh honor this.
+    touch "$CHASSIS_HOME/PACMAN_HARD_PAUSE"
+
+    # 2. Snapshot. This is the rollback, keep the file.
+    python3 chassis/scripts/pacman-migrate-siyuan-queue.py --snapshot queue-snapshot.json --dry-run
+
+    # 3. Backfill.
+    python3 chassis/scripts/pacman-migrate-siyuan-queue.py --snapshot queue-snapshot.json
+
+Required env:
+    SIYUAN_TOKEN                    SiYuan API token
+    PACMAN_SIYUAN_QUEUE_BLOCK_ID    /To Investigate parent block ID
+    CHASSIS_PG_DSN                  Postgres DSN (or BEHALFBOT_PG_DSN / JAX_PG_DSN)
+
+Optional env:
+    SIYUAN_URL                      Default http://localhost:6806
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+_PACKAGE_PARENT = Path(__file__).resolve().parents[2]
+if str(_PACKAGE_PARENT) not in sys.path:
+    sys.path.insert(0, str(_PACKAGE_PARENT))
+
+from chassis.db import ChassisDBUnavailable, connect  # noqa: E402
+from chassis.pacman.tokens import new_token  # noqa: E402
+
+URL_RE = re.compile(r"https?://[^\s<>\"'`,)\]]+", re.IGNORECASE)
+BLOCK_ID_TS_RE = re.compile(r"^(\d{14})-")
+
+DEFAULT_SIYUAN_URL = "http://localhost:6806"
+MIGRATION_SOURCE = "siyuan-migration"
+
+
+def fetch_queue_blocks(siyuan_url: str, token: str, parent_id: str) -> list[dict]:
+    """Read the queue blocks from SiYuan, oldest first.
+
+    Same predicate the old gather script counted with, so the snapshot and the
+    old count agree. If they do not, that discrepancy is itself the signal.
+    """
+    stmt = (
+        "SELECT id, content, created FROM blocks "
+        f"WHERE root_id = '{parent_id}' AND id != '{parent_id}' "
+        "AND type IN ('h', 'p', 'l', 'i') AND content LIKE '%http%' "
+        "ORDER BY created ASC"
+    )
+    req = urllib.request.Request(
+        f"{siyuan_url.rstrip('/')}/api/query/sql",
+        data=json.dumps({"stmt": stmt}).encode(),
+        method="POST",
+    )
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Authorization", f"Token {token}")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        payload = json.loads(resp.read().decode())
+    if payload.get("code") != 0:
+        raise RuntimeError(f"SiYuan query failed: {str(payload)[:300]}")
+    return payload.get("data") or []
+
+
+def created_at_from_block_id(block_id: str, fallback: str | None) -> tuple[str | None, bool]:
+    """Return (ISO timestamp, used_fallback). See module docstring on ordering."""
+    match = BLOCK_ID_TS_RE.match(block_id or "")
+    if match:
+        try:
+            return datetime.strptime(match.group(1), "%Y%m%d%H%M%S").isoformat(), False
+        except ValueError:
+            pass
+    if fallback:
+        match = BLOCK_ID_TS_RE.match(str(fallback) + "-")
+        if match:
+            try:
+                return datetime.strptime(match.group(1), "%Y%m%d%H%M%S").isoformat(), True
+            except ValueError:
+                pass
+    return None, True
+
+
+def plan(blocks: list[dict]) -> tuple[list[dict], list[dict]]:
+    """Split blocks into (rows to insert, problems). One row per URL."""
+    rows: list[dict] = []
+    problems: list[dict] = []
+    for block in blocks:
+        block_id = block.get("id") or ""
+        content = block.get("content") or ""
+        urls = []
+        seen: set[str] = set()
+        for raw in URL_RE.findall(content):
+            cleaned = raw.rstrip(".,;:!?)\"'`")
+            if cleaned not in seen:
+                seen.add(cleaned)
+                urls.append(cleaned)
+        if not urls:
+            # The gather predicate matched '%http%' but no parseable URL came
+            # out. Report it - this is exactly the "counted as one entry when
+            # it was two" class of failure step 4 of the design note guards.
+            problems.append({"block_id": block_id, "reason": "no parseable URL", "content": content[:200]})
+            continue
+        created_at, used_fallback = created_at_from_block_id(block_id, block.get("created"))
+        if created_at is None:
+            problems.append({"block_id": block_id, "reason": "unparseable timestamp", "content": content[:200]})
+            continue
+        if used_fallback:
+            problems.append({"block_id": block_id, "reason": "timestamp from SiYuan created column, not block id"})
+        # URLs from one block share an entry_group - requirement 5.
+        group = str(uuid.uuid4())
+        for url in urls:
+            rows.append({
+                "url": url,
+                "legacy_block_id": block_id,
+                "entry_group": group,
+                "created_at": created_at,
+            })
+    return rows, problems
+
+
+def insert_rows(conn, rows: list[dict]) -> tuple[int, int]:
+    """Insert rows, skipping ones already migrated. Returns (inserted, skipped)."""
+    cur = conn.cursor()
+    inserted = 0
+    for row in rows:
+        cur.execute(
+            "INSERT INTO chassis_pacman_queue "
+            "(token, url, source, source_ref, entry_group, created_at, legacy_block_id) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s) "
+            "ON CONFLICT (legacy_block_id, url) WHERE legacy_block_id IS NOT NULL "
+            "DO NOTHING RETURNING token",
+            (
+                new_token(),
+                row["url"],
+                MIGRATION_SOURCE,
+                row["legacy_block_id"],
+                row["entry_group"],
+                row["created_at"],
+                row["legacy_block_id"],
+            ),
+        )
+        if cur.fetchone():
+            inserted += 1
+    conn.commit()
+    return inserted, len(rows) - inserted
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Backfill the SiYuan Pacman queue into Postgres.")
+    parser.add_argument("--dry-run", action="store_true", help="Read and report, insert nothing.")
+    parser.add_argument("--snapshot", type=Path, default=None, help="Write the raw SiYuan rows here before inserting.")
+    args = parser.parse_args(argv)
+
+    token = os.environ.get("SIYUAN_TOKEN")
+    parent_id = os.environ.get("PACMAN_SIYUAN_QUEUE_BLOCK_ID")
+    siyuan_url = os.environ.get("SIYUAN_URL", DEFAULT_SIYUAN_URL)
+    if not token or not parent_id:
+        print("ERROR: SIYUAN_TOKEN and PACMAN_SIYUAN_QUEUE_BLOCK_ID must both be set.", file=sys.stderr)
+        return 2
+
+    try:
+        blocks = fetch_queue_blocks(siyuan_url, token, parent_id)
+    except Exception as exc:
+        print(f"ERROR: could not read the SiYuan queue: {exc}", file=sys.stderr)
+        return 2
+
+    if args.snapshot:
+        args.snapshot.write_text(json.dumps(blocks, indent=2, default=str), encoding="utf-8")
+        print(f"snapshot: {len(blocks)} block(s) written to {args.snapshot}")
+
+    rows, problems = plan(blocks)
+
+    print(f"blocks read:      {len(blocks)}")
+    print(f"rows to insert:   {len(rows)}")
+    print(f"problems:         {len(problems)}")
+    for problem in problems:
+        print(f"  PROBLEM {problem.get('block_id')}: {problem.get('reason')}", file=sys.stderr)
+
+    if args.dry_run:
+        print("dry run - nothing inserted")
+        return 1 if problems else 0
+
+    try:
+        conn = connect()
+    except ChassisDBUnavailable as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    try:
+        inserted, skipped = insert_rows(conn, rows)
+    finally:
+        conn.close()
+
+    print(f"inserted:         {inserted}")
+    print(f"already present:  {skipped}")
+    print("SiYuan blocks were NOT deleted. Verify a full drain cycle before cleaning them up.")
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/chassis/scripts/pacman-process-reactions.py
+++ b/chassis/scripts/pacman-process-reactions.py
@@ -1,28 +1,33 @@
 #!/usr/bin/env python3
-"""pacman-process-reactions.py — Process Telegram reaction events for Pacman.
+"""pacman-process-reactions.py - Process Telegram reaction events for Pacman.
 
 Called inline from a Telegram gather script after a getUpdates call. Reads
 the raw `result` array (JSON) from stdin and:
 1. Caches every message body under `<chat_id>:<message_id>` for later lookup
 2. For each `message_reaction` update: if 👀 was added by the configured
    trigger user in one of the configured admin chats, look up the cached
-   source message, extract URLs, and POST each URL to the SiYuan
-   /To Investigate queue via pacman-queue-add.py.
+   source message, extract URLs, and enqueue each URL via pacman-queue-add.py.
+
+What changed (2026-07-19, docs/pacman-queue-storage.md): the helper this calls
+now writes to Postgres rather than to a SiYuan block, so SIYUAN_TOKEN and
+PACMAN_SIYUAN_QUEUE_BLOCK_ID are no longer part of this script's contract.
 
 Required env (chassis bootstrap hydrates from chassis.config.yaml or .env):
     PACMAN_TELEGRAM_TRIGGER_USER_ID   Telegram user_id whose 👀 fires the trigger
     PACMAN_ADMIN_CHAT_IDS             Comma-separated chat_ids to watch
-    SIYUAN_TOKEN                      SiYuan API token (used by queue-add helper)
-    PACMAN_SIYUAN_QUEUE_BLOCK_ID      Queue parent block ID (used by helper)
+    CHASSIS_PG_DSN                    Postgres DSN (used by the queue-add helper)
 
-If any required env is missing the script silently no-ops (so chassis
-installs without Telegram integration can ship the script without
-configuring it).
+If the Telegram env is missing the script silently no-ops (so chassis installs
+without Telegram integration can ship the script without configuring it).
+
+A failed enqueue is NOT silent. Telegram reactions are the one intake where
+the URL exists nowhere else the moment the group chat moves on, so every
+failure is logged with the URL verbatim under event `queue_failed_urls`, which
+makes the log the recovery path. The script still exits 0 so the calling
+gather script completes, but the failure is recoverable rather than invisible.
 
 Cache file: $CHASSIS_HOME/scheduled-tasks/telegram-message-cache.json
 (last 200 messages by date). Logs to $CHASSIS_HOME/logs/pacman/YYYY-MM-DD.jsonl.
-
-Exits 0 always (caller continues regardless of reaction-processing outcome).
 """
 
 from __future__ import annotations
@@ -100,26 +105,35 @@ def save_cache(cache: dict) -> None:
     CACHE_FILE.write_text(json.dumps(cache, indent=2))
 
 
-def queue_url(url: str, source_tag: str) -> bool:
-    """Call pacman-queue-add.py to append URL to SiYuan queue. Returns True on success."""
+def queue_url(url: str, source_tag: str, source_ref: str | None = None) -> str | None:
+    """Enqueue a URL via pacman-queue-add.py. Returns the approval token, or None.
+
+    The helper prints the token on stdout and exits 2 when Postgres is
+    unreachable, so an enqueue failure is distinguishable from a rejected URL.
+    Both are logged; neither is swallowed.
+    """
     helper = Path(__file__).parent / "pacman-queue-add.py"
     if not helper.exists():
         log({"event": "queue_helper_missing", "path": str(helper)})
-        return False
+        return None
+    cmd = ["python3", str(helper), url, "--source", source_tag]
+    if source_ref:
+        cmd += ["--source-ref", source_ref]
     try:
-        result = subprocess.run(
-            ["python3", str(helper), url, "--source", source_tag],
-            capture_output=True,
-            text=True,
-            timeout=20,
-        )
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=20)
         if result.returncode == 0:
-            return True
-        log({"event": "queue_helper_failed", "url": url, "rc": result.returncode, "stderr": result.stderr[:200]})
-        return False
+            return result.stdout.strip() or None
+        log({
+            "event": "queue_helper_failed",
+            "url": url,
+            "rc": result.returncode,
+            "db_unavailable": result.returncode == 2,
+            "stderr": result.stderr[:300],
+        })
+        return None
     except Exception as e:
         log({"event": "queue_helper_exception", "url": url, "err": str(e)[:200]})
-        return False
+        return None
 
 
 def main() -> int:
@@ -166,6 +180,7 @@ def main() -> int:
         }
 
     queued = []
+    failed = []
     for u in updates:
         rxn = u.get("message_reaction")
         if not rxn:
@@ -204,13 +219,31 @@ def main() -> int:
             if cleaned in seen_in_run:
                 continue
             seen_in_run.add(cleaned)
-            if queue_url(cleaned, source_tag=f"telegram-react-{chat_id}"):
-                queued.append({"url": cleaned, "chat_id": chat_id, "message_id": message_id})
+            token = queue_url(
+                cleaned,
+                source_tag=f"telegram-react-{chat_id}",
+                source_ref=f"{chat_id}:{message_id}",
+            )
+            if token:
+                queued.append({
+                    "url": cleaned,
+                    "token": token,
+                    "chat_id": chat_id,
+                    "message_id": message_id,
+                })
+            else:
+                failed.append({"url": cleaned, "chat_id": chat_id, "message_id": message_id})
 
     save_cache(cache)
 
     if queued:
         log({"event": "run_complete", "queued_count": len(queued), "queued": queued})
+
+    # The URL verbatim, not a count. Telegram reactions are the intake where a
+    # lost URL is unrecoverable once the group chat scrolls past it, so this
+    # log line is the manual recovery path: re-run pacman-queue-add.py on each.
+    if failed:
+        log({"event": "queue_failed_urls", "failed_count": len(failed), "failed": failed})
 
     return 0
 

--- a/chassis/scripts/pacman-queue-add.py
+++ b/chassis/scripts/pacman-queue-add.py
@@ -1,25 +1,36 @@
 #!/usr/bin/env python3
-"""pacman-queue-add.py — Append a URL to the SiYuan /To Investigate queue.
+"""pacman-queue-add.py - Append a URL to the Pacman queue.
 
-Helper called inline by other gather scripts when an installer triggers
-the "queue this for Pacman review" pattern (e.g. a 👀 reaction in a
-Telegram group). POSTs an h2 block with the URL to the configured
-SiYuan parent block.
+Helper called inline by other gather scripts when an installer triggers the
+"queue this for Pacman review" pattern (e.g. a 👀 reaction in a Telegram
+group). Kept as its own entry point because existing callers invoke it by
+name; the queue logic itself lives in chassis/pacman/queue.py and this is a
+thin wrapper over `queue.add`.
+
+What changed (2026-07-19, docs/pacman-queue-storage.md): the URL used to be
+POSTed as an h2 block under PACMAN_SIYUAN_QUEUE_BLOCK_ID. It now becomes a row
+in chassis_pacman_queue, so this works identically on SiYuan, Obsidian, Notion,
+and adapter-mode installs.
+
+Behaviour change worth reading before you rely on it: this script used to be
+"designed to fail silently (caller continues if URL append fails)". It is not
+any more. The queue row is the only durable record that a URL was ever
+submitted - once the source Discord or Telegram message scrolls out of reach
+there is nothing to recover it from - so a failed write must be visible to the
+caller and must happen before anything acknowledges the submission. Exit codes:
+
+    0  queued; the approval token is printed to stdout
+    1  bad URL, or the write failed for a non-connectivity reason
+    2  Postgres unconfigured or unreachable
 
 Usage:
-    python3 pacman-queue-add.py <url> [--source <source-tag>]
+    python3 pacman-queue-add.py <url> [--source <source-tag>] [--source-ref <id>]
 
 Required env (chassis bootstrap hydrates from chassis.config.yaml or .env):
-    SIYUAN_TOKEN                    SiYuan API token
-    PACMAN_SIYUAN_QUEUE_BLOCK_ID    Parent block ID for the /To Investigate queue
+    CHASSIS_PG_DSN (or BEHALFBOT_PG_DSN / JAX_PG_DSN)   Postgres DSN
 
 Optional env:
-    SIYUAN_URL                      SiYuan API endpoint (default: http://localhost:6806)
-    CHASSIS_HOME / CHASSIS_HOME         Install root (used for log path resolution)
-
-Exits 0 on success, 1 on any error. Designed to fail silently (caller
-continues if URL append fails — bad URL, SiYuan unreachable, missing
-config, etc.).
+    CHASSIS_HOME    Install root, used for log path resolution
 """
 
 from __future__ import annotations
@@ -28,53 +39,27 @@ import argparse
 import json
 import os
 import sys
-import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
+_PACKAGE_PARENT = Path(__file__).resolve().parents[2]
+if str(_PACKAGE_PARENT) not in sys.path:
+    sys.path.insert(0, str(_PACKAGE_PARENT))
+
+from chassis.db import ChassisDBUnavailable  # noqa: E402
+from chassis.pacman import queue  # noqa: E402
+
 
 def _resolve_repo() -> Path:
-    """Resolve chassis root from env vars or compute from script location."""
-    for var in ("CHASSIS_HOME", "CHASSIS_HOME"):
-        value = os.environ.get(var)
-        if value:
-            return Path(value)
-    return Path(__file__).resolve().parent.parent.parent
+    value = os.environ.get("CHASSIS_HOME") or os.environ.get("CUSTOMER_HOME")
+    if value:
+        return Path(value)
+    return Path(__file__).resolve().parents[2]
 
 
 REPO = _resolve_repo()
 LOG_DIR = REPO / "logs" / "pacman"
 LOG_DIR.mkdir(parents=True, exist_ok=True)
-
-DEFAULT_SIYUAN_URL = "http://localhost:6806"
-
-
-def load_env_fallback() -> dict[str, str]:
-    """Fallback env loader: reads $REPO/.env as flat key=value if present.
-
-    Container/install bootstraps typically hydrate the env before script
-    invocation, so os.environ is the primary source. This fallback covers
-    the case where the script is invoked outside the dispatcher loop.
-    """
-    env: dict[str, str] = {}
-    env_file = REPO / ".env"
-    if not env_file.exists():
-        return env
-    for line in env_file.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        k, v = line.split("=", 1)
-        env[k.strip()] = v.strip().strip('"').strip("'")
-    return env
-
-
-def env_get(key: str, default: str | None = None) -> str | None:
-    """os.environ first, then $REPO/.env fallback."""
-    value = os.environ.get(key)
-    if value is not None:
-        return value
-    return load_env_fallback().get(key, default)
 
 
 def log(record: dict) -> None:
@@ -85,53 +70,35 @@ def log(record: dict) -> None:
         f.write(json.dumps(record) + "\n")
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("url", help="URL to append to /To Investigate queue")
-    parser.add_argument("--source", default="manual", help="Source tag for the log entry (e.g. 'telegram-react', 'manual')")
-    args = parser.parse_args()
-
-    if not args.url.lower().startswith(("http://", "https://")):
-        log({"event": "invalid_url", "url": args.url[:200]})
-        return 1
-
-    sy_token = env_get("SIYUAN_TOKEN")
-    sy_url = (env_get("SIYUAN_URL", DEFAULT_SIYUAN_URL) or DEFAULT_SIYUAN_URL).rstrip("/")
-    queue_block_id = env_get("PACMAN_SIYUAN_QUEUE_BLOCK_ID")
-
-    if not sy_token:
-        log({"event": "no_siyuan_token"})
-        return 1
-    if not queue_block_id:
-        log({"event": "no_queue_block_id", "hint": "set PACMAN_SIYUAN_QUEUE_BLOCK_ID in env"})
-        return 1
-
-    payload = {
-        "dataType": "markdown",
-        "data": f"## {args.url}",
-        "parentID": queue_block_id,
-    }
-
-    req = urllib.request.Request(
-        f"{sy_url}/api/block/appendBlock",
-        data=json.dumps(payload).encode(),
-        method="POST",
+    parser.add_argument("url", help="URL to append to the Pacman queue")
+    parser.add_argument(
+        "--source",
+        default="manual",
+        help="Source tag stored on the row (e.g. 'telegram-react-123', 'manual')",
     )
-    req.add_header("Content-Type", "application/json")
-    req.add_header("Authorization", f"Token {sy_token}")
-    req.add_header("User-Agent", "chassis-pacman/1.0")
+    parser.add_argument(
+        "--source-ref",
+        default=None,
+        help="Originating message id, kept for audit",
+    )
+    args = parser.parse_args(argv)
 
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            data = json.loads(resp.read().decode())
-            if data.get("code") == 0:
-                log({"event": "url_queued", "url": args.url, "source": args.source})
-                return 0
-            log({"event": "siyuan_append_failed", "url": args.url, "resp": str(data)[:200]})
-            return 1
-    except Exception as e:
-        log({"event": "siyuan_post_exception", "url": args.url, "err": str(e)[:200]})
+        token = queue.add(args.url, source=args.source, source_ref=args.source_ref)
+    except queue.QueueError as exc:
+        log({"event": "queue_add_rejected", "url": args.url[:200], "err": str(exc)[:200]})
+        print(f"ERROR: {exc}", file=sys.stderr)
         return 1
+    except ChassisDBUnavailable as exc:
+        log({"event": "queue_db_unavailable", "url": args.url[:200], "err": str(exc)[:300]})
+        print(f"ERROR: pacman queue unavailable, URL NOT queued: {exc}", file=sys.stderr)
+        return 2
+
+    log({"event": "url_queued", "url": args.url, "source": args.source, "token": token})
+    print(token)
+    return 0
 
 
 if __name__ == "__main__":

--- a/chassis/scripts/pacman-queue.py
+++ b/chassis/scripts/pacman-queue.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""pacman-queue.py - CLI over the Postgres-backed Pacman queue.
+
+This is the interface the drain prompt drives. The old drain read the queue by
+issuing raw SQL through the SiYuan MCP server and deleted entries with its
+block-delete tool, which is why Pacman only worked on SiYuan installs and did
+nothing at all in adapter mode. Both of those are now shell calls to this
+script, which behaves identically on every backend.
+
+Subcommands:
+    add <url> [--source S] [--source-ref R]   enqueue, prints the token
+    count                                     JSON {"count": N} for the gather gate
+    pending [--limit N]                       JSON list, read-only, does not claim
+    claim [--limit N]                         JSON list, marks rows claimed
+    complete <token> --verdict V [--gate N] [--doc-id D]
+    release <token>                           un-claim a row
+
+Every subcommand exits non-zero and prints to stderr when Postgres is
+unreachable. That is deliberate: the queue is the only durable record of a
+submitted URL, so a silent empty result is data loss with a green checkmark.
+`count` is the one place this matters most, because the dispatcher treats a
+failed gather as a heartbeat failure and alerts on it.
+
+Usage from the drain prompt:
+    python3 "$CHASSIS_ROOT/scripts/pacman-queue.py" claim --limit 10
+    python3 "$CHASSIS_ROOT/scripts/pacman-queue.py" complete qhtnbz --verdict drop --gate 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_PACKAGE_PARENT = Path(__file__).resolve().parents[2]
+if str(_PACKAGE_PARENT) not in sys.path:
+    sys.path.insert(0, str(_PACKAGE_PARENT))
+
+from chassis.db import ChassisDBUnavailable  # noqa: E402
+from chassis.pacman import queue  # noqa: E402
+
+
+def _cmd_add(args) -> int:
+    token = queue.add(args.url, source=args.source, source_ref=args.source_ref)
+    print(token)
+    return 0
+
+
+def _cmd_count(args) -> int:
+    print(json.dumps({"count": queue.pending_count()}))
+    return 0
+
+
+def _cmd_pending(args) -> int:
+    print(json.dumps(queue.pending(limit=args.limit), indent=2))
+    return 0
+
+
+def _cmd_claim(args) -> int:
+    print(json.dumps(queue.claim(limit=args.limit), indent=2))
+    return 0
+
+
+def _cmd_complete(args) -> int:
+    changed = queue.complete(
+        args.token,
+        args.verdict,
+        gate=args.gate,
+        proposal_doc_id=args.doc_id,
+    )
+    if not changed:
+        # Not an error. Exactly-once means the second call is a no-op, and a
+        # drain that retries a step should not be told it failed.
+        print(json.dumps({"token": args.token, "changed": False, "reason": "already processed"}))
+        return 0
+    print(json.dumps({"token": args.token, "changed": True, "verdict": args.verdict}))
+    return 0
+
+
+def _cmd_release(args) -> int:
+    print(json.dumps({"token": args.token, "released": queue.release(args.token)}))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Pacman queue operations.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_add = sub.add_parser("add", help="Enqueue a URL, print its approval token.")
+    p_add.add_argument("url")
+    p_add.add_argument("--source", default="manual")
+    p_add.add_argument("--source-ref", default=None)
+    p_add.set_defaults(func=_cmd_add)
+
+    p_count = sub.add_parser("count", help='Print {"count": N} of claimable rows.')
+    p_count.set_defaults(func=_cmd_count)
+
+    p_pending = sub.add_parser("pending", help="List claimable rows without claiming.")
+    p_pending.add_argument("--limit", type=int, default=25)
+    p_pending.set_defaults(func=_cmd_pending)
+
+    p_claim = sub.add_parser("claim", help="Claim up to N rows, oldest first.")
+    p_claim.add_argument("--limit", type=int, default=10)
+    p_claim.set_defaults(func=_cmd_claim)
+
+    p_complete = sub.add_parser("complete", help="Mark a claimed row processed.")
+    p_complete.add_argument("token")
+    p_complete.add_argument("--verdict", required=True, choices=list(queue.VALID_VERDICTS))
+    p_complete.add_argument("--gate", type=int, default=None)
+    p_complete.add_argument("--doc-id", default=None, help="Opaque proposal doc id from the second-brain adapter.")
+    p_complete.set_defaults(func=_cmd_complete)
+
+    p_release = sub.add_parser("release", help="Un-claim a row so the next drain retries it.")
+    p_release.add_argument("token")
+    p_release.set_defaults(func=_cmd_release)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return args.func(args)
+    except ChassisDBUnavailable as exc:
+        print(f"ERROR: pacman queue unavailable: {exc}", file=sys.stderr)
+        return 2
+    except queue.QueueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/chassis/scripts/pacman.sh
+++ b/chassis/scripts/pacman.sh
@@ -1,39 +1,49 @@
 #!/usr/bin/env bash
-# pacman.sh — Run the Pacman 4-gate URL self-improvement pipeline.
+# pacman.sh - Run the Pacman 4-gate URL self-improvement pipeline.
 #
 # Pacman is a chassis-core capability that turns the installer's "interesting
 # but uncategorized" inbound URLs into either (a) one-line drops, (b) reviewed
-# proposals filed in SiYuan, or (c) GitHub issues after approval. It runs the
-# same 4-gate filter (Relevant? Beneficial? Feasible? Plan?) regardless of
-# installer.
+# proposals filed in the installer's second brain, or (c) GitHub issues after
+# approval. It runs the same 4-gate filter (Relevant? Beneficial? Feasible?
+# Plan?) regardless of installer.
 #
 # Usage:
 #   pacman.sh <url> [<url2> <url3> ...]   # process one or more URLs
-#   pacman.sh --queue                     # drain SiYuan queue
+#   pacman.sh --queue                     # drain the Pacman queue
 #   pacman.sh --stdin                     # read URLs from stdin
 #
 # All gate logic lives in the chassis pacman skill (chassis/skills/pacman.md).
 # This script is a thin invocation wrapper around `claude -p`.
 #
+# What changed (2026-07-19, docs/pacman-queue-storage.md): the queue moved from
+# SiYuan blocks to Postgres, so PACMAN_SIYUAN_QUEUE_BLOCK_ID and
+# PACMAN_SIYUAN_DROPPED_BLOCK_ID are no longer required or referenced. Proposals
+# and drop records are written through the second-brain adapter
+# (PACMAN_PROPOSALS_PARENT / PACMAN_DROPPED_DOC_ID), which is what makes this
+# work unchanged on SiYuan, Obsidian, and Notion.
+#
 # Required env (chassis bootstrap hydrates these from chassis.config.yaml or
 # the installer's .env):
 #   PACMAN_DISCORD_CHAT_ID         Discord channel for one-line drop notes + proposal summaries
-#   PACMAN_SIYUAN_QUEUE_BLOCK_ID   SiYuan parent block for the /To Investigate queue
-#   PACMAN_SIYUAN_DROPPED_BLOCK_ID SiYuan parent block for the /Dropped archive
 #   PACMAN_GITHUB_REPO             owner/repo for `gh issue create` on approval
+#   CHASSIS_PG_DSN                 Postgres DSN holding the queue (or
+#                                  BEHALFBOT_PG_DSN / JAX_PG_DSN)
 #
 # Optional env:
+#   PACMAN_PROPOSALS_PARENT        Adapter doc id/path proposals are filed under
+#   PACMAN_DROPPED_DOC_ID          Adapter doc id/path for the drop audit trail
 #   PACMAN_DISCORD_CHANNEL_LABEL   Human-readable channel label for prompts (default: derived from chat_id)
 #   PACMAN_GITHUB_LABELS           Comma-separated GH labels (default: pacman)
 #   PACMAN_MAX_BATCH_URLS          Per-invocation URL cap (default: 10)
 #   PACMAN_HARD_PAUSE              File path; if exists, script exits 0 without invoking claude
 #
 # Chassis root resolution: $CHASSIS_HOME (set by container entrypoint) >
-# $CHASSIS_HOME (legacy) > the directory two levels up from this script.
+# $CUSTOMER_HOME > the directory two levels up from this script.
 
 set -euo pipefail
 
-CHASSIS_ROOT="${CHASSIS_HOME:-${CHASSIS_HOME:-$(cd "$(dirname "$0")/../.." && pwd)}}"
+CHASSIS_ROOT="${CHASSIS_HOME:-${CUSTOMER_HOME:-$(cd "$(dirname "$0")/../.." && pwd)}}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOG_DIR="$CHASSIS_ROOT/logs/pacman"
 mkdir -p "$LOG_DIR"
 
@@ -49,7 +59,6 @@ if [[ -f "$PAUSE_FILE" ]]; then
 fi
 
 : "${PACMAN_DISCORD_CHAT_ID:?PACMAN_DISCORD_CHAT_ID must be set}"
-: "${PACMAN_SIYUAN_QUEUE_BLOCK_ID:?PACMAN_SIYUAN_QUEUE_BLOCK_ID must be set}"
 : "${PACMAN_GITHUB_REPO:?PACMAN_GITHUB_REPO must be set}"
 
 PACMAN_DISCORD_CHANNEL_LABEL="${PACMAN_DISCORD_CHANNEL_LABEL:-Discord channel ${PACMAN_DISCORD_CHAT_ID}}"
@@ -60,7 +69,14 @@ DATE="$(date -u +%Y-%m-%d)"
 LOG_FILE="$LOG_DIR/$DATE.jsonl"
 
 if [[ "$1" == "--queue" ]]; then
-  PROMPT="Read chassis/skills/pacman.md. Drain the SiYuan /To Investigate queue (block ${PACMAN_SIYUAN_QUEUE_BLOCK_ID}). Process up to ${PACMAN_MAX_BATCH_URLS} URLs that don't yet have a pacman_processed attribute. For each: run the 4-gate pipeline. Drops post one-line notes to ${PACMAN_DISCORD_CHANNEL_LABEL} (chat_id ${PACMAN_DISCORD_CHAT_ID}). Proposals get written as SiYuan sub-docs and posted to ${PACMAN_DISCORD_CHANNEL_LABEL} with approve/reject prompts. Cap batch at ${PACMAN_MAX_BATCH_URLS} URLs."
+  # Fail before spending a Claude invocation if the queue is unreachable. The
+  # drain prompt would otherwise discover this partway through and report a
+  # clean run over an empty result, which is the exact failure PR #78 removed.
+  if ! python3 "$SCRIPT_DIR/pacman-queue.py" count >/dev/null; then
+    echo "Pacman queue is unreachable - not invoking claude. See the error above." >&2
+    exit 1
+  fi
+  PROMPT="Read chassis/skills/pacman.md. Drain the Pacman queue. Claim up to ${PACMAN_MAX_BATCH_URLS} URLs with 'python3 chassis/scripts/pacman-queue.py claim --limit ${PACMAN_MAX_BATCH_URLS}'. For each claimed row: run the 4-gate pipeline, then mark it done with 'python3 chassis/scripts/pacman-queue.py complete <token> --verdict <drop|proposal|fetch_failed>'. Drops post one-line notes to ${PACMAN_DISCORD_CHANNEL_LABEL} (chat_id ${PACMAN_DISCORD_CHAT_ID}). Proposals get written through mcp__secondbrain__create_doc and posted to ${PACMAN_DISCORD_CHANNEL_LABEL} with approve/reject prompts quoting the row's approval token."
   echo "{\"ts\":\"$TS\",\"mode\":\"queue\",\"event\":\"invoke\"}" >> "$LOG_FILE"
   claude -p "$PROMPT"
   echo "{\"ts\":\"$TS\",\"mode\":\"queue\",\"event\":\"complete\"}" >> "$LOG_FILE"
@@ -93,7 +109,7 @@ PROMPT="Read chassis/skills/pacman.md. Run the Pacman 4-gate pipeline on the fol
 
 ${URL_LIST}
 
-Source: manual CLI invocation (multi-URL batch). For each URL: run the 4 gates. Drops post one-line notes to ${PACMAN_DISCORD_CHANNEL_LABEL} (chat_id ${PACMAN_DISCORD_CHAT_ID}). Proposals get written as SiYuan sub-docs and posted to ${PACMAN_DISCORD_CHANNEL_LABEL} with approve/reject prompts. Process URLs sequentially. After all URLs are processed, post a single batch-summary line to ${PACMAN_DISCORD_CHANNEL_LABEL}: 'Pacman batch: processed ${COUNT} URL(s) (P proposals, D drops).'"
+Source: manual CLI invocation (multi-URL batch). For each URL: run the 4 gates. Drops post one-line notes to ${PACMAN_DISCORD_CHANNEL_LABEL} (chat_id ${PACMAN_DISCORD_CHAT_ID}). Proposals get written through mcp__secondbrain__create_doc and posted to ${PACMAN_DISCORD_CHANNEL_LABEL} with approve/reject prompts. These URLs came from the CLI, not from the queue, so there is no queue row to complete unless you enqueued them yourself. Process URLs sequentially. After all URLs are processed, post a single batch-summary line to ${PACMAN_DISCORD_CHANNEL_LABEL}: 'Pacman batch: processed ${COUNT} URL(s) (P proposals, D drops).'"
 
 echo "{\"ts\":\"$TS\",\"mode\":\"batch\",\"url_count\":${COUNT},\"event\":\"invoke\"}" >> "$LOG_FILE"
 claude -p "$PROMPT"

--- a/chassis/skills/pacman.md
+++ b/chassis/skills/pacman.md
@@ -1,17 +1,17 @@
 ---
 name: pacman
-description: URL self-improvement filter — when the installer drops a URL with the Pacman trigger, run the 4-gate pipeline (Relevant? Beneficial? Feasible? Plan?) and either drop with a 1-line note or write a SiYuan proposal sub-doc. Use whenever the installer posts `Pacman <url>` in the configured Discord channel (`${PACMAN_DISCORD_CHAT_ID}`).
+description: URL self-improvement filter - when the installer drops a URL with the Pacman trigger, run the 4-gate pipeline (Relevant? Beneficial? Feasible? Plan?) and either drop with a 1-line note or write a proposal sub-doc through the second-brain adapter. Use whenever the installer posts `Pacman <url>` in the configured Discord channel (`${PACMAN_DISCORD_CHAT_ID}`).
 ---
 
-# Skill: Pacman — URL → 4-gate filter → proposal pipeline
+# Skill: Pacman - URL to 4-gate filter to proposal pipeline
 
 Pacman is a self-improvement filter. Feed it a URL, run the content through 4 gates (Relevant? Beneficial? Feasible? Plan?), and either drop it (with a 1-line reason) or generate a proposal the installer can approve into a GitHub issue.
 
-Pacman is chassis-core — every install gets it. Per-install knobs (Discord channel, SiYuan queue block, GitHub repo) are hydrated from `chassis.config.yaml` at bootstrap. The Pacman pipeline is identical across installs; only the destination identifiers vary.
+Pacman is chassis-core - every install gets it. Per-install knobs (Discord channel, proposal parent doc, GitHub repo) are hydrated from `chassis.config.yaml` at bootstrap. The Pacman pipeline is identical across installs; only the destination identifiers vary.
 
 Source design: <v1-reference-install>#270 (the canonical design issue from when Pacman was first built in the V1 reference install). Calibration choices baked into the design:
 - **Drop logging:** verbose. Every dropped URL gets a 1-line `Pacman: <url> dropped at gate <N> (<reason>)` post to the configured Discord channel.
-- **Storage:** SiYuan doc `/To Investigate` (block ID `${PACMAN_SIYUAN_QUEUE_BLOCK_ID}`) is the queue + proposal home. Proposals are written as sub-docs of that node.
+- **Storage:** the queue is a Postgres table (`chassis_pacman_queue`), reached via `chassis/scripts/pacman-queue.py`. Proposals and drop records are written through the second-brain adapter (`mcp__secondbrain__*`) so they land on whatever backend the install runs. Changed 2026-07-19 - see `docs/pacman-queue-storage.md` for why block IDs did not port.
 - **Invocation modes:** (a) installer DMs `Pacman <url>` in the configured channel, (b) Telegram 👀 reaction in admin groups appends URL to queue, (c) heartbeat drains queue periodically, (d) manual `bash chassis/scripts/pacman.sh <url>`.
 
 ## Required configuration
@@ -22,39 +22,44 @@ The skill reads these environment variables (chassis bootstrap hydrates from `ch
 |---|---|
 | `PACMAN_DISCORD_CHAT_ID` | Discord channel for drop notes + proposal summaries |
 | `PACMAN_DISCORD_CHANNEL_LABEL` | Human-readable channel label (optional, falls back to chat_id) |
-| `PACMAN_SIYUAN_QUEUE_BLOCK_ID` | SiYuan parent block for the `/To Investigate` queue |
-| `PACMAN_SIYUAN_DROPPED_BLOCK_ID` | SiYuan parent block for the `/Dropped` audit-trail sub-doc |
+| `CHASSIS_PG_DSN` | Postgres DSN holding the queue (or `BEHALFBOT_PG_DSN` / `JAX_PG_DSN`) |
+| `PACMAN_PROPOSALS_PARENT` | Adapter doc id/path that proposal sub-docs are filed under |
+| `PACMAN_DROPPED_DOC_ID` | Adapter doc id/path for the `/Dropped` audit trail |
 | `PACMAN_GITHUB_REPO` | `owner/repo` for `gh issue create` on approval |
 | `PACMAN_GITHUB_LABELS` | Comma-separated GH labels to apply on issue creation (default: `pacman`) |
+| `PACMAN_MAX_BATCH_URLS` | Per-drain URL cap (default: 10) |
+| `PACMAN_CLAIM_TIMEOUT_MINUTES` | Minutes before a claimed-but-unprocessed row is reclaimable (default: 60) |
+
+`PACMAN_SIYUAN_QUEUE_BLOCK_ID` and `PACMAN_SIYUAN_DROPPED_BLOCK_ID` are gone as of 2026-07-19. The only script that still reads `PACMAN_SIYUAN_QUEUE_BLOCK_ID` is the one-time backfill, `chassis/scripts/pacman-migrate-siyuan-queue.py`.
 
 Pacman fails loudly if any required variable is missing. The script wrapper (`chassis/scripts/pacman.sh`) validates env before invoking claude.
 
 ## When to invoke this skill
 
 - The installer types a message in the configured Discord channel matching the pattern `Pacman <url>` (case-insensitive, optional `:` after `Pacman`). The trigger is documented in the chassis-level `CLAUDE.md` so the main session catches it without an explicit ask.
-- A Pacman heartbeat fires and finds queued URLs in the SiYuan `/To Investigate` doc that haven't been processed yet.
+- A Pacman heartbeat fires and finds unprocessed rows in the Pacman queue.
 - A user (installer or subagent) explicitly asks "run Pacman on <url>".
 
 ## The 4 gates
 
-Pacman runs all 4 gates sequentially — stop at the first failure and log the drop. Only if all four pass does Pacman generate a proposal.
+Pacman runs all 4 gates sequentially - stop at the first failure and log the drop. Only if all four pass does Pacman generate a proposal.
 
 | Gate | Question | Output |
 |---|---|---|
 | 1. Relevant? | Does this URL discuss something in the installer's current problem space (active projects, daemons, skills, pain points)? | pass/fail + one-sentence reason |
 | 2. Beneficial? | If the installer adopted this idea, would it move something forward that matters? | pass/fail + impact 1-5 + one-sentence why |
 | 3. Feasible? | Can the install actually implement this with the current stack, data, skills, and budget? | pass/fail + cost estimate (time / tokens / external $) + one-sentence why |
-| 4. Plan? | Does a concrete implementation path EXIST that fits the install's actual setup? | pass/fail + one paragraph naming the 1-2 most concrete entry points (NOT the full implementation plan — that's saved for the GH issue if approved) |
+| 4. Plan? | Does a concrete implementation path EXIST that fits the install's actual setup? | pass/fail + one paragraph naming the 1-2 most concrete entry points (NOT the full implementation plan - that's saved for the GH issue if approved) |
 
-Relevance is inherently install-specific. The Relevance gate reads the install's facts file (`installer-facts.md` or equivalent), active project memory, current heartbeat configuration, and the most recent briefings to decide whether a URL ties to current work. Calibrate toward false positives — verbose drop notes catch over-rejections.
+Relevance is inherently install-specific. The Relevance gate reads the install's facts file (`installer-facts.md` or equivalent), active project memory, current heartbeat configuration, and the most recent briefings to decide whether a URL ties to current work. Calibrate toward false positives - verbose drop notes catch over-rejections.
 
-If a gate fails, drop the proposal at that gate and log the failure (see "Drop logging" below). If all 4 pass, write the SiYuan proposal sub-doc.
+If a gate fails, drop the proposal at that gate and log the failure (see "Drop logging" below). If all 4 pass, write the proposal sub-doc through the adapter.
 
-## Proposal format (SiYuan sub-doc — EXPANDED triage length)
+## Proposal format (adapter sub-doc - EXPANDED triage length)
 
-When all 4 gates pass, write the EXPANDED proposal as a SiYuan sub-doc under `/To Investigate`. The SiYuan doc gives the installer the full reasoning behind each gate — but stops short of the implementation spec. The full implementation plan goes into the GitHub issue if approved.
+When all 4 gates pass, write the EXPANDED proposal as a sub-doc under `${PACMAN_PROPOSALS_PARENT}` via `mcp__secondbrain__create_doc`. The doc gives the installer the full reasoning behind each gate - but stops short of the implementation spec. The full implementation plan goes into the GitHub issue if approved.
 
-Target ~400-600 words in the SiYuan doc body. The Discord post (separate, ~150-250 words) is the gist; SiYuan is the expanded reasoning behind that gist.
+Target ~400-600 words in the proposal doc body. The Discord post (separate, ~150-250 words) is the gist; the doc is the expanded reasoning behind that gist.
 
 Template:
 
@@ -66,11 +71,11 @@ Template:
 
 ## Essence of the capability
 
-<3-5 sentences explaining what the source proposes — the actual pattern, capability, or technique. Avoid the source's marketing framing; describe the underlying mechanic in plain language.>
+<3-5 sentences explaining what the source proposes - the actual pattern, capability, or technique. Avoid the source's marketing framing; describe the underlying mechanic in plain language.>
 
 ## Relevance to this install
 
-<2-4 sentences naming the specific active projects, daemons, skills, or pain points this maps to. Reference by name (issue numbers, daemon names, file paths). If the source's idea applies to multiple parts of the stack, list them in priority order — Pacman's job is to surface the highest-leverage application, not all theoretical ones.>
+<2-4 sentences naming the specific active projects, daemons, skills, or pain points this maps to. Reference by name (issue numbers, daemon names, file paths). If the source's idea applies to multiple parts of the stack, list them in priority order - Pacman's job is to surface the highest-leverage application, not all theoretical ones.>
 
 ## Why it matters / metrics it could move
 
@@ -82,7 +87,7 @@ Template:
 ## Feasibility + cost
 
 - **Time to build:** <small (under 1 day) / medium (1-3 days) / large (multi-day, multi-PR)>
-- **Tokens:** <est, e.g. "negligible — architectural change" or "~5k tokens per use">
+- **Tokens:** <est, e.g. "negligible - architectural change" or "~5k tokens per use">
 - **External $:** <est, e.g. "$0 ongoing" or "$10/mo for X service">
 - **Maintenance burden:** <ongoing per-week / per-month effort to keep this alive>
 - **New dependencies:** <list or "none">
@@ -101,10 +106,10 @@ Template:
 
 ---
 
-*Full implementation plan, acceptance criteria, risks, and open questions for the implementor will be written into the GitHub issue if approved. SiYuan keeps the expanded triage reasoning; GH gets the working spec.*
+*Full implementation plan, acceptance criteria, risks, and open questions for the implementor will be written into the GitHub issue if approved. The second brain keeps the expanded triage reasoning; GH gets the working spec.*
 ```
 
-The approval-time GitHub issue (separate, only created if the installer replies `approve <block-id>`) gets the FULL plan: numbered implementation steps, checkable acceptance criteria, risks with mitigations, open questions for the implementor. See "GitHub issue creation" section below.
+The approval-time GitHub issue (separate, only created if the installer replies `approve <token>`) gets the FULL plan: numbered implementation steps, checkable acceptance criteria, risks with mitigations, open questions for the implementor. See "GitHub issue creation" section below.
 
 ## Drop logging
 
@@ -121,21 +126,25 @@ If any gate fails, do NOT generate a proposal. Instead:
    {"ts": "<ISO timestamp>", "url": "<url>", "dropped_at_gate": <N>, "reason": "<one-sentence>", "source": "<discord|telegram|manual|heartbeat>"}
    ```
 
-3. Append an entry to the SiYuan `/To Investigate/Dropped` sub-doc (block ID `${PACMAN_SIYUAN_DROPPED_BLOCK_ID}`) using `mcp__siyuan__append_block`:
+3. Append an entry to the Dropped audit trail via `mcp__secondbrain__append_to_doc(doc_id: "${PACMAN_DROPPED_DOC_ID}", content: ...)`:
    ```markdown
    - **YYYY-MM-DD** [<url>](<url>) - gate <N> (<reason>)
    ```
-   The Dropped sub-doc is the audit trail the installer reads to catch over-rejections (false negatives) and tune the gate calibration over time.
+   The Dropped doc is the audit trail the installer reads to catch over-rejections (false negatives) and tune the gate calibration over time. It goes through the second-brain adapter rather than any backend-specific append tool, so it lands correctly on Obsidian and Notion too.
 
-4. **Remove the source URL block from the queue** (the `/To Investigate` parent doc, block ID `${PACMAN_SIYUAN_QUEUE_BLOCK_ID}`). Pacman processes URLs as queue entries — once processed (drop OR proposal), the source block must be deleted via `mcp__siyuan__delete_block`. Otherwise the next heartbeat fire re-processes the same URL. **This is non-negotiable.** True queue semantics — items removed once consumed.
+4. **Mark the queue row processed:**
+   ```bash
+   python3 chassis/scripts/pacman-queue.py complete <token> --verdict drop --gate <N>
+   ```
+   Once processed (drop OR proposal), the row must be completed. Otherwise the next heartbeat fire re-processes the same URL. **This is non-negotiable.** True queue semantics - items removed from the pending set once consumed. `complete` is exactly-once, so a retried call is a harmless no-op rather than a corrupted verdict.
 
 ## Approval flow (proposal passes all gates)
 
-1. Write the EXPANDED proposal (per "Proposal format" section above — ~400-600 words) to a new SiYuan sub-doc under `/To Investigate` via `mcp__siyuan__create_doc`. Path: `/To Investigate/YYYY-MM-DD-<slug>` where slug is derived from the URL's title (lowercase, hyphenated, max 8 words).
+1. Write the EXPANDED proposal (per "Proposal format" section above - ~400-600 words) via `mcp__secondbrain__create_doc(parent: "${PACMAN_PROPOSALS_PARENT}", title: "YYYY-MM-DD-<slug>", body: ...)` where slug is derived from the URL's title (lowercase, hyphenated, max 8 words). The adapter files it in the right place on whatever backend the install runs.
 
-2. Get the new sub-doc's block ID from `mcp__siyuan__sql_query`: `SELECT id FROM blocks WHERE hpath = '/To Investigate/YYYY-MM-DD-<slug>' AND type = 'd' LIMIT 1`.
+2. Keep the `doc_id` and `deeplink` that `create_doc` returned. The `doc_id` is opaque - a SiYuan block ID, a Notion UUID, or an Obsidian vault path depending on the install. Never parse it, never construct it, and never show it to the installer as something to type. Store it on the queue row with `--doc-id` in step 4, which is what lets the approval step find the document from the approval token later.
 
-3. Post a 4-section Discord summary to the configured channel. The Discord post is the gist — the installer reads it inline and decides if the SiYuan link is worth clicking. Target ~150-250 words, four explicit sections. Format:
+3. Post a 4-section Discord summary to the configured channel. The Discord post is the gist - the installer reads it inline and decides if the doc link is worth clicking. Target ~150-250 words, four explicit sections. Format:
    ```
    **Pacman proposal:** <one-sentence headline>
 
@@ -147,42 +156,71 @@ If any gate fails, do NOT generate a proposal. Instead:
 
    **Feasibility + cost.** <2-3 sentences on time-to-build, ongoing $, ongoing maintenance burden, new dependencies. Be specific: "small (4-8h, no recurring cost)" beats "feasible".>
 
-   Read the expanded proposal: [SiYuan sub-doc](siyuan://blocks/<block-id>)
+   Read the expanded proposal: [<backend name>](<deeplink from create_doc>)
    Source URL: <url>
 
-   Reply `approve <block-id>` to ship as a GH issue with full implementation plan, `reject <block-id>` to drop, `defer <block-id>` to keep in the queue.
+   Reply `approve <token>` to ship as a GH issue with full implementation plan, `reject <token>` to drop, `defer <token>` to keep in the queue.
    ```
-   Use `mcp__plugin_discord_discord__reply` with `chat_id = ${PACMAN_DISCORD_CHAT_ID}`. The `siyuan://blocks/<block-id>` URL must be wrapped in markdown link syntax `[text](siyuan://blocks/<block-id>)` so Discord renders it as a clickable link that opens the SiYuan desktop app via custom protocol handler.
+   Use `mcp__plugin_discord_discord__reply` with `chat_id = ${PACMAN_DISCORD_CHAT_ID}`. Use the `deeplink` string `create_doc` returned verbatim, wrapped in markdown link syntax so Discord renders it clickable. Do not construct the URL yourself - the scheme differs per backend (`siyuan://blocks/...`, `obsidian://open?...`, `https://notion.so/...`).
 
-   The Discord post needs to give the installer enough to decide approve/reject/defer at a glance, without burying them in implementation detail. The SiYuan link is for "show me your work" — the Discord post is for "tell me the gist." Don't shrink Discord too far (a too-thin post forces a click for every triage decision) — but also don't paste the full SiYuan body.
+   `<token>` is the queue row's approval token from step 2 of the drain (six lowercase letters, e.g. `qhtnbz`). It is NOT the `doc_id`. See "Approval tokens" below.
 
-4. **Remove the source URL block from the queue** (block in `/To Investigate` doc that contained the URL). Use `mcp__siyuan__delete_block`. Same rule as drops — items consumed are removed.
+   The Discord post needs to give the installer enough to decide approve/reject/defer at a glance, without burying them in implementation detail. The doc link is for "show me your work" - the Discord post is for "tell me the gist." Don't shrink Discord too far (a too-thin post forces a click for every triage decision) - but also don't paste the full doc body.
 
-5. Wait for the installer's response. Listen for messages matching `^(approve|reject|defer)\s+(\d{14}-\w{7})(?:\s+(.+))?$`:
-   - `approve <block-id>` → write the FULL implementation plan into a GH issue (see "GitHub issue creation" below), then comment in the SiYuan sub-doc with the issue link, mark proposal as approved.
-   - `approve <block-id> <caveat-text>` → same flow, AND incorporate the trailing free-form text as an approval caveat. The caveat goes into the GH issue body as a prominent section near the top:
+4. **Mark the queue row processed**, recording the proposal document so the approval step can find it:
+   ```bash
+   python3 chassis/scripts/pacman-queue.py complete <token> --verdict proposal --doc-id <doc_id from create_doc>
+   ```
+   Same rule as drops - items consumed are removed from the pending set.
+
+5. Wait for the installer's response. Listen for messages matching:
+   ```
+   ^(approve|reject|defer)\s+([bcdfghjkmnpqrstvwxz]{6}|\d{14}-\w{7})(?:\s+(.+))?$
+   ```
+   The canonical implementation is `chassis/pacman/tokens.py` (`APPROVAL_RE`, `parse_approval`). Use it rather than re-deriving the pattern.
+
+   - First alternative: the current approval token.
+   - Second alternative: a legacy SiYuan block ID. **Deprecated.** Accepted only so proposals posted before the 2026-07-19 cutover can still be approved; look those up by `proposal_doc_id`, not by token. Drop this alternative once no pre-cutover proposal is outstanding.
+
+   Then:
+   - `approve <token>` → write the FULL implementation plan into a GH issue (see "GitHub issue creation" below), then append the issue link to the proposal doc via `mcp__secondbrain__append_to_doc`, mark proposal as approved.
+   - `approve <token> <caveat-text>` → same flow, AND incorporate the trailing free-form text as an approval caveat. The caveat goes into the GH issue body as a prominent section near the top:
      ```markdown
      ## Approval caveat from the installer
 
      <caveat text verbatim>
 
-     This caveat MUST be considered during implementation. It may modify scope, change the implementation path, or add constraints not present in the original SiYuan proposal. Where the caveat conflicts with a step in the original plan, the modified step is annotated below with `(Modified per installer caveat - see top of issue.)` so the implementor doesn't silently use a stale step.
+     This caveat MUST be considered during implementation. It may modify scope, change the implementation path, or add constraints not present in the original proposal doc. Where the caveat conflicts with a step in the original plan, the modified step is annotated below with `(Modified per installer caveat - see top of issue.)` so the implementor doesn't silently use a stale step.
      ```
-     Then re-read the original implementation plan and tag any conflicting steps with `(Modified per installer caveat - see top of issue.)`. Don't silently rewrite the plan — flag the conflict for the implementor.
-   - `reject <block-id>` (with or without trailing reason) → append `rejected YYYY-MM-DD: <reason if given>` line to the SiYuan sub-doc, leave the doc in place as audit trail.
-   - `defer <block-id>` (with or without trailing reason) → leave the SiYuan sub-doc in place, do not re-process unless the installer explicitly says so. Treat the proposal as parked for re-review.
+     Then re-read the original implementation plan and tag any conflicting steps with `(Modified per installer caveat - see top of issue.)`. Don't silently rewrite the plan - flag the conflict for the implementor.
+   - `reject <token>` (with or without trailing reason) → append `rejected YYYY-MM-DD: <reason if given>` to the proposal doc via `mcp__secondbrain__append_to_doc`, leave the doc in place as audit trail.
+   - `defer <token>` (with or without trailing reason) → leave the proposal doc in place, do not re-process unless the installer explicitly says so. Treat the proposal as parked for re-review.
 
-   If the block ID doesn't match an existing SiYuan proposal sub-doc, fail loudly in the configured Discord channel with the specific ID mismatch (`Pacman: block ID <id> not found - check for typo. Existing proposals: <list>.`). Don't guess or auto-correct.
+   If the token doesn't match a queue row, fail loudly in the configured Discord channel with the specific mismatch (`Pacman: token <id> not found - check for typo. Recent proposals: <list>.`). Don't guess or auto-correct.
+
+## Approval tokens
+
+The installer approves a proposal by typing its token, e.g. `approve qhtnbz`.
+
+The token is the queue row's own identifier: six lowercase letters drawn from `bcdfghjkmnpqrstvwxz`, generated at enqueue, unique, and identical on every backend. It is deliberately NOT a second-brain document id. This used to be a 14-digit SiYuan block ID, which a Notion UUID and an Obsidian path both fail to match - an independently SiYuan-shaped assumption sitting in the approval path that moving the queue would not have fixed on its own.
+
+Three properties, each load-bearing:
+
+- **No digits, so it can never collide with `approve N`.** The outreach flow uses `approve 1 3 5` to approve drafts by list position. A token containing no digits is structurally incapable of being read as a number, so the two forms can never be confused. This is a guarantee, not a probability.
+- **No vowels and no `y`, so it can never spell a word.** English has no six-letter vowel-free words, which keeps `approve later` and similar from ever parsing as a token.
+- **Six characters, one case, no `i`/`l`/`1` or `o`/`0` ambiguity.** Sean approves from his phone. A 32-character Notion UUID is unusable there.
+
+Full reasoning and the canonical regex: `chassis/pacman/tokens.py`.
 
 ## GitHub issue creation (on approval)
 
-This is when Pacman writes the full working spec. The SiYuan proposal is intentionally light (triage summary). The GH issue is heavy (implementation plan + acceptance criteria + risks + open questions for the implementor).
+This is when Pacman writes the full working spec. The proposal doc is intentionally light (triage summary). The GH issue is heavy (implementation plan + acceptance criteria + risks + open questions for the implementor).
 
 Use `gh issue create --repo ${PACMAN_GITHUB_REPO} --label ${PACMAN_GITHUB_LABELS}` (with `${PACMAN_GITHUB_LABELS}` split on comma into separate `--label` flags if multiple). Title: `Pacman: <one-sentence summary of idea>` (under 70 chars). Body:
 
 ```markdown
 **Source:** <URL>
-**SiYuan proposal:** siyuan://blocks/<block-id>
+**Proposal doc:** <deeplink from create_doc>
 **Approved:** YYYY-MM-DD
 
 <!-- If the installer appended a caveat to their approve message, insert this section here: -->
@@ -190,7 +228,7 @@ Use `gh issue create --repo ${PACMAN_GITHUB_REPO} --label ${PACMAN_GITHUB_LABELS
 
 <caveat text verbatim>
 
-This caveat MUST be considered during implementation. It may modify scope, change the implementation path, or add constraints not present in the original SiYuan proposal. Where the caveat conflicts with a step in the original plan, the affected step is annotated `(Modified per installer caveat - see top of issue.)` so the implementor doesn't silently use a stale step.
+This caveat MUST be considered during implementation. It may modify scope, change the implementation path, or add constraints not present in the original proposal doc. Where the caveat conflicts with a step in the original plan, the affected step is annotated `(Modified per installer caveat - see top of issue.)` so the implementor doesn't silently use a stale step.
 <!-- End caveat section -->
 
 ## Idea (paraphrase)
@@ -237,7 +275,7 @@ This caveat MUST be considered during implementation. It may modify scope, chang
 - <known risk 2, with mitigation>
 
 ---
-*Issue created by Pacman pipeline YYYY-MM-DD per skill `chassis/skills/pacman.md`. Source SiYuan proposal: siyuan://blocks/<block-id>.*
+*Issue created by Pacman pipeline YYYY-MM-DD per skill `chassis/skills/pacman.md`. Source proposal doc: <deeplink>.*
 ```
 
 Then post to the configured Discord channel with a clickable link:
@@ -245,7 +283,7 @@ Then post to the configured Discord channel with a clickable link:
 Pacman: shipped as [${PACMAN_GITHUB_REPO}#<N>](<github URL>) - <one-sentence summary>
 ```
 
-Then comment in the SiYuan sub-doc (use `mcp__siyuan__append_block` against the sub-doc's block ID): `**Approved YYYY-MM-DD:** shipped as [${PACMAN_GITHUB_REPO}#<N>](<github URL>).`
+Then append to the proposal doc (use `mcp__secondbrain__append_to_doc` against the row's `proposal_doc_id`): `**Approved YYYY-MM-DD:** shipped as [${PACMAN_GITHUB_REPO}#<N>](<github URL>).`
 
 ## Invocation modes (where URLs come from)
 
@@ -254,11 +292,11 @@ Then comment in the SiYuan sub-doc (use `mcp__siyuan__append_block` against the 
 The installer types in the configured Discord channel: `Pacman https://example.com/article`, OR a list of URLs in any layout (space / newline / comma / markdown bullet). The main session extracts all `https?://...` substrings from the message body following the `Pacman` keyword, dedupes them, and invokes this skill on each URL sequentially.
 
 For batches (>1 URL):
-- Each URL is processed through the full 4-gate pipeline independently. Drop a URL at gate N, propose a different URL — both behaviors are independent.
+- Each URL is processed through the full 4-gate pipeline independently. Drop a URL at gate N, propose a different URL - both behaviors are independent.
 - Drop notes are per-URL (verbose).
-- Proposals are per-URL (each one its own SiYuan sub-doc + Discord 4-section TLDR).
+- Proposals are per-URL (each one its own adapter sub-doc + Discord 4-section TLDR).
 - After all URLs processed, post a single batch-summary line to the configured channel: `Pacman batch: processed N URL(s) (P proposals, D drops).`
-- Cap a single Discord message at `${PACMAN_MAX_BATCH_URLS}` (default 10) URLs per batch — if more are pasted, process the first N and post a note `Pacman: capped batch at N URLs, paste the remaining M as a new message`. Prevents context blowout on huge link dumps.
+- Cap a single Discord message at `${PACMAN_MAX_BATCH_URLS}` (default 10) URLs per batch - if more are pasted, process the first N and post a note `Pacman: capped batch at N URLs, paste the remaining M as a new message`. Prevents context blowout on huge link dumps.
 
 ### Mode B: Telegram 👀 reaction (optional, off by default)
 
@@ -270,41 +308,59 @@ The reaction processor exits silently when those env vars aren't set, so the scr
 
 ### Mode C: heartbeat-drained queue
 
-A Pacman heartbeat fires periodically (suggested cadence: every 4h, configurable in HEARTBEATS.md). It reads new sub-docs of `/To Investigate` that haven't been processed (no `pacman_processed` attribute set), runs the 4-gate pipeline on each, and either drops or proposes. Cap the batch at `${PACMAN_MAX_BATCH_URLS}` URLs per fire to bound token cost.
+A Pacman heartbeat fires periodically (suggested cadence: every 4h, configurable in HEARTBEATS.md). `chassis/scripts/gather-pacman-queue.sh` counts claimable rows first, so the heartbeat costs zero Claude tokens when the queue is empty. When it fires, the drain claims a batch with `pacman-queue.py claim --limit ${PACMAN_MAX_BATCH_URLS}`, runs the 4-gate pipeline on each row, and completes each one. Prompt: `chassis/scheduled-tasks/pacman-drain-prompt.md`.
 
 ### Mode D: manual CLI
 
-- `bash chassis/scripts/pacman.sh <url>` — process one URL.
-- `bash chassis/scripts/pacman.sh <url1> <url2> <url3> ...` — process multiple URLs in a batch.
-- `bash chassis/scripts/pacman.sh --stdin` — read URLs from stdin (one per line, or whitespace/comma-separated, or any text containing `https?://...` substrings).
-- `bash chassis/scripts/pacman.sh --queue` — drain the SiYuan `/To Investigate` queue (cap `${PACMAN_MAX_BATCH_URLS}`).
+- `bash chassis/scripts/pacman.sh <url>` - process one URL.
+- `bash chassis/scripts/pacman.sh <url1> <url2> <url3> ...` - process multiple URLs in a batch.
+- `bash chassis/scripts/pacman.sh --stdin` - read URLs from stdin (one per line, or whitespace/comma-separated, or any text containing `https?://...` substrings).
+- `bash chassis/scripts/pacman.sh --queue` - drain the Pacman queue (cap `${PACMAN_MAX_BATCH_URLS}`).
 
-Each invocation runs the same gate logic, posts to the configured Discord channel, writes to SiYuan. Useful for testing gate calibration without going through Discord.
+Each invocation runs the same gate logic, posts to the configured Discord channel, writes through the second-brain adapter. Useful for testing gate calibration without going through Discord.
 
 ## Calibration notes
 
-- **Gate 1 (relevance) is prone to over-reject.** When in doubt, lean toward pass — it's better to surface a borderline idea and let the installer reject it in the Discord approval step than to drop it silently. Verbose drop notes help catch over-rejects.
-- **Gate 3 (feasibility) needs an up-to-date stack model.** Re-read the install's `CLAUDE.md` and the most recent `briefings/` files at the start of each Pacman run — the stack changes weekly.
-- **Idempotency:** every URL processed gets logged to `$CHASSIS_HOME/logs/pacman/YYYY-MM-DD.jsonl` with a hash of the URL. Before processing, check the last 30 days of logs — if the same URL was already processed, skip with a Discord note "Pacman: <url> already processed YYYY-MM-DD (gate <N>: <action>)".
+- **Gate 1 (relevance) is prone to over-reject.** When in doubt, lean toward pass - it's better to surface a borderline idea and let the installer reject it in the Discord approval step than to drop it silently. Verbose drop notes help catch over-rejects.
+- **Gate 3 (feasibility) needs an up-to-date stack model.** Re-read the install's `CLAUDE.md` and the most recent `briefings/` files at the start of each Pacman run - the stack changes weekly.
+- **Idempotency:** every URL processed gets logged to `$CHASSIS_HOME/logs/pacman/YYYY-MM-DD.jsonl` with a hash of the URL. Before processing, check the last 30 days of logs - if the same URL was already processed, skip with a Discord note "Pacman: <url> already processed YYYY-MM-DD (gate <N>: <action>)".
 
-## SiYuan structure (canonical)
+## Storage layout (canonical)
 
-- **Queue doc** — `/To Investigate` (block ID `${PACMAN_SIYUAN_QUEUE_BLOCK_ID}`). URLs waiting to be processed live here as paragraph or heading blocks. After processing, the block is deleted (true queue semantics — see "Drop logging" + "Approval flow" steps).
-- **Proposal sub-docs** — `/To Investigate/YYYY-MM-DD-<slug>` for each URL that passed all 4 gates. Short triage summaries (under 250 words). The installer reads these to decide approve/reject/defer.
-- **Dropped audit trail** — `/To Investigate/Dropped` (block ID `${PACMAN_SIYUAN_DROPPED_BLOCK_ID}`). Pacman appends a 1-line entry per dropped URL: date, URL, gate that dropped it, reason. Append-only audit trail for catching over-rejections.
+- **Queue** - Postgres table `chassis_pacman_queue`, one row per URL. Never read or written directly by the skill; go through `chassis/scripts/pacman-queue.py`. A row leaves the pending set when `complete` is called on its token (true queue semantics - see "Drop logging" + "Approval flow" steps).
+- **Proposal sub-docs** - written under `${PACMAN_PROPOSALS_PARENT}` via `mcp__secondbrain__create_doc`, titled `YYYY-MM-DD-<slug>`, one per URL that passed all 4 gates. The installer reads these to decide approve/reject/defer. The returned `doc_id` is stored on the queue row as `proposal_doc_id`.
+- **Dropped audit trail** - `${PACMAN_DROPPED_DOC_ID}` via `mcp__secondbrain__append_to_doc`. One line per dropped URL: date, URL, gate that dropped it, reason. Append-only audit trail for catching over-rejections.
+
+Nothing here names a backend. On a SiYuan install the adapter writes SiYuan docs, on Obsidian it writes vault files, on Notion it writes pages, and the skill does not change.
+
+### Seeing what is queued
+
+Moving the queue out of the second brain cost the installer the ability to open `/To Investigate` and read what is pending. That trade is paid back by:
+
+```bash
+python3 chassis/scripts/pacman-queue.py pending --limit 25
+```
+
+which lists claimable rows oldest-first with their tokens, and does not claim anything.
 
 ## Files
 
-- `chassis/skills/pacman.md` — this playbook.
-- `chassis/scripts/pacman.sh` — manual invocation wrapper.
-- `chassis/scripts/pacman-queue-add.py` — append-URL-to-queue helper called by Telegram reaction processor.
-- `chassis/scripts/pacman-process-reactions.py` — Telegram 👀 reaction handler (Mode B).
-- `chassis/scheduled-tasks/pacman-drain-prompt.md` — heartbeat prompt that drives the gate pipeline (Mode C).
-- `$CHASSIS_HOME/logs/pacman/YYYY-MM-DD.jsonl` — per-URL processing log.
+- `chassis/skills/pacman.md` - this playbook.
+- `chassis/pacman/queue.py` - queue operations against Postgres. The only place queue SQL lives.
+- `chassis/pacman/tokens.py` - approval token generation and the canonical approval regex.
+- `chassis/db/migrations/001_pacman_queue.sql` - the `chassis_pacman_queue` schema.
+- `chassis/scripts/pacman-queue.py` - CLI over the queue (`add` / `count` / `pending` / `claim` / `complete` / `release`).
+- `chassis/scripts/pacman.sh` - manual invocation wrapper.
+- `chassis/scripts/pacman-queue-add.py` - append-URL-to-queue helper called by the Telegram reaction processor.
+- `chassis/scripts/pacman-process-reactions.py` - Telegram 👀 reaction handler (Mode B).
+- `chassis/scripts/gather-pacman-queue.sh` - dispatcher gate; emits `{"count": N}`.
+- `chassis/scripts/pacman-migrate-siyuan-queue.py` - one-time SiYuan backfill, run once per install.
+- `chassis/scheduled-tasks/pacman-drain-prompt.md` - heartbeat prompt that drives the gate pipeline (Mode C).
+- `$CHASSIS_HOME/logs/pacman/YYYY-MM-DD.jsonl` - per-URL processing log.
 
 ## Hard rules
 
-- **Never auto-create a GH issue.** Issue creation requires the installer's explicit `approve <block-id>` reply in Discord.
+- **Never auto-create a GH issue.** Issue creation requires the installer's explicit `approve <token>` reply in Discord.
 - **Never spam the configured channel.** If the queue has more than 5 unprocessed URLs that all pass gate 1, batch the proposal posts (one Discord message with multiple proposals) rather than 5 separate messages.
-- **Never expose API keys, tokens, or credentials in any proposal output, drop note, or SiYuan doc.**
-- **Respect `PACMAN_HARD_PAUSE` flag** — if a file exists at `$PACMAN_HARD_PAUSE` (or default `$CHASSIS_HOME/PACMAN_HARD_PAUSE`), Pacman pauses immediately without invoking claude.
+- **Never expose API keys, tokens, or credentials in any proposal output, drop note, or proposal doc.**
+- **Respect `PACMAN_HARD_PAUSE` flag** - if a file exists at `$PACMAN_HARD_PAUSE` (or default `$CHASSIS_HOME/PACMAN_HARD_PAUSE`), Pacman pauses immediately without invoking claude.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,6 +7,7 @@
 #   install-plugin <name>
 #                    - one-shot: run plugins/<name>/install.sh
 #   hydrate-env      - one-shot: pull secrets from Vaultwarden via rbw, write to .env
+#   migrate          - one-shot: apply chassis/db/migrations/*.sql
 #   smoke-test       - one-shot: run chassis + plugin smoke checks
 #   claude           - interactive Claude CLI (needs -it)
 #   shell            - interactive zsh (needs -it)
@@ -78,9 +79,26 @@ run_dispatcher_once() {
     touch /tmp/dispatcher.alive
 }
 
+run_chassis_migrations() {
+    # Idempotent and advisory-locked, so running it on every boot is safe and
+    # two containers starting together cannot race. Non-fatal on failure: an
+    # install with no Postgres still gets a dispatcher, it just gets a Pacman
+    # queue that fails loudly when touched (which is the intended behaviour -
+    # see chassis/db/connection.py).
+    (cd /app && python3 -m chassis.db.migrate) || \
+        log "WARN: chassis migrations did not apply - Postgres-backed features will fail loudly until they do"
+}
+
+cmd_migrate() {
+    ensure_customer_layout
+    source_env
+    (cd /app && exec python3 -m chassis.db.migrate "$@")
+}
+
 cmd_dispatcher() {
     ensure_customer_layout
     source_env
+    run_chassis_migrations
     log "dispatcher loop starting - tick=${DISPATCHER_INTERVAL_SECONDS}s, CHASSIS_HOME=$CHASSIS_HOME"
     # Touch sentinel up-front so healthcheck doesn't fail before first tick.
     touch /tmp/dispatcher.alive
@@ -97,6 +115,7 @@ cmd_dispatcher() {
 cmd_bootstrap() {
     ensure_customer_layout
     source_env
+    run_chassis_migrations
     log "running bootstrap.sh against CHASSIS_HOME=$CHASSIS_HOME"
     CHASSIS_HOME="$CHASSIS_HOME" bash /app/bootstrap.sh "$@"
 }
@@ -156,12 +175,13 @@ case "$MODE" in
     bootstrap)        cmd_bootstrap        "$@" ;;
     install-plugin)   cmd_install_plugin   "$@" ;;
     hydrate-env)      cmd_hydrate_env      "$@" ;;
+    migrate)          cmd_migrate          "$@" ;;
     smoke-test)       cmd_smoke_test       "$@" ;;
     claude)           cmd_claude           "$@" ;;
     shell)            cmd_shell            "$@" ;;
     *)
         echo "unknown mode: $MODE" >&2
-        echo "valid modes: dispatcher | bootstrap | install-plugin <name> | hydrate-env | smoke-test | claude | shell" >&2
+        echo "valid modes: dispatcher | bootstrap | install-plugin <name> | hydrate-env | migrate | smoke-test | claude | shell" >&2
         exit 2
         ;;
 esac

--- a/docs/pacman-queue-storage.md
+++ b/docs/pacman-queue-storage.md
@@ -1,6 +1,9 @@
 # Pacman queue storage - design proposal
 
-**Status:** proposal, not ratified. Nothing in this document is implemented.
+**Status:** ratified by Sean and implemented, 2026-07-19. Option A, sequenced
+A1 → A2 → A3 in a single PR. Section 9 records what actually shipped and where
+it differs from the proposal; sections 1 through 8 are left as written so the
+reasoning stays readable against the decision.
 **Author:** Jax, 2026-07-19
 **Decision owner:** Sean
 **Context:** Stage 2 of the second-brain adapter work. PR #58 listed "Pacman
@@ -314,3 +317,109 @@ not touch it.
    or accept that the queue becomes opaque?
 4. Approval tokens: widen the regex, or issue short opaque tokens? (Short
    tokens recommended - phone ergonomics.)
+
+---
+
+## 9. What shipped
+
+Option A, with A1, A2 and A3 in one PR. Differences from the proposal above,
+and the answers to section 8's four questions.
+
+### Answers to the open questions
+
+1. **Option A (Postgres).** As recommended.
+2. **Yes, `chassis/db/` was promoted first.** It is deliberately smaller than
+   the dating plugin's selector: DSN resolution, a connection helper, and a
+   migration runner. No backend selector and no ORM. The chassis already
+   decided Postgres is canonical, so core code does not inherit BFL's
+   SQLite-mirror branch. `plugins/dating/scripts/_chassis_db.py` is left
+   untouched - migrating it is a separate change with its own blast radius.
+3. **Replaced with a CLI listing, not a Discord command.**
+   `pacman-queue.py pending` lists claimable rows with their tokens and claims
+   nothing. A Discord `pacman queue` command is a thin wrapper over that if it
+   is ever wanted; the visibility itself is no longer missing.
+4. **Short opaque tokens**, as recommended. Details below.
+
+### The approval token
+
+Six characters from `bcdfghjkmnpqrstvwxz` - 19 lowercase letters, no digits,
+no vowels, no `y`, no `i`/`l`/`o`. Generated at enqueue, unique per row,
+identical on every backend. `chassis/pacman/tokens.py` owns the generator and
+the canonical `APPROVAL_RE`.
+
+The collision constraint in section 6 turned out to have a stronger answer than
+"unlikely". Because the alphabet contains no digits, a token can never be
+parsed as an integer, so it cannot collide with the outreach flow's numeric
+`approve N` form under any input - a structural guarantee rather than a
+probabilistic one. Dropping the vowels adds a second property for free: no
+six-letter English word survives, so `approve later` cannot be misread as a
+token either. Both directions are asserted in
+`chassis/pacman/tests/test_tokens.py`, including over a shared input set where
+no message may be accepted by both handlers.
+
+The legacy `\d{14}-\w{7}` form is still accepted, flagged as `legacy` by the
+parser, so proposals posted to Discord before the cutover remain approvable.
+Drop that alternative once none are outstanding.
+
+### Schema differences from the section 5 sketch
+
+- Added `token TEXT NOT NULL UNIQUE` - the sketch predated the decision to make
+  the queue row own the approval handle.
+- Added `legacy_block_id TEXT` plus a partial unique index on
+  `(legacy_block_id, url) WHERE legacy_block_id IS NOT NULL`. This is the
+  backfill's idempotency key. It has to be the pair and not the block alone,
+  because a block holding two URLs becomes two rows - the exact failure
+  section 7 step 4 exists to catch.
+- `entry_group` is `NOT NULL`. Every row belongs to a group even when the group
+  has one member; a nullable group would mean two code paths at read time.
+
+### One bug found during implementation
+
+`UPDATE ... RETURNING` does not preserve the ORDER BY of the subquery that
+selects the ids. The first version of `claim()` ordered only inside that
+subquery, so Postgres returned batches in update order and the drain processed
+out of FIFO order. Every fake-connection test passed; only the opt-in
+live-Postgres test caught it. `claim()` now wraps the update in a CTE and
+orders in an outer SELECT, and the ordering key is `(created_at, id)` rather
+than `created_at` alone, because `add_many` inserts a pasted batch in a tight
+loop and two rows can share a microsecond. Both properties have regression
+tests that run without a database.
+
+### Operator procedure
+
+Section 7's sequence holds, with concrete commands. Steps 2 and 3 are
+idempotent, so a partial run is retried by re-running it.
+
+```bash
+# 1. Freeze. Both gather-pacman-queue.sh and pacman.sh already honor this.
+touch "$CHASSIS_HOME/PACMAN_HARD_PAUSE"
+
+# 2. Apply the schema.
+docker compose run --rm chassis migrate
+
+# 3. Snapshot and inspect before writing anything. Keep the JSON - it is the rollback.
+docker compose run --rm chassis shell -c \
+  'python3 chassis/scripts/pacman-migrate-siyuan-queue.py --dry-run --snapshot /app/customer/state/pacman-queue-snapshot.json'
+
+# 4. Backfill. Non-zero exit means something was reported rather than migrated - read it.
+docker compose run --rm chassis shell -c \
+  'python3 chassis/scripts/pacman-migrate-siyuan-queue.py --snapshot /app/customer/state/pacman-queue-snapshot.json'
+
+# 5. Verify the row count matches the snapshot's URL count, and the order.
+docker compose run --rm chassis shell -c 'python3 chassis/scripts/pacman-queue.py pending --limit 100'
+
+# 6. Unfreeze and watch one real drain.
+rm "$CHASSIS_HOME/PACMAN_HARD_PAUSE"
+```
+
+Step 7 of section 7 - deleting the SiYuan blocks - stays manual and stays
+last. The backfill script never deletes anything, and a test asserts it
+contains no delete call at all.
+
+**On Sean's install specifically:** the dry run reads 0 blocks. `/To Investigate`
+(`20260409114829-al0ay1t`) exists and holds 158 blocks, but none contain a URL
+in either the `content` or `markdown` column, so there is nothing in flight to
+migrate. The backfill is still the right thing to ship for other installs and
+for the audit trail, but on this install steps 3 and 4 are expected to be
+no-ops. Do not read a `0` there as a failed query - it was checked directly
+against SiYuan, not inferred.


### PR DESCRIPTION
Implements `docs/pacman-queue-storage.md` (Option A, sequenced A1 to A3 in one PR, per the recommendation). Follows PR #78's Stage 2 work, which made the SiYuan-only drain fail loudly rather than silently; this removes the reason it was failing.

**Do not merge without reading the "Operator procedure" section below.** There is a cutover, and it has an order.

## The problem

Pacman stored its work queue as SiYuan blocks and used SiYuan block IDs as queue handles. SiYuan is one of three supported second brains, so Pacman was broken on Notion and Obsidian installs and broken on any install running `second_brain.mode: adapter`, where the native SiYuan MCP server is deliberately not registered. Pacman is chassis-core, so that is a defect rather than a limitation.

## What changed

### A1 - `chassis/db/`

The module `plugins/dating/scripts/_chassis_db.py` says is missing in its own docstring. Three things and no more:

- `connection.py` - DSN resolution (`CHASSIS_PG_DSN`, then `BEHALFBOT_PG_DSN`, then `JAX_PG_DSN`), a connection helper, and one exception type.
- `migrate.py` - applies `chassis/db/migrations/*.sql` in order, records them in a ledger, holds an advisory lock so two containers booting together cannot race. No down-migrations, no checksums.
- `migrations/001_pacman_queue.sql`.

Deliberately **not** a backend selector and **not** an ORM. The dating plugin's selector branches on SQLite because BFL predates the "Postgres from start" call and still has a mirror to keep alive; core code has no such history and should not inherit the branch. `_chassis_db.py` is left untouched - migrating it is a separate change with its own blast radius.

The failure mode is the point. A queue that returns zero rows because Postgres is unreachable is indistinguishable from an empty queue, and the queue is the only durable record that a URL was ever submitted. Every path raises `ChassisDBUnavailable` with a message naming the variable to set or the service to check.

### A2 - the queue

`chassis_pacman_queue`, one row per URL. Beyond the design note's sketch:

- `claimed_at` - a drain that dies mid-batch leaves a stale claim, reclaimable after `PACMAN_CLAIM_TIMEOUT_MINUTES` (default 60). The old design could not express "being processed" at all, so a dead drain either lost URLs or reprocessed them.
- `legacy_block_id` plus a partial unique index on `(legacy_block_id, url)`. This is the backfill's idempotency key. It has to be the pair, not the block alone, because a block holding two URLs becomes two rows - the exact failure section 7 step 4 of the design note exists to catch.

`pending_count` and `claim` share one `PENDING_PREDICATE` constant, with a test asserting both statements embed it. If they drift, the dispatcher either burns Claude tokens on an empty queue or leaves real work permanently unclaimed.

Writes are durable before the caller acknowledges. `pacman-queue-add.py` was previously documented as "designed to fail silently", which was survivable only while the URL was also sitting in a Discord message someone could scroll back to.

### A3 - the approval id

This is the part the design note flagged as easy to miss, and a queue-migration test would not have caught it.

The token is now **the queue row's own handle, not a second-brain document id**. Six characters from `bcdfghjkmnpqrstvwxz` - 19 lowercase letters, no digits, no vowels, no `y`, no `i`/`l`/`o`. Generated at enqueue, unique, identical on every backend.

The collision constraint has a stronger answer than "unlikely":

- **No digits means a token can never be parsed as an integer**, so it cannot collide with the outreach flow's numeric `approve N` form under any input. That is structural, not probabilistic. `test_tokens.py` asserts it in both directions and over a shared input set where no message may be accepted by both handlers (20k samples per direction).
- **No vowels means no six-letter English word survives**, so `approve later` cannot be misread as a token either.
- Six characters, one case, no ambiguous glyphs. Sean approves from his phone; a 32-char Notion UUID is unusable there.

Legacy `\d{14}-\w{7}` block IDs are still accepted and flagged as `legacy` by the parser, so proposals posted before the cutover stay approvable. Drop that alternative once none are outstanding.

### A3 (cont.) - adapter mode

Every Pacman write now goes through `mcp__secondbrain__*`. Queue reads and completion go through `pacman-queue.py`. No Pacman runtime file names a SiYuan tool any more, and `test_backend_neutrality.py` asserts that as a negative - if one reappears, the backend branch is back and one of the three backends is silently broken again.

The prompt and skill *are* the implementation for a model-driven pipeline, so a SiYuan block-delete call left in the drain prompt is executable code. Those string assertions are the only thing that can fail when it drifts.

## A bug found during implementation

`UPDATE ... RETURNING` does not preserve the `ORDER BY` of the subquery that selects the ids. The first version of `claim()` ordered only inside that subquery, so Postgres returned batches in update order and **the drain processed out of FIFO order**. Every fake-connection test passed. Only the opt-in live-Postgres test caught it.

`claim()` now wraps the update in a CTE and orders in an outer SELECT, keyed on `(created_at, id)` rather than `created_at` alone - `add_many` inserts a pasted batch in a tight loop and two rows can share a microsecond. Both properties have regression tests that run without a database.

## Operator procedure

Steps 2 and 3 are idempotent; a partial run is retried by re-running it. The backfill never deletes anything, and a test asserts it contains no delete call at all.

```bash
# 1. Freeze. Both gather-pacman-queue.sh and pacman.sh already honor this.
touch "$CHASSIS_HOME/PACMAN_HARD_PAUSE"

# 2. Apply the schema.
docker compose run --rm chassis migrate

# 3. Snapshot and inspect before writing anything. Keep the JSON - it is the rollback.
docker compose run --rm chassis shell -c \
  'python3 chassis/scripts/pacman-migrate-siyuan-queue.py --dry-run --snapshot /app/customer/state/pacman-queue-snapshot.json'

# 4. Backfill. Non-zero exit means something was reported rather than migrated - read it.
docker compose run --rm chassis shell -c \
  'python3 chassis/scripts/pacman-migrate-siyuan-queue.py --snapshot /app/customer/state/pacman-queue-snapshot.json'

# 5. Verify row count and order against the snapshot.
docker compose run --rm chassis shell -c 'python3 chassis/scripts/pacman-queue.py pending --limit 100'

# 6. Unfreeze, watch one real drain end to end.
rm "$CHASSIS_HOME/PACMAN_HARD_PAUSE"
```

Removing the old SiYuan blocks stays manual and stays last, after a full clean drain cycle.

**On Sean's install, steps 3 and 4 are expected to be no-ops.** The dry run reads 0 blocks. `/To Investigate` (`20260409114829-al0ay1t`) exists and holds 158 blocks, but none contain a URL in either the `content` or `markdown` column - checked directly against the live SiYuan API, not inferred from the script. There is nothing in flight to lose. The backfill still ships for other installs and for the audit trail.

## Verification

- **Full suite, no database: 330 passed, 12 skipped** (was 193 passed before this PR). Skips carry a message explaining how to enable them. CI needs no Postgres.
- **With a live Postgres** (throwaway `pacman_ci_tmp` on `behalfbot-postgres`): **149 passed, 0 skipped** across the new suites. This is the layer that caught the FIFO bug.
- **End-to-end against a real database**, driving the actual scripts rather than the library: enqueue via both `pacman-queue-add.py` and `pacman-queue.py add`; `gather-pacman-queue.sh` returning `{"count": 3}`; `pending` listing in order; `claim --limit 2` returning the two oldest; gate dropping to `{"count": 1}` after the claim; `complete` twice on one token returning `changed: true` then `changed: false` with the first verdict preserved; `release` returning a row to the pending set. An Obsidian-shaped `--doc-id` (`To Investigate/2026-07-19-thing.md`) round-tripped through `proposal_doc_id` unparsed.
- **Loud failure confirmed**: with an unreachable DSN, `gather-pacman-queue.sh` exits 1 and prints nothing resembling `{"count": 0}`; the dispatcher records that as `gather_failed`. Previously it printed `{"count": 0}` and exited 0.
- **Dry-run backfill against the live SiYuan queue**, read-only, as recorded above.
- `bash -n` clean on all three modified shell scripts.

## Notes

- **`chassis/VERSION` deliberately untouched** - separate bump PR for Sean.
- I created a throwaway `pacman_ci_tmp` database on `behalfbot-postgres` for the live tests. The guardrail hook correctly blocked me from removing it, so it is still there and needs clearing by hand. It contains only test rows.
- Out of scope, found while working: `plugins/dating/scripts/_chassis_db.py` now has a chassis-core module it could delegate to, and its docstring's "until the chassis grows one" is satisfied. Migrating it is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
