### PR TITLE
feat(gmail): fetch attachments over IMAP, ported to the chassis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,3 +108,24 @@ VAULTWARDEN_DOMAIN=http://localhost:8222
 # refuses every write. It is not itself a credential, but it lives beside them.
 # The server appends to this file when it creates a sheet, so it must be writable.
 # GOOGLE_SHEETS_ALLOWLIST=/app/customer/secrets/google/sheets-allowlist.json
+
+# --- Gmail attachments (IMAP) -----------------------------------------------
+# Read by chassis/scripts/gmail-attachment.py. Independent of the OAuth block
+# above and deliberately so: no Gmail connector, hosted or self-hosted, exposes
+# an attachment endpoint, and the OAuth path has a failure mode this one does
+# not. A consent screen left at External + Testing issues refresh tokens that
+# expire after seven days, silently. IMAP has no consent screen, no Cloud
+# project, and no expiry cliff.
+#
+# Both values come from the Vaultwarden item "Behalf.bot - Google Workspace
+# agent" and are written here by chassis/scripts/hydrate-env-from-vw.sh -
+# username field to GOOGLE_AGENT_EMAIL, password field to
+# GOOGLE_AGENT_APP_PASSWORD. Set them by hand only on an install with no
+# Vaultwarden.
+#
+# The password is a Google APP PASSWORD, not the account password. It requires
+# 2FA on the account, and a Workspace admin can disable app passwords
+# org-wide - check that before debugging anything else. Setup and failure
+# modes: docs/gmail-attachments.md.
+# GOOGLE_AGENT_EMAIL=
+# GOOGLE_AGENT_APP_PASSWORD=

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,6 +10,8 @@ on:
     paths:
       - 'chassis/second_brain/**'
       - 'chassis/scripts/hydrate-mcp-json.py'
+      - 'chassis/scripts/gmail-attachment.py'
+      - 'chassis/scripts/tests/**'
       - 'chassis/.mcp.json.template'
       - 'chassis.config.yaml'
       - 'requirements.txt'
@@ -19,6 +21,8 @@ on:
     paths:
       - 'chassis/second_brain/**'
       - 'chassis/scripts/hydrate-mcp-json.py'
+      - 'chassis/scripts/gmail-attachment.py'
+      - 'chassis/scripts/tests/**'
       - 'chassis/.mcp.json.template'
       - 'chassis.config.yaml'
       - 'requirements.txt'
@@ -38,4 +42,4 @@ jobs:
       # mcp is pinned to the same version as requirements.txt so the e2e
       # server test exercises what the image ships.
       - run: pip install pytest pyyaml mcp==1.28.1
-      - run: python3 -m pytest chassis/second_brain/tests/ -v
+      - run: python3 -m pytest chassis/second_brain/tests/ chassis/scripts/tests/ -v

--- a/chassis/scripts/gmail-attachment.py
+++ b/chassis/scripts/gmail-attachment.py
@@ -1,0 +1,713 @@
+#!/usr/bin/env python3
+"""gmail-attachment.py - Fetch Gmail attachments over IMAP.
+
+The Claude.ai Gmail connector exposes get_thread / get_message /
+search_threads / create_draft / label ops and no attachment endpoint at all.
+Every install hits that wall the first time someone forwards a PDF, so this
+belongs in the chassis rather than in one customer's tree. Ported from
+scrollinondubs/new-jaxity#314 (decision record: new-jaxity#311).
+
+Why IMAP + a Workspace app password, and not a self-hosted Gmail MCP with our
+own OAuth: an OAuth consent screen left at External + Testing issues refresh
+tokens that expire after seven days. The failure is silent - the agent simply
+stops being able to read mail, with no error until someone looks. At least one
+install in this fleet is believed to have been sitting in that state
+(gmail-ozzy). IMAP has no consent screen, no Cloud project, and no expiry
+cliff. A service account with domain-wide delegation was also rejected: DWD
+grants access to every mailbox on the domain, which is wildly disproportionate
+for fetching a PDF.
+
+Standard library only - imaplib, email, ssl. No new dependencies, nothing to
+add to requirements.txt.
+
+Read-only. This script never sets IMAP flags, moves messages, or marks
+anything as read: it opens mailboxes with readonly=True and fetches with
+BODY.PEEK[]. Flag-writing (a Processed-label workflow) would land separately.
+
+Credentials
+===========
+Two env vars, both already in the default Vaultwarden manifest in
+chassis/scripts/hydrate-env-from-vw.sh under "Behalf.bot - Google Workspace
+agent":
+
+    GOOGLE_AGENT_EMAIL          the mailbox to read (also the IMAP username)
+    GOOGLE_AGENT_APP_PASSWORD   a Google app password for that account
+
+Deliberately no aliases and no second accepted name for either var. The
+chassis has already been bitten once by carrying two names for one secret
+(NOTION_API_TOKEN vs NOTION_INTEGRATION_TOKEN - see the note in
+hydrate-env-from-vw.sh): an installer who followed the wrong one shipped a
+literal placeholder as a bearer token and 401'd on every call.
+
+The password is read at invocation time, never written to disk by this
+script, and never included in any log or error message.
+
+Operator setup: see docs/gmail-attachments.md.
+
+CLI usage:
+  # List attachments on the message matching a Gmail search
+  python3 chassis/scripts/gmail-attachment.py list --gmail-search 'subject:"Invoice"'
+
+  # Fetch one by name (substring match) or by the index shown by `list`
+  python3 chassis/scripts/gmail-attachment.py fetch --gmail-search '...' --name Invoice -o ~/Downloads
+  python3 chassis/scripts/gmail-attachment.py fetch --gmail-search '...' --index 0 -o ~/Downloads
+
+  # Fetch everything
+  python3 chassis/scripts/gmail-attachment.py fetch-all --message-id '<abc@mail.example>' -o ~/Downloads
+
+  # Config check for smoke-test.sh - env only, no network
+  python3 chassis/scripts/gmail-attachment.py check
+"""
+from __future__ import annotations
+
+import argparse
+import email
+import imaplib
+import os
+import re
+import sys
+from email.header import decode_header, make_header
+from email.message import Message
+from pathlib import Path
+from typing import Iterable, Iterator, NamedTuple
+
+IMAP_HOST = "imap.gmail.com"
+IMAP_PORT = 993
+
+# The env var contract. See the module docstring for why there is exactly one
+# accepted name per value.
+ENV_USER = "GOOGLE_AGENT_EMAIL"
+ENV_PASSWORD = "GOOGLE_AGENT_APP_PASSWORD"
+
+# Gmail's "All Mail" is the only folder guaranteed to contain a message
+# regardless of which label it carries, so it is the right default to search.
+DEFAULT_MAILBOX = "[Gmail]/All Mail"
+
+# Refuse to write anything larger than this. A 25 MB cap matches Gmail's own
+# per-message attachment limit, so a legitimate attachment cannot exceed it.
+DEFAULT_MAX_BYTES = 25 * 1024 * 1024
+
+# Characters allowed through to the filesystem. Everything else becomes "_".
+# Deliberately an allowlist: attachment filenames arrive from whoever sent
+# the mail, so a denylist is the wrong shape here.
+_SAFE_CHARS = re.compile(r"[^A-Za-z0-9._ ()\[\]+,&@-]")
+
+_MAX_FILENAME_LEN = 200
+
+# How many matching messages to download while hunting for one with an
+# attachment. A thread search can match dozens; downloading all of them to
+# answer "where is the PDF" is wasteful.
+_MAX_SCAN = 25
+
+
+class Attachment(NamedTuple):
+    """One attachment leaf found in a message tree."""
+
+    filename: str  # already sanitised
+    raw_filename: str  # as it appeared on the wire, for display only
+    content_type: str
+    part: Message
+    path: tuple[int, ...]  # index path through the MIME tree
+    nested: bool  # True if it lives inside a message/rfc822 forward
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers. These are the parts under unit test - no mailbox required.
+# ---------------------------------------------------------------------------
+
+
+def decode_encoded_word(value: str | None) -> str:
+    """Decode an RFC 2047 encoded-word header, e.g. =?UTF-8?B?...?=.
+
+    Message.get_filename() collapses RFC 2231 continuations but leaves RFC
+    2047 encoded-words untouched, so senders that use the older form come
+    back as literal "=?UTF-8?B?..." text without this step.
+    """
+    if not value:
+        return ""
+    try:
+        return str(make_header(decode_header(value)))
+    except Exception:
+        # A malformed header must not abort the whole fetch. Falling back to
+        # the raw string is safe: sanitize_filename() runs on it either way.
+        return value
+
+
+def sanitize_filename(raw: str | None, fallback: str = "attachment.bin") -> str:
+    """Reduce an attacker-controlled filename to a single safe path segment.
+
+    Someone can email a file called ../../.ssh/authorized_keys. Everything
+    that could steer the write elsewhere is stripped here; safe_join() then
+    re-checks the resolved path as a second, independent barrier.
+    """
+    if not raw:
+        return fallback
+
+    name = decode_encoded_word(raw)
+    name = name.replace("\x00", "")
+
+    # Normalise backslashes to forward slashes before taking the basename,
+    # otherwise a Windows-style "..\\..\\evil" survives posix basename intact.
+    name = name.replace("\\", "/")
+    name = name.split("/")[-1]
+
+    name = _SAFE_CHARS.sub("_", name)
+    name = re.sub(r"\s+", " ", name).strip()
+
+    # Leading/trailing dots would leave ".." and "." intact and would create
+    # hidden files from names like ".bashrc".
+    name = name.strip(". ")
+
+    if not name:
+        return fallback
+
+    if len(name) > _MAX_FILENAME_LEN:
+        stem, dot, ext = name.rpartition(".")
+        if dot and len(ext) <= 10:
+            name = stem[: _MAX_FILENAME_LEN - len(ext) - 1] + "." + ext
+        else:
+            name = name[:_MAX_FILENAME_LEN]
+
+    return name
+
+
+def safe_join(target_dir: str | os.PathLike, filename: str) -> Path:
+    """Resolve filename inside target_dir, refusing anything that escapes.
+
+    resolve() follows symlinks, so this also rejects the case where the
+    target directory contains a symlink pointing outside the tree.
+    """
+    base = Path(target_dir).resolve()
+    candidate = (base / filename).resolve()
+    if candidate == base or base not in candidate.parents:
+        raise ValueError(
+            f"refusing to write outside {base}: sanitised name {filename!r} "
+            f"resolved to {candidate}"
+        )
+    return candidate
+
+
+def get_part_filename(part: Message) -> str:
+    """Best-effort filename for a MIME part, before sanitisation."""
+    raw = part.get_filename()
+    if not raw:
+        # Some senders put the name only in Content-Type; name= is legacy but
+        # still common from Outlook and from scanner/MFP appliances.
+        raw = part.get_param("name")
+        if isinstance(raw, tuple):
+            # RFC 2231 form: (charset, language, value)
+            raw = raw[2]
+    return decode_encoded_word(raw) if raw else ""
+
+
+def is_attachment(part: Message, include_inline: bool = False) -> bool:
+    """Decide whether a leaf part is something a caller wanted saved.
+
+    The case that matters: an HTML mail with an embedded logo has an
+    image/png part with Content-Disposition: inline and a Content-ID that the
+    HTML references. That is page furniture, not an attachment, and treating
+    it as one buries the real file in noise.
+    """
+    disposition = (part.get_content_disposition() or "").lower()
+    filename = get_part_filename(part)
+    ctype = part.get_content_type()
+
+    if disposition == "attachment":
+        return True
+
+    if disposition == "inline":
+        if part.get("Content-ID") and ctype.startswith("image/"):
+            return include_inline
+        return bool(filename)
+
+    # No Content-Disposition at all. A filename is then the only signal that
+    # this is a file rather than the message body.
+    return bool(filename)
+
+
+def walk_parts(
+    part: Message, path: tuple[int, ...] = (), nested: bool = False
+) -> Iterator[tuple[Message, tuple[int, ...], bool]]:
+    """Yield every leaf part, descending into message/rfc822 forwards.
+
+    message/rfc822 must be handled before the generic is_multipart() branch:
+    it reports as multipart, but its payload is a one-element list holding the
+    whole forwarded message, and the attachments we want are inside that.
+    """
+    if part.get_content_type() == "message/rfc822":
+        # A message/rfc822 carrying Content-Disposition: attachment is itself
+        # a file the sender attached - Gmail shows it as a .eml. Yield it as
+        # well as descending, because the two cases both occur and neither
+        # subsumes the other: a forwarded proposal is a PDF *inside* a
+        # message/rfc822, while a covering note with seven .eml files attached
+        # has nothing but body text inside each one. Found by scanning real
+        # mail during new-jaxity#314: recursing without yielding reported that
+        # second message as having zero attachments.
+        if (part.get_content_disposition() or "").lower() == "attachment":
+            yield part, path, nested
+
+        payload = part.get_payload()
+        if isinstance(payload, list):
+            for i, sub in enumerate(payload):
+                yield from walk_parts(sub, path + (i,), nested=True)
+        return
+
+    if part.is_multipart():
+        payload = part.get_payload()
+        if isinstance(payload, list):
+            for i, sub in enumerate(payload):
+                yield from walk_parts(sub, path + (i,), nested=nested)
+        return
+
+    yield part, path, nested
+
+
+def collect_attachments(msg: Message, include_inline: bool = False) -> list[Attachment]:
+    """Every attachment in a message, forwards included, in tree order."""
+    found: list[Attachment] = []
+    for part, path, nested in walk_parts(msg):
+        if not is_attachment(part, include_inline=include_inline):
+            continue
+        raw = get_part_filename(part)
+        subtype = part.get_content_subtype() or "bin"
+        fallback = f"part-{'-'.join(str(i) for i in path) or '0'}.{subtype}"
+        found.append(
+            Attachment(
+                filename=sanitize_filename(raw, fallback=fallback),
+                raw_filename=raw or "(no filename)",
+                content_type=part.get_content_type(),
+                part=part,
+                path=path,
+                nested=nested,
+            )
+        )
+    return found
+
+
+def decode_payload(att: Attachment, max_bytes: int = DEFAULT_MAX_BYTES) -> bytes:
+    """Decoded bytes for an attachment, with a size cap.
+
+    get_payload(decode=True) handles base64 and quoted-printable, and returns
+    the raw bytes for 7bit/8bit/binary. It returns None only when the part is
+    a container, which cannot happen for a leaf.
+    """
+    if att.content_type == "message/rfc822":
+        # get_payload(decode=True) returns None for a container. An attached
+        # .eml is reconstructed by serialising the message it holds.
+        payload = att.part.get_payload()
+        if not isinstance(payload, list) or not payload:
+            raise ValueError(f"{att.filename}: empty message/rfc822 part")
+        data = payload[0].as_bytes()
+    else:
+        data = att.part.get_payload(decode=True)
+
+    if data is None:
+        raise ValueError(f"{att.filename}: part has no decodable payload")
+    if len(data) > max_bytes:
+        raise ValueError(
+            f"{att.filename}: {len(data)} bytes exceeds the {max_bytes} byte cap. "
+            f"Raise it with --max-bytes if this attachment is genuinely that large."
+        )
+    return data
+
+
+def unique_path(path: Path) -> Path:
+    """Add a -1, -2 ... suffix rather than clobbering an existing file."""
+    if not path.exists():
+        return path
+    stem, ext = path.stem, path.suffix
+    for n in range(1, 1000):
+        candidate = path.with_name(f"{stem}-{n}{ext}")
+        if not candidate.exists():
+            return candidate
+    raise ValueError(f"could not find a free filename near {path}")
+
+
+def write_attachment(
+    att: Attachment, target_dir: str | os.PathLike, max_bytes: int = DEFAULT_MAX_BYTES
+) -> tuple[Path, int]:
+    """Write one attachment into target_dir. Returns (path, bytes written)."""
+    data = decode_payload(att, max_bytes=max_bytes)
+    dest = unique_path(safe_join(target_dir, att.filename))
+    dest.write_bytes(data)
+    return dest, len(data)
+
+
+# ---------------------------------------------------------------------------
+# Credentials
+# ---------------------------------------------------------------------------
+
+
+def customer_home() -> Path | None:
+    """Customer state root, per the resolution order in chassis/scripts/_env.sh.
+
+    Same precedence the other Python helpers use (pacman-queue-add.py):
+    CHASSIS_HOME first for legacy co-located installs, then CUSTOMER_HOME,
+    then the in-container bind-mount, then the new-install host default.
+    """
+    for var in (os.environ.get("CHASSIS_HOME"), os.environ.get("CUSTOMER_HOME")):
+        if var and var.strip():
+            return Path(var.strip()).expanduser()
+    for candidate in (Path("/app/customer"), Path.home() / ".behalfbot"):
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def _parse_env_file(path: Path) -> dict[str, str]:
+    """Minimal KEY=value reader for a hydrated .env. Never raises."""
+    values: dict[str, str] = {}
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return values
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key):
+            continue
+        value = value.strip()
+        # Strip one layer of matched quotes; hydrate-env-from-vw.sh writes
+        # bare values but hand-edited .env files often quote them.
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def _from_env_file(name: str) -> str:
+    """Re-read a var straight off the hydrated .env on disk.
+
+    This is the chassis equivalent of the `bw sync` retry in the new-jaxity
+    original. There, the bw CLI reads a local encrypted cache rather than the
+    server, so an item created minutes earlier was invisible until a sync -
+    the very first live run of that script failed on exactly this. The chassis
+    never reaches Vaultwarden at runtime (hydration is bootstrap-time only, see
+    hydrate-env-from-vw.sh), so the same staleness shows up in a different
+    place: the process env was captured before the operator hydrated or
+    re-hydrated. Reading the file settles it without a restart.
+    """
+    home = customer_home()
+    if home is None:
+        return ""
+    for candidate in (home / ".env", home / ".env.baked"):
+        if candidate.is_file():
+            value = _parse_env_file(candidate).get(name, "").strip()
+            if value:
+                return value
+    return ""
+
+
+def resolve_credential(name: str) -> str:
+    """Process env first, hydrated .env on disk second, empty string if neither."""
+    return os.environ.get(name, "").strip() or _from_env_file(name)
+
+
+def credential_status() -> tuple[str, str]:
+    """(status, message) for the smoke test. Env only - deliberately no network.
+
+    No login attempt here. smoke-test.sh runs at every boot, and repeated
+    failed IMAP logins against Google get the account rate-limited and
+    eventually flagged. A half-configured install is the failure this catches,
+    and that is visible from the env alone.
+    """
+    user = resolve_credential(ENV_USER)
+    password = resolve_credential(ENV_PASSWORD)
+
+    if not user and not password:
+        return "SKIP", (
+            f"{ENV_USER}/{ENV_PASSWORD} unset - Gmail attachment fetching not "
+            f"configured for this install"
+        )
+    if not user:
+        return "FAIL", (
+            f"{ENV_PASSWORD} is set but {ENV_USER} is not - no mailbox to read. "
+            f"Both come from the Vaultwarden item 'Behalf.bot - Google Workspace agent'."
+        )
+    if not password:
+        return "FAIL", (
+            f"{ENV_USER} is set but {ENV_PASSWORD} is not - IMAP login will fail. "
+            f"Both come from the Vaultwarden item 'Behalf.bot - Google Workspace agent'."
+        )
+    return "PASS", f"Gmail IMAP credentials present for {user}"
+
+
+def require_credentials() -> tuple[str, str]:
+    """Both credentials or a RuntimeError naming the fix."""
+    user = resolve_credential(ENV_USER)
+    password = resolve_credential(ENV_PASSWORD)
+    missing = [n for n, v in ((ENV_USER, user), (ENV_PASSWORD, password)) if not v]
+    if missing:
+        raise RuntimeError(
+            f"{' and '.join(missing)} not set. Populate the Vaultwarden item "
+            f"'Behalf.bot - Google Workspace agent' (username = the mailbox, "
+            f"password = a Google app password), then re-run "
+            f"chassis/scripts/hydrate-env-from-vw.sh. See docs/gmail-attachments.md."
+        )
+    return user, password
+
+
+# ---------------------------------------------------------------------------
+# IMAP
+# ---------------------------------------------------------------------------
+
+
+def connect(mailbox: str = DEFAULT_MAILBOX) -> imaplib.IMAP4_SSL:
+    """Log in and select a mailbox read-only.
+
+    Google app passwords are shown with spaces for legibility; IMAP wants
+    them without. Stripping here means a paste from the Google UI works.
+    """
+    user, password = require_credentials()
+    password = password.replace(" ", "")
+    conn = imaplib.IMAP4_SSL(IMAP_HOST, IMAP_PORT)
+    try:
+        conn.login(user, password)
+    except imaplib.IMAP4.error:
+        # Deliberately does not echo the server's reply: a failed IMAP LOGIN
+        # response can quote the credential back.
+        raise RuntimeError(
+            f"IMAP login failed for {user}. Check that 2FA is on for that account, "
+            f"that the Workspace admin console still permits app passwords, and "
+            f"that {ENV_PASSWORD} holds a current one. See docs/gmail-attachments.md."
+        ) from None
+    finally:
+        del password
+
+    status, _ = conn.select(f'"{mailbox}"', readonly=True)
+    if status != "OK":
+        raise RuntimeError(f"could not select mailbox {mailbox!r}")
+    return conn
+
+
+def imap_quote(value: str) -> str:
+    """Wrap a search term as an IMAP quoted string.
+
+    Search terms containing spaces are not optional to quote: an unquoted
+    subject:"Two Words" is parsed as two atoms and the server answers
+    BAD Could not parse command.
+    """
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _search(
+    conn: imaplib.IMAP4_SSL, prefix: list[str], term: str | None = None
+) -> list[bytes]:
+    """UID SEARCH where `term` is the final, caller-supplied argument.
+
+    Non-ASCII terms cannot go inline: they must be sent as a CHARSET UTF-8
+    literal. imaplib exposes that through the `literal` attribute, which it
+    appends to the end of the command, so `term` has to be the last argument.
+    Any accented subject line takes this path.
+    """
+    if term is None:
+        status, data = conn.uid("SEARCH", *prefix)
+    elif term.isascii():
+        status, data = conn.uid("SEARCH", *prefix, imap_quote(term))
+    else:
+        conn.literal = term.encode("utf-8")
+        status, data = conn.uid("SEARCH", "CHARSET", "UTF-8", *prefix)
+
+    if status != "OK":
+        raise RuntimeError(f"IMAP search failed: {data!r}")
+    return data[0].split() if data and data[0] else []
+
+
+def find_uids(
+    conn: imaplib.IMAP4_SSL,
+    message_id: str | None = None,
+    gmail_search: str | None = None,
+    subject: str | None = None,
+    imap_search: str | None = None,
+) -> list[bytes]:
+    """Locate candidate message UIDs by whichever selector the caller gave."""
+    if message_id:
+        mid = message_id if message_id.startswith("<") else f"<{message_id}>"
+        return _search(conn, ["HEADER", "Message-ID"], mid)
+    if gmail_search:
+        # X-GM-RAW is Gmail's IMAP extension: it accepts the same query
+        # language as the Gmail search box, which is far stronger than plain
+        # IMAP SEARCH and is the selector to reach for by default.
+        return _search(conn, ["X-GM-RAW"], gmail_search)
+    if subject:
+        return _search(conn, ["HEADER", "SUBJECT"], subject)
+    if imap_search:
+        return _search(conn, imap_search.split())
+    raise ValueError("one of --message-id, --gmail-search, --subject or --search is required")
+
+
+def fetch_message(conn: imaplib.IMAP4_SSL, uid: bytes) -> Message:
+    """Download and parse one message by UID.
+
+    BODY.PEEK[] rather than RFC822 so the \\Seen flag is not set - this
+    script stays read-only even though the mailbox is already selected
+    readonly.
+    """
+    status, data = conn.uid("FETCH", uid.decode(), "(BODY.PEEK[])")
+    if status != "OK" or not data or not isinstance(data[0], tuple):
+        raise RuntimeError(f"IMAP fetch failed for UID {uid.decode()}")
+    return email.message_from_bytes(data[0][1])
+
+
+def describe(msg: Message) -> str:
+    subject = decode_encoded_word(msg.get("Subject")) or "(no subject)"
+    sender = decode_encoded_word(msg.get("From")) or "(no sender)"
+    date = msg.get("Date") or "(no date)"
+    return f"{subject}\n  from: {sender}\n  date: {date}"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _resolve_one_message(conn: imaplib.IMAP4_SSL, args) -> Message:
+    """Pick the message to operate on, preferring one that has attachments.
+
+    "Most recent match" is the wrong default here. A subject search across a
+    thread returns every reply, and the replies are almost always the newest
+    while the attachment sits on the original. Measured during new-jaxity#314:
+    a subject search returned 7 messages, the PDF was on the oldest, and the 6
+    newer replies carried nothing. So scan newest-first and stop at the first
+    message that actually has an attachment.
+    """
+    if args.uid:
+        return fetch_message(conn, str(args.uid).encode())
+
+    uids = find_uids(
+        conn,
+        message_id=args.message_id,
+        gmail_search=args.gmail_search,
+        subject=args.subject,
+        imap_search=args.search,
+    )
+    if not uids:
+        raise RuntimeError("no message matched that selector")
+    if len(uids) == 1:
+        return fetch_message(conn, uids[0])
+
+    scanned = list(reversed(uids))[:_MAX_SCAN]
+    for uid in scanned:
+        msg = fetch_message(conn, uid)
+        if collect_attachments(msg, include_inline=args.include_inline):
+            print(
+                f"{len(uids)} messages matched; using UID {uid.decode()}, the "
+                f"most recent one carrying an attachment. Pin another with --uid.",
+                file=sys.stderr,
+            )
+            return msg
+
+    print(
+        f"{len(uids)} messages matched and none of the {len(scanned)} scanned "
+        f"carry an attachment; reporting on the most recent.",
+        file=sys.stderr,
+    )
+    return fetch_message(conn, uids[-1])
+
+
+def _print_listing(attachments: Iterable[Attachment]) -> None:
+    items = list(attachments)
+    if not items:
+        print("no attachments found")
+        return
+    for i, att in enumerate(items):
+        marker = " [inside a forwarded message]" if att.nested else ""
+        print(f"[{i}] {att.filename}  ({att.content_type}){marker}")
+        if att.raw_filename and att.raw_filename != att.filename:
+            print(f"     wire name: {att.raw_filename}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Fetch Gmail attachments over IMAP (read-only)."
+    )
+    parser.add_argument("command", choices=["list", "fetch", "fetch-all", "check"])
+
+    selector = parser.add_argument_group("message selector (pick one)")
+    selector.add_argument("--message-id", help="RFC 5322 Message-ID, with or without angle brackets")
+    selector.add_argument("--gmail-search", help="Gmail search-box syntax, via IMAP X-GM-RAW")
+    selector.add_argument("--subject", help="substring of the Subject header")
+    selector.add_argument("--search", help="raw IMAP SEARCH criteria, space separated")
+    selector.add_argument("--uid", type=int, help="exact IMAP UID, skipping the search step")
+
+    parser.add_argument("--name", help="fetch: substring of the attachment filename")
+    parser.add_argument("--index", type=int, help="fetch: index from the `list` output")
+    parser.add_argument("-o", "--output-dir", default=".", help="directory to write into")
+    parser.add_argument("--mailbox", default=DEFAULT_MAILBOX)
+    parser.add_argument(
+        "--include-inline",
+        action="store_true",
+        help="also save inline images referenced by the HTML body",
+    )
+    parser.add_argument("--max-bytes", type=int, default=DEFAULT_MAX_BYTES)
+    args = parser.parse_args(argv)
+
+    if args.command == "check":
+        # smoke-test.sh contract: exactly one STATUS|message line, always
+        # exit 0. The caller decides what a status means for the run.
+        status, message = credential_status()
+        print(f"{status}|{message}")
+        return 0
+
+    if args.command == "fetch" and args.name is None and args.index is None:
+        parser.error("fetch requires --name or --index")
+
+    conn = connect(args.mailbox)
+    try:
+        msg = _resolve_one_message(conn, args)
+        print(describe(msg), file=sys.stderr)
+        attachments = collect_attachments(msg, include_inline=args.include_inline)
+
+        if args.command == "list":
+            _print_listing(attachments)
+            return 0
+
+        if not attachments:
+            print("no attachments found", file=sys.stderr)
+            return 1
+
+        if args.command == "fetch-all":
+            selected = attachments
+        elif args.index is not None:
+            if not 0 <= args.index < len(attachments):
+                print(
+                    f"index {args.index} out of range (0..{len(attachments) - 1})",
+                    file=sys.stderr,
+                )
+                return 1
+            selected = [attachments[args.index]]
+        else:
+            needle = args.name.lower()
+            selected = [
+                a
+                for a in attachments
+                if needle in a.filename.lower() or needle in a.raw_filename.lower()
+            ]
+            if not selected:
+                print(f"no attachment matched {args.name!r}", file=sys.stderr)
+                _print_listing(attachments)
+                return 1
+
+        target = Path(args.output_dir).expanduser()
+        target.mkdir(parents=True, exist_ok=True)
+        for att in selected:
+            dest, size = write_attachment(att, target, max_bytes=args.max_bytes)
+            print(f"{dest}  ({size} bytes)")
+        return 0
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+        conn.logout()
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (RuntimeError, ValueError) as exc:
+        print(f"gmail-attachment: {exc}", file=sys.stderr)
+        sys.exit(2)

--- a/chassis/scripts/smoke-test.sh
+++ b/chassis/scripts/smoke-test.sh
@@ -238,6 +238,34 @@ check_second_brain_backend_reachable() {
     esac
 }
 
+check_gmail_attachment_credentials() {
+    # Same helper contract as check_second_brain_backend_reachable: one
+    # STATUS|message line on stdout, always exit 0.
+    #
+    # Env only, no IMAP login. This runs at every boot, and repeated failed
+    # logins against Google get the account rate-limited and eventually
+    # flagged. The failure worth catching here is the half-configured install -
+    # hydration pulled the username field and not the password, which reads as
+    # configured but cannot authenticate.
+    local helper="$CHASSIS_ROOT/scripts/gmail-attachment.py"
+    if [[ ! -f "$helper" ]]; then
+        record SKIP gmail_attachment_credentials "$helper not found"
+        return
+    fi
+    local out status msg
+    out=$(python3 "$helper" check 2>/dev/null | tail -1)
+    if [[ -z "$out" ]]; then
+        record FAIL gmail_attachment_credentials "gmail-attachment.py check produced no output"
+        return
+    fi
+    status="${out%%|*}"
+    msg="${out#*|}"
+    case "$status" in
+        PASS|FAIL|SKIP) record "$status" gmail_attachment_credentials "$msg" ;;
+        *) record FAIL gmail_attachment_credentials "unparseable helper output: $out" ;;
+    esac
+}
+
 check_discord_webhook_reachable() {
     # Reach the briefings webhook with a HEAD-equivalent (no message sent) to
     # confirm DNS + connectivity. Actual post would be intrusive; skip.
@@ -266,6 +294,7 @@ run_core_checks() {
     check_slack_intake_helper
     check_postgres_connectivity
     check_second_brain_backend_reachable
+    check_gmail_attachment_credentials
     check_discord_webhook_reachable
 }
 

--- a/chassis/scripts/tests/test_gmail_attachment.py
+++ b/chassis/scripts/tests/test_gmail_attachment.py
@@ -1,0 +1,537 @@
+"""Unit tests for chassis/scripts/gmail-attachment.py.
+
+Run from repo root:
+  python3 -m pytest chassis/scripts/tests/test_gmail_attachment.py -v
+
+No live mailbox, no Vaultwarden, no network. Every test builds MIME messages
+in memory or points the credential resolver at a temp directory, so this suite
+runs identically in CI and on a laptop with no chassis install at all.
+
+Ported from scrollinondubs/new-jaxity#314 (38 tests) plus coverage for the
+chassis-side credential resolution, which is the part that was rewritten.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from email.message import EmailMessage
+from pathlib import Path
+from unittest import mock
+
+# The module has a hyphen in its name, so it cannot be imported normally.
+# Same importlib shim test_check_second_brain_backend.py uses for the other
+# chassis/scripts helper under test.
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "gmail-attachment.py"
+_spec = importlib.util.spec_from_file_location("gmail_attachment", _MODULE_PATH)
+mod = importlib.util.module_from_spec(_spec)
+sys.modules["gmail_attachment"] = mod
+_spec.loader.exec_module(mod)
+
+
+class TestSanitizeFilename(unittest.TestCase):
+    def test_plain_name_survives(self):
+        self.assertEqual(mod.sanitize_filename("Proposta_Alma.pdf"), "Proposta_Alma.pdf")
+
+    def test_posix_traversal_stripped(self):
+        self.assertEqual(
+            mod.sanitize_filename("../../.ssh/authorized_keys"), "authorized_keys"
+        )
+
+    def test_windows_traversal_stripped(self):
+        self.assertEqual(mod.sanitize_filename(r"..\..\windows\evil.exe"), "evil.exe")
+
+    def test_absolute_path_stripped(self):
+        self.assertEqual(mod.sanitize_filename("/etc/passwd"), "passwd")
+
+    def test_dot_dot_alone_falls_back(self):
+        self.assertEqual(mod.sanitize_filename(".."), "attachment.bin")
+
+    def test_empty_and_none_fall_back(self):
+        self.assertEqual(mod.sanitize_filename(""), "attachment.bin")
+        self.assertEqual(mod.sanitize_filename(None), "attachment.bin")
+
+    def test_null_byte_removed(self):
+        self.assertEqual(mod.sanitize_filename("evil\x00.pdf"), "evil.pdf")
+
+    def test_leading_dot_not_hidden_file(self):
+        self.assertEqual(mod.sanitize_filename(".bashrc"), "bashrc")
+
+    def test_shell_metacharacters_replaced(self):
+        self.assertEqual(mod.sanitize_filename("a;rm -rf $HOME`.pdf"), "a_rm -rf _HOME_.pdf")
+
+    def test_long_name_truncated_keeping_extension(self):
+        name = mod.sanitize_filename("x" * 500 + ".pdf")
+        self.assertLessEqual(len(name), mod._MAX_FILENAME_LEN)
+        self.assertTrue(name.endswith(".pdf"))
+
+    def test_encoded_word_filename_decoded(self):
+        # =?UTF-8?B?UmVsYXTDs3Jpby5wZGY=?= is "Relatório.pdf"
+        got = mod.sanitize_filename("=?UTF-8?B?UmVsYXTDs3Jpby5wZGY=?=")
+        # The accented char is not in the allowlist, so it becomes "_", but
+        # the encoded-word wrapper must be gone.
+        self.assertNotIn("=?", got)
+        self.assertTrue(got.endswith(".pdf"))
+
+
+class TestDecodeEncodedWord(unittest.TestCase):
+    def test_base64_utf8(self):
+        self.assertEqual(
+            mod.decode_encoded_word("=?UTF-8?B?UmVsYXTDs3Jpby5wZGY=?="), "Relatório.pdf"
+        )
+
+    def test_quoted_printable_word(self):
+        self.assertEqual(
+            mod.decode_encoded_word("=?utf-8?Q?Reabilita=C3=A7=C3=A3o?="), "Reabilitação"
+        )
+
+    def test_plain_ascii_passthrough(self):
+        self.assertEqual(mod.decode_encoded_word("Plain Subject"), "Plain Subject")
+
+    def test_none_returns_empty(self):
+        self.assertEqual(mod.decode_encoded_word(None), "")
+
+    def test_malformed_does_not_raise(self):
+        self.assertIsInstance(mod.decode_encoded_word("=?UTF-8?B?!!!not-base64!!!?="), str)
+
+
+class TestSafeJoin(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmp.name).resolve()
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_normal_child_allowed(self):
+        self.assertEqual(mod.safe_join(self.base, "report.pdf"), self.base / "report.pdf")
+
+    def test_traversal_rejected(self):
+        with self.assertRaises(ValueError):
+            mod.safe_join(self.base, "../escaped.pdf")
+
+    def test_absolute_path_rejected(self):
+        with self.assertRaises(ValueError):
+            mod.safe_join(self.base, "/etc/passwd")
+
+    def test_symlink_out_of_tree_rejected(self):
+        outside = Path(self._tmp.name).parent / "outside-target"
+        outside.mkdir(exist_ok=True)
+        link = self.base / "link"
+        link.symlink_to(outside, target_is_directory=True)
+        with self.assertRaises(ValueError):
+            mod.safe_join(self.base, "link/evil.pdf")
+        outside.rmdir()
+
+    def test_sanitized_traversal_is_safe_end_to_end(self):
+        name = mod.sanitize_filename("../../.ssh/authorized_keys")
+        dest = mod.safe_join(self.base, name)
+        self.assertEqual(dest.parent, self.base)
+
+
+def _pdf_bytes(body: bytes = b"acceptance") -> bytes:
+    return b"%PDF-1.4\n" + body + b"\n%%EOF\n"
+
+
+def _make_forwarded_message() -> EmailMessage:
+    """A forward whose PDF lives inside the message/rfc822 part.
+
+    The attachment is not a child of the outer message, so a walker that stops
+    at the first level reports zero attachments.
+    """
+    inner = EmailMessage()
+    inner["Subject"] = "Proposta Alma - Fasurb Lda"
+    inner["From"] = "orcamentos@example.pt"
+    inner.set_content("Segue em anexo a proposta.")
+    inner.add_attachment(
+        _pdf_bytes(),
+        maintype="application",
+        subtype="pdf",
+        filename="415_01_26_PropostaAlma.pdf",
+    )
+
+    outer = EmailMessage()
+    outer["Subject"] = "Fwd: Proposta Alma - Fasurb Lda"
+    outer.set_content("FYI")
+    outer.add_attachment(inner, filename="original.eml")
+    return outer
+
+
+class TestMimeWalking(unittest.TestCase):
+    def test_flat_attachment_found(self):
+        msg = EmailMessage()
+        msg.set_content("hello")
+        msg.add_attachment(b"data", maintype="application", subtype="pdf", filename="a.pdf")
+        found = mod.collect_attachments(msg)
+        self.assertEqual([a.filename for a in found], ["a.pdf"])
+        self.assertFalse(found[0].nested)
+
+    def test_nested_rfc822_attachment_found(self):
+        found = mod.collect_attachments(_make_forwarded_message())
+        by_name = {a.filename: a for a in found}
+        self.assertIn("415_01_26_PropostaAlma.pdf", by_name)
+        self.assertTrue(
+            by_name["415_01_26_PropostaAlma.pdf"].nested,
+            "attachment inside a forward must be flagged nested",
+        )
+
+    def test_attached_eml_container_also_reported(self):
+        # The container and its contents are both real attachments. Found by
+        # scanning a real mailbox during new-jaxity#314: a covering note with
+        # seven .eml files whose own contents are body text only, so recursing
+        # without yielding the container reported zero attachments.
+        found = mod.collect_attachments(_make_forwarded_message())
+        names = [a.filename for a in found]
+        self.assertIn("original.eml", names)
+        self.assertLess(
+            names.index("original.eml"),
+            names.index("415_01_26_PropostaAlma.pdf"),
+            "container should be listed before its contents",
+        )
+
+    def test_attached_eml_payload_is_the_serialised_message(self):
+        found = mod.collect_attachments(_make_forwarded_message())
+        eml = next(a for a in found if a.filename == "original.eml")
+        data = mod.decode_payload(eml)
+        self.assertIn(b"Proposta Alma - Fasurb Lda", data)
+        self.assertIn(b"415_01_26_PropostaAlma.pdf", data)
+
+    def test_bounce_style_rfc822_without_disposition_not_an_attachment(self):
+        # Delivery-status bounces embed the original message inline, with no
+        # Content-Disposition. That is not a file the sender attached.
+        import email as _email
+
+        raw = (
+            "MIME-Version: 1.0\r\n"
+            "Content-Type: multipart/report; boundary=B\r\n"
+            "\r\n"
+            "--B\r\n"
+            "Content-Type: text/plain\r\n"
+            "\r\n"
+            "Delivery failed.\r\n"
+            "--B\r\n"
+            "Content-Type: message/rfc822\r\n"
+            "\r\n"
+            "Subject: original\r\n"
+            "Content-Type: text/plain\r\n"
+            "\r\n"
+            "the body\r\n"
+            "--B--\r\n"
+        )
+        self.assertEqual(mod.collect_attachments(_email.message_from_string(raw)), [])
+
+    def test_nested_payload_decodes_to_original_bytes(self):
+        found = mod.collect_attachments(_make_forwarded_message())
+        pdf = next(a for a in found if a.filename.endswith(".pdf"))
+        self.assertEqual(mod.decode_payload(pdf), _pdf_bytes())
+
+    def test_body_parts_are_not_attachments(self):
+        msg = EmailMessage()
+        msg.set_content("plain body")
+        msg.add_alternative("<p>html body</p>", subtype="html")
+        self.assertEqual(mod.collect_attachments(msg), [])
+
+    def test_inline_cid_image_excluded_by_default(self):
+        msg = EmailMessage()
+        msg.set_content("body")
+        msg.add_related(
+            b"\x89PNG\r\n",
+            maintype="image",
+            subtype="png",
+            cid="<logo@example>",
+            filename="logo.png",
+            disposition="inline",
+        )
+        self.assertEqual(mod.collect_attachments(msg), [])
+
+    def test_inline_cid_image_included_on_request(self):
+        msg = EmailMessage()
+        msg.set_content("body")
+        msg.add_related(
+            b"\x89PNG\r\n",
+            maintype="image",
+            subtype="png",
+            cid="<logo@example>",
+            filename="logo.png",
+            disposition="inline",
+        )
+        found = mod.collect_attachments(msg, include_inline=True)
+        self.assertEqual([a.filename for a in found], ["logo.png"])
+
+    def test_double_nested_forward(self):
+        inner = _make_forwarded_message()
+        outer = EmailMessage()
+        outer["Subject"] = "Fwd: Fwd: Proposta"
+        outer.set_content("passing this along")
+        outer.add_attachment(inner)
+        found = mod.collect_attachments(outer)
+        self.assertIn("415_01_26_PropostaAlma.pdf", [a.filename for a in found])
+
+    def test_attachment_without_filename_gets_positional_fallback(self):
+        msg = EmailMessage()
+        msg.set_content("body")
+        msg.add_attachment(b"data", maintype="application", subtype="octet-stream")
+        found = mod.collect_attachments(msg)
+        self.assertEqual(len(found), 1)
+        self.assertTrue(found[0].filename.startswith("part-"))
+
+
+class TestTransferEncodings(unittest.TestCase):
+    def test_base64_roundtrip(self):
+        payload = bytes(range(256))
+        msg = EmailMessage()
+        msg.set_content("body")
+        msg.add_attachment(payload, maintype="application", subtype="pdf", filename="b.pdf")
+        found = mod.collect_attachments(msg)
+        self.assertEqual(mod.decode_payload(found[0]), payload)
+
+    def test_quoted_printable_roundtrip(self):
+        raw = (
+            "MIME-Version: 1.0\r\n"
+            "Content-Type: multipart/mixed; boundary=BOUND\r\n"
+            "\r\n"
+            "--BOUND\r\n"
+            "Content-Type: text/plain\r\n"
+            "\r\n"
+            "body\r\n"
+            "--BOUND\r\n"
+            'Content-Type: text/plain; name="notes.txt"\r\n'
+            'Content-Disposition: attachment; filename="notes.txt"\r\n'
+            "Content-Transfer-Encoding: quoted-printable\r\n"
+            "\r\n"
+            "Reabilita=C3=A7=C3=A3o de telhado\r\n"
+            "--BOUND--\r\n"
+        )
+        import email as _email
+
+        msg = _email.message_from_string(raw)
+        found = mod.collect_attachments(msg)
+        self.assertEqual([a.filename for a in found], ["notes.txt"])
+        self.assertEqual(
+            mod.decode_payload(found[0]).decode("utf-8").strip(),
+            "Reabilitação de telhado",
+        )
+
+
+class TestSizeCap(unittest.TestCase):
+    def test_over_cap_raises(self):
+        msg = EmailMessage()
+        msg.set_content("body")
+        msg.add_attachment(b"x" * 2048, maintype="application", subtype="pdf", filename="big.pdf")
+        att = mod.collect_attachments(msg)[0]
+        with self.assertRaises(ValueError) as ctx:
+            mod.decode_payload(att, max_bytes=1024)
+        self.assertIn("exceeds", str(ctx.exception))
+
+    def test_under_cap_passes(self):
+        msg = EmailMessage()
+        msg.set_content("body")
+        msg.add_attachment(b"x" * 100, maintype="application", subtype="pdf", filename="ok.pdf")
+        att = mod.collect_attachments(msg)[0]
+        self.assertEqual(len(mod.decode_payload(att, max_bytes=1024)), 100)
+
+
+class TestWriteAttachment(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmp.name).resolve()
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_traversal_filename_lands_inside_target(self):
+        msg = EmailMessage()
+        msg.set_content("body")
+        msg.add_attachment(
+            b"pwned",
+            maintype="application",
+            subtype="octet-stream",
+            filename="../../.ssh/authorized_keys",
+        )
+        att = mod.collect_attachments(msg)[0]
+        dest, size = mod.write_attachment(att, self.base)
+        self.assertEqual(dest.parent, self.base)
+        self.assertEqual(dest.name, "authorized_keys")
+        self.assertEqual(size, 5)
+
+    def test_collision_gets_suffix_not_overwrite(self):
+        (self.base / "a.pdf").write_bytes(b"original")
+        msg = EmailMessage()
+        msg.set_content("body")
+        msg.add_attachment(b"new", maintype="application", subtype="pdf", filename="a.pdf")
+        att = mod.collect_attachments(msg)[0]
+        dest, _ = mod.write_attachment(att, self.base)
+        self.assertEqual(dest.name, "a-1.pdf")
+        self.assertEqual((self.base / "a.pdf").read_bytes(), b"original")
+
+
+# ---------------------------------------------------------------------------
+# Chassis-side credential resolution. This is the part that replaced the
+# new-jaxity Vaultwarden read, so it carries the new coverage.
+# ---------------------------------------------------------------------------
+
+
+class _CredentialTestCase(unittest.TestCase):
+    """Points CHASSIS_HOME at a temp dir so no real install is consulted."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp.name).resolve()
+        self._env = mock.patch.dict(
+            "os.environ",
+            {"CHASSIS_HOME": str(self.home), "CUSTOMER_HOME": str(self.home)},
+            clear=False,
+        )
+        self._env.start()
+        # patch.dict restores on stop(), so popping the two vars under test
+        # here is safe even if the developer running this has them set.
+        import os as _os
+
+        _os.environ.pop(mod.ENV_USER, None)
+        _os.environ.pop(mod.ENV_PASSWORD, None)
+
+    def tearDown(self):
+        self._env.stop()
+        self._tmp.cleanup()
+
+    def write_env_file(self, body: str, name: str = ".env") -> None:
+        (self.home / name).write_text(body, encoding="utf-8")
+
+
+class TestCustomerHome(_CredentialTestCase):
+    def test_chassis_home_wins(self):
+        self.assertEqual(mod.customer_home(), self.home)
+
+    def test_customer_home_used_when_chassis_home_absent(self):
+        import os as _os
+
+        _os.environ.pop("CHASSIS_HOME")
+        self.assertEqual(mod.customer_home(), self.home)
+
+
+class TestEnvFileParsing(_CredentialTestCase):
+    def test_plain_key_value(self):
+        self.write_env_file("GOOGLE_AGENT_EMAIL=agent@example.com\n")
+        self.assertEqual(mod.resolve_credential(mod.ENV_USER), "agent@example.com")
+
+    def test_comments_and_blanks_ignored(self):
+        self.write_env_file(
+            "# hydrated by hydrate-env-from-vw.sh\n"
+            "\n"
+            "GOOGLE_AGENT_APP_PASSWORD=abcd efgh ijkl mnop\n"
+        )
+        self.assertEqual(
+            mod.resolve_credential(mod.ENV_PASSWORD), "abcd efgh ijkl mnop"
+        )
+
+    def test_quoted_value_unwrapped(self):
+        self.write_env_file('GOOGLE_AGENT_EMAIL="agent@example.com"\n')
+        self.assertEqual(mod.resolve_credential(mod.ENV_USER), "agent@example.com")
+
+    def test_value_containing_equals_survives(self):
+        # Base64-ish secrets end in "=" padding; splitting on every "=" would
+        # truncate them.
+        self.write_env_file("GOOGLE_AGENT_APP_PASSWORD=abc=def==\n")
+        self.assertEqual(mod.resolve_credential(mod.ENV_PASSWORD), "abc=def==")
+
+    def test_process_env_beats_disk(self):
+        import os as _os
+
+        self.write_env_file("GOOGLE_AGENT_EMAIL=stale@example.com\n")
+        _os.environ[mod.ENV_USER] = "fresh@example.com"
+        self.assertEqual(mod.resolve_credential(mod.ENV_USER), "fresh@example.com")
+
+    def test_env_baked_used_when_env_absent(self):
+        # LaunchDaemon-style contexts read .env.baked - same fallback the DB
+        # helper uses.
+        self.write_env_file("GOOGLE_AGENT_EMAIL=baked@example.com\n", name=".env.baked")
+        self.assertEqual(mod.resolve_credential(mod.ENV_USER), "baked@example.com")
+
+    def test_missing_file_returns_empty_not_raises(self):
+        self.assertEqual(mod.resolve_credential(mod.ENV_USER), "")
+
+
+class TestCredentialStatus(_CredentialTestCase):
+    def test_neither_set_is_skip(self):
+        status, _ = mod.credential_status()
+        self.assertEqual(status, "SKIP")
+
+    def test_both_set_is_pass(self):
+        self.write_env_file(
+            "GOOGLE_AGENT_EMAIL=agent@example.com\nGOOGLE_AGENT_APP_PASSWORD=secret\n"
+        )
+        status, message = mod.credential_status()
+        self.assertEqual(status, "PASS")
+        self.assertIn("agent@example.com", message)
+
+    def test_half_configured_is_fail(self):
+        # The failure this check exists for: hydration pulled one field and not
+        # the other, which looks configured but cannot log in.
+        self.write_env_file("GOOGLE_AGENT_EMAIL=agent@example.com\n")
+        status, message = mod.credential_status()
+        self.assertEqual(status, "FAIL")
+        self.assertIn(mod.ENV_PASSWORD, message)
+
+    def test_password_without_user_is_fail(self):
+        self.write_env_file("GOOGLE_AGENT_APP_PASSWORD=secret\n")
+        status, message = mod.credential_status()
+        self.assertEqual(status, "FAIL")
+        self.assertIn(mod.ENV_USER, message)
+
+    def test_status_message_never_contains_the_password(self):
+        self.write_env_file(
+            "GOOGLE_AGENT_EMAIL=agent@example.com\n"
+            "GOOGLE_AGENT_APP_PASSWORD=hunter2secretvalue\n"
+        )
+        _, message = mod.credential_status()
+        self.assertNotIn("hunter2secretvalue", message)
+
+
+class TestRequireCredentials(_CredentialTestCase):
+    def test_returns_pair_when_present(self):
+        self.write_env_file(
+            "GOOGLE_AGENT_EMAIL=agent@example.com\nGOOGLE_AGENT_APP_PASSWORD=secret\n"
+        )
+        self.assertEqual(
+            mod.require_credentials(), ("agent@example.com", "secret")
+        )
+
+    def test_missing_raises_naming_the_rehydration_step(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            mod.require_credentials()
+        message = str(ctx.exception)
+        self.assertIn(mod.ENV_USER, message)
+        self.assertIn("hydrate-env-from-vw.sh", message)
+
+
+class TestCheckCommand(_CredentialTestCase):
+    def test_emits_one_pipe_delimited_line_and_exits_zero(self):
+        # smoke-test.sh parses status="${out%%|*}" from the last stdout line
+        # and treats an unparseable line as a FAIL.
+        import io
+        import contextlib
+
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            code = mod.main(["check"])
+        self.assertEqual(code, 0)
+        lines = buffer.getvalue().strip().splitlines()
+        self.assertEqual(len(lines), 1)
+        self.assertIn(lines[0].split("|", 1)[0], {"PASS", "FAIL", "SKIP"})
+
+    def test_check_makes_no_network_call(self):
+        # A boot-time smoke test must not attempt an IMAP login: repeated
+        # failed logins get the Google account rate-limited and eventually
+        # flagged.
+        import io
+        import contextlib
+
+        with mock.patch.object(mod.imaplib, "IMAP4_SSL") as imap:
+            with contextlib.redirect_stdout(io.StringIO()):
+                mod.main(["check"])
+        imap.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/gmail-attachments.md
+++ b/docs/gmail-attachments.md
@@ -1,0 +1,201 @@
+# Gmail attachments over IMAP
+
+`chassis/scripts/gmail-attachment.py` lists and downloads attachments from the
+install's Gmail mailbox. Standard library only, read-only, no new dependencies.
+
+Ported from `scrollinondubs/new-jaxity#314`; decision record in
+`scrollinondubs/new-jaxity#311`.
+
+## Why this exists
+
+The Claude.ai Gmail connector exposes `get_thread`, `get_message`,
+`search_threads`, `create_draft` and label operations. It has no attachment
+endpoint at all. Every install hits that the first time someone forwards a PDF
+and asks the agent to read it. This is a capability gap, not a permissions
+problem - no scope, no admin toggle and no reconnect fixes it.
+
+## Why IMAP and not OAuth
+
+The obvious alternative is a self-hosted Gmail MCP server with our own OAuth
+client. It was rejected.
+
+An OAuth consent screen left in **External + Testing** issues refresh tokens
+that expire after **seven days**. The agent then simply stops being able to
+read mail. Nothing errors loudly; the next scheduled run just does less. At
+least one install in this fleet is believed to have been sitting in exactly
+that state.
+
+Moving the consent screen to Published requires verification for restricted
+Gmail scopes, which is a review process, not a checkbox. A service account with
+domain-wide delegation avoids the expiry but grants access to every mailbox on
+the domain - wildly disproportionate for fetching a PDF.
+
+IMAP with an app password has no consent screen, no Cloud project, and no
+expiry cliff. The credential is revocable from one page and scoped to one
+mailbox.
+
+The OAuth block in `.env.example` (`GMAIL_OAUTH_PATH` and friends) is separate
+and unaffected. It drives the Gmail MCP server for drafts and labels. This
+script does not use it.
+
+## Env var contract
+
+Two variables. There is exactly one accepted name for each - no aliases, no
+fallbacks.
+
+| Variable | Meaning |
+|---|---|
+| `GOOGLE_AGENT_EMAIL` | The mailbox to read. Also the IMAP username. |
+| `GOOGLE_AGENT_APP_PASSWORD` | A Google app password for that account. |
+
+Both are already in the default Vaultwarden manifest in
+`chassis/scripts/hydrate-env-from-vw.sh`, under the item
+**"Behalf.bot - Google Workspace agent"** (username field and password field).
+Until this script landed nothing in the chassis read them - the manifest
+promised a credential that had no consumer.
+
+Single-name-per-value is deliberate. The chassis has been bitten once by
+carrying two names for one secret: `NOTION_API_TOKEN` in `.env.example` and the
+factory, `NOTION_INTEGRATION_TOKEN` in the hydrator and `.mcp.json.template`.
+An installer who followed the wrong one shipped a literal placeholder as a
+bearer token and got a 401 on every call.
+
+### Resolution order
+
+1. Process environment.
+2. `$CUSTOMER_HOME/.env`, read straight off disk.
+3. `$CUSTOMER_HOME/.env.baked`, for LaunchDaemon-style contexts that never
+   sourced `.env`.
+
+`CUSTOMER_HOME` resolves per `chassis/scripts/_env.sh` - `CHASSIS_HOME` first
+for legacy co-located installs, then `CUSTOMER_HOME`, then `/app/customer`,
+then `~/.behalfbot`.
+
+Step 2 exists because credential state goes stale. In the new-jaxity original
+the staleness was in the `bw` CLI, which reads a local encrypted cache rather
+than the server, so a vault item created minutes earlier was invisible until a
+sync - the very first live run failed on exactly that. The chassis never
+reaches Vaultwarden at runtime (hydration is bootstrap-time only), so the same
+staleness reappears one layer up: the process environment was captured before
+the operator hydrated. Reading the file settles it without a restart.
+
+## Operator setup
+
+1. **Turn on 2-Step Verification** for the mailbox account. Google will not
+   offer app passwords without it.
+2. **Generate an app password** at
+   <https://myaccount.google.com/apppasswords>. Google shows it as four
+   space-separated groups. Copy it verbatim - the script strips the spaces
+   itself, so a paste from the Google UI works.
+3. **Store it in Vaultwarden** in an item named
+   `Behalf.bot - Google Workspace agent`. Username field: the mailbox address.
+   Password field: the app password.
+4. **Hydrate**: run `chassis/scripts/hydrate-env-from-vw.sh`. It writes both
+   variables into `$CHASSIS_HOME/.env`.
+5. **Verify**: `python3 chassis/scripts/gmail-attachment.py check` should print
+   `PASS|Gmail IMAP credentials present for <address>`. The same check runs as
+   `gmail_attachment_credentials` in `chassis/scripts/smoke-test.sh`.
+6. **Confirm end to end** against a real message:
+   `python3 chassis/scripts/gmail-attachment.py list --gmail-search 'has:attachment'`
+
+On an install with no Vaultwarden, skip steps 3 and 4 and set the two variables
+in `$CUSTOMER_HOME/.env` by hand. Chmod that file 0600.
+
+### Workspace admin note
+
+A Google Workspace administrator can disable app passwords for the entire
+organisation (Admin console > Security > Authentication > Less secure apps and
+app passwords). If that setting is off, step 2 will not offer the option at
+all and no amount of debugging on this side will help. Check it first.
+
+## Usage
+
+```
+# What is attached to the message matching a search
+python3 chassis/scripts/gmail-attachment.py list --gmail-search 'subject:"Invoice"'
+
+# Fetch by filename substring, or by the index `list` printed
+python3 chassis/scripts/gmail-attachment.py fetch --gmail-search '...' --name Invoice -o ~/Downloads
+python3 chassis/scripts/gmail-attachment.py fetch --gmail-search '...' --index 0 -o ~/Downloads
+
+# Everything on one message
+python3 chassis/scripts/gmail-attachment.py fetch-all --message-id '<abc@mail.example>' -o ~/Downloads
+
+# Config check - env only, no network
+python3 chassis/scripts/gmail-attachment.py check
+```
+
+Selectors, in the order to reach for them:
+
+- `--gmail-search` - Gmail search-box syntax via the `X-GM-RAW` IMAP
+  extension. Far stronger than plain IMAP SEARCH. This is the default choice.
+- `--message-id` - exact RFC 5322 Message-ID, with or without angle brackets.
+- `--subject` - substring of the Subject header.
+- `--search` - raw IMAP SEARCH criteria, space separated.
+- `--uid` - exact IMAP UID, skipping the search step entirely.
+
+### Message selection
+
+A search that matches several messages does **not** take the most recent one.
+A subject search returns a whole thread, and the attachment is almost always on
+the oldest message while the replies are newest. The script scans newest-first
+and stops at the first message that actually carries an attachment, printing
+which UID it chose. Pin a different one with `--uid`.
+
+## Behaviour worth knowing
+
+**Read-only.** Mailboxes are selected with `readonly=True` and messages fetched
+with `BODY.PEEK[]`. Nothing is flagged, moved, or marked read.
+
+**Default mailbox** is `[Gmail]/All Mail`, the only folder guaranteed to hold a
+message regardless of its labels. Override with `--mailbox`.
+
+**Inline images are excluded.** An HTML mail with an embedded logo carries an
+`image/png` part with `Content-Disposition: inline` and a `Content-ID` the body
+references. That is page furniture, and listing it buries the real file. Pass
+`--include-inline` to get them.
+
+**Forwarded messages are descended into, and attached `.eml` files are
+themselves emitted.** Both cases occur and neither subsumes the other: a
+forwarded proposal is a PDF inside a `message/rfc822` part, while a covering
+note with seven `.eml` attachments has nothing but body text inside each one.
+A `message/rfc822` part is emitted as an attachment when it carries
+`Content-Disposition: attachment`. Delivery-status bounces embed the original
+with no disposition and are correctly not treated as attachments.
+
+**Filenames are sanitised, then the resolved path is re-checked.** Attachment
+filenames are attacker-controlled - someone can email a file called
+`../../.ssh/authorized_keys`. It lands as `authorized_keys` inside the target
+directory. Two independent layers, and the second uses `resolve()` so a symlink
+inside the target pointing outward is also rejected.
+
+**25 MB size cap**, matching Gmail's own per-message attachment limit, checked
+against the decoded length before any write. Raise with `--max-bytes`.
+
+**Existing files are never clobbered** - a `-1`, `-2` suffix is added.
+
+## Failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `GOOGLE_AGENT_APP_PASSWORD not set` | Never hydrated, or the vault item has no password field | Populate the VW item, re-run `hydrate-env-from-vw.sh` |
+| Smoke test `FAIL ... is set but ... is not` | Half-configured: hydration pulled one field, not the other | Check both fields exist on the VW item |
+| `IMAP login failed for <address>` | 2FA off, app passwords disabled org-wide, or the password was revoked | Work the list in that order - the org-wide toggle is the one people miss |
+| `could not select mailbox` | IMAP disabled in Gmail settings, or a bad `--mailbox` | Gmail Settings > Forwarding and POP/IMAP > Enable IMAP |
+| `no message matched that selector` | Search matched nothing in All Mail | Try the same query in the Gmail web UI first |
+| Reports no attachments on a message that visibly has one | Should not happen - the `message/rfc822` cases are handled both ways | File it with the raw message; that is the class of bug this walker exists to prevent |
+
+The IMAP login error deliberately does not echo the server's reply. A failed
+`LOGIN` response can quote the credential back.
+
+## Tests
+
+`chassis/scripts/tests/test_gmail_attachment.py` - 56 tests. No live mailbox,
+no Vaultwarden, no network. MIME trees are built in memory and credential
+resolution is pointed at a temp directory.
+
+```
+python3 -m pytest chassis/scripts/tests/test_gmail_attachment.py -v
+```
+
+Runs in CI via `.github/workflows/python-tests.yml`.


### PR DESCRIPTION
Ports `gmail-attachment.py` from `scrollinondubs/new-jaxity` (merged as **new-jaxity#314**, decision record **new-jaxity#311**) into the chassis so every install gets it. **Do not merge** - Sean ratifies.

## Why this belongs in the chassis, not one customer's tree

The Claude.ai Gmail connector exposes `get_thread`, `get_message`, `search_threads`, `create_draft` and label operations, and **no attachment endpoint at all**. Every install hits this the first time someone forwards a PDF. It is a capability gap, not a permissions problem - no scope, no admin toggle and no reconnect closes it.

## Why IMAP and not a self-hosted Gmail MCP with our own OAuth

An OAuth consent screen left at **External + Testing** issues refresh tokens that **expire after seven days**, silently. The agent just quietly stops reading mail. That failure is documented in this codebase as probably having already hit at least one customer install (`gmail-ozzy`). Publishing the consent screen means Google verification for restricted Gmail scopes - a review, not a checkbox. A service account with domain-wide delegation avoids the expiry but grants access to every mailbox on the domain, which is wildly disproportionate for fetching a PDF.

IMAP with a Workspace app password has no consent screen, no Cloud project and no expiry cliff. The credential is revocable from one page and scoped to one mailbox. The existing OAuth block in `.env.example` (`GMAIL_OAUTH_PATH` and friends) drives the Gmail MCP server for drafts and labels and is untouched.

## What changed

| File | |
|---|---|
| `chassis/scripts/gmail-attachment.py` | new - list / fetch / fetch-all / check |
| `chassis/scripts/tests/test_gmail_attachment.py` | new - 56 tests |
| `docs/gmail-attachments.md` | new - env contract, operator setup, failure modes |
| `chassis/scripts/smoke-test.sh` | `+ check_gmail_attachment_credentials` in `run_core_checks` |
| `.env.example` | Gmail attachments (IMAP) section |
| `.github/workflows/python-tests.yml` | paths + `chassis/scripts/tests/` in the pytest invocation |

Standard library only - `imaplib`, `email`, `ssl`. Nothing added to `requirements.txt`. Read-only: mailboxes selected `readonly=True`, messages fetched with `BODY.PEEK[]`, so nothing is flagged, moved or marked read.

## The env var contract

```
GOOGLE_AGENT_EMAIL          the mailbox to read (also the IMAP username)
GOOGLE_AGENT_APP_PASSWORD   a Google app password for that account
```

These are **not new names**. Both are already in the default Vaultwarden manifest in `chassis/scripts/hydrate-env-from-vw.sh` under the item `Behalf.bot - Google Workspace agent` (username field and password field). Nothing in the chassis read them until now - the manifest promised a credential that had no consumer. This is the consumer.

Deliberately **one accepted name per value, no aliases**. The chassis has been bitten once by carrying two names for one secret (`NOTION_API_TOKEN` vs `NOTION_INTEGRATION_TOKEN`); an installer who followed the wrong one shipped a literal placeholder as a bearer token and 401'd on every call. The comment recording that is in `hydrate-env-from-vw.sh`.

Resolution order: process env, then `$CUSTOMER_HOME/.env` read off disk, then `.env.baked`. `CUSTOMER_HOME` resolves per `chassis/scripts/_env.sh` (`CHASSIS_HOME` first for legacy co-located installs, then `CUSTOMER_HOME`, then `/app/customer`, then `~/.behalfbot`) - the same precedence `pacman-queue-add.py` uses.

## What was generalised

1. **Credential resolution.** Was a runtime Vaultwarden read via Sean's `scripts/bw-fetch.sh` against a hardcoded item UUID. The chassis never reaches Vaultwarden at runtime - hydration is bootstrap-time only - so it now reads the two env vars above. `bw-fetch.sh` and the item UUID are gone.
2. **The `bw sync` retry, preserved in the chassis idiom.** The original retried because the `bw` CLI reads a local encrypted cache rather than the server, so an item created minutes earlier was invisible until a sync - the first live run failed on exactly that. The same staleness reappears one layer up here: the process environment was captured before the operator hydrated. So a missing var is re-read straight off `$CUSTOMER_HOME/.env` on disk before giving up, which settles it without a restart. The error, when it does give up, names `hydrate-env-from-vw.sh` and the VW item by name.
3. **Mailbox identity.** Was hardcoded `jax@vibecodelisboa.com`. Now `GOOGLE_AGENT_EMAIL`.
4. **Paths.** `~/.behalfbot/scripts/bw-fetch.sh` is gone; the only path resolution left is `customer_home()`, per `_env.sh`.
5. **Test import shim.** Was `Path(__file__).parent.parent / "scripts"`. Now uses the `importlib.util.spec_from_file_location` pattern from `test_check_second_brain_backend.py`, which is the precedent for testing a hyphenated `chassis/scripts` helper.
6. **Customer-specific comments and docstrings.** UID references, mailbox scan counts, "Sean's mailbox", the Alma roof proposal and Portuguese subject lines were replaced with the general statement of the case plus a `new-jaxity#314` citation. The findings are preserved; the customer's mail is not in the chassis.

## Smoke test integration

`check_gmail_attachment_credentials` follows the `check-second-brain-backend.py` precedent exactly: the helper emits one `STATUS|message` line on stdout and always exits 0, and `smoke-test.sh` decides what the status means.

**Env only, deliberately no IMAP login.** Smoke tests run at every boot, and repeated failed logins against Google get the account rate-limited and eventually flagged. The failure actually worth catching is visible from the env alone: a half-configured install where hydration pulled the username field and not the password reads as configured but cannot authenticate. That is a FAIL; both-unset is a SKIP; both-present is a PASS.

Note `chassis.config.yaml` still lists `gmail_draft_creation` under `success_criteria.smoke_tests` with no check implementing it. Different capability, left alone.

## Preserved from the original

- **Path traversal blocked at two independent layers** - `sanitize_filename()` (backslash normalisation before basename, character allowlist not denylist, leading/trailing dots stripped) and `safe_join()`, which re-resolves with `resolve()` so a symlink inside the target pointing outward is also rejected.
- **25 MB size cap** checked against the decoded length before any write.
- **The IMAP login failure path does not echo the server reply** - a failed `LOGIN` can quote the credential back.
- **`message/rfc822` handled in both directions** - descends into nested forwards AND emits an rfc822 part as an attachment when it carries `Content-Disposition: attachment`. Bounce messages, which embed the original with no disposition, stay correctly excluded.
- **Message selection takes the oldest match carrying an attachment**, not the most recent, because a subject search returns a whole thread and the file sits on the original.
- App-password space stripping, `X-GM-RAW` search, UTF-8 literal search for non-ASCII terms, inline-CID exclusion, collision suffixing.

## Deliberately left behind

- `_BW_ITEM_ID`, `_BW_FETCH`, `_bw_fetch()`, `fetch_app_password()` and the `subprocess` import - Vaultwarden-at-runtime has no chassis equivalent.
- The hardcoded `IMAP_USER`.
- Customer mail specifics in comments (see item 6 above).
- No `chassis/VERSION` bump - separate PR for Sean.
- No CHANGELOG entry for an unreleased version; the detail is here instead.

## Test plan

pytest is not installed system-wide; venv with `pytest pyyaml mcp==1.28.1` plus `psycopg[binary]` (without it two pre-existing `chassis/db` tests fail for unrelated reasons).

- [x] Baseline before, `python -m pytest chassis/ plugins/ -q`: **330 passed, 12 skipped, 8 subtests passed**
- [x] After: **386 passed, 12 skipped, 8 subtests passed**. +56, no regressions.
- [x] New suite alone: `python -m pytest chassis/scripts/tests/test_gmail_attachment.py -q` -> **56 passed**. 38 ported from new-jaxity#314, 18 new covering credential resolution, `.env` / `.env.baked` parsing, the PASS/FAIL/SKIP matrix, that the status message never contains the password, and that `check` makes no network call.
- [x] Runs with no live mailbox, no Vaultwarden and no network - verified by running the suite with both env vars unset and `CHASSIS_HOME` pointed at a temp dir.
- [x] `bash -n chassis/scripts/smoke-test.sh` clean.
- [x] Smoke check driven end to end through `smoke-test.sh core` against a temp `CHASSIS_HOME` in all three credential states:
  - unset -> `SKIP gmail_attachment_credentials  GOOGLE_AGENT_EMAIL/GOOGLE_AGENT_APP_PASSWORD unset ...`
  - email only -> `FAIL ... GOOGLE_AGENT_EMAIL is set but GOOGLE_AGENT_APP_PASSWORD is not ...`, and the full run exits 1
  - both -> `PASS Gmail IMAP credentials present for agent@example.com`
- [x] **Full CLI path driven end to end** against a fake IMAP server (argparse -> credential resolution -> login -> search -> fetch -> MIME walk -> write), with the credentials supplied only via `.env` on disk and the process env empty. Asserted in the harness: `select()` received `readonly=True`, `uid("FETCH", ...)` used `BODY.PEEK[]`, and the app password reached `login()` with its display spaces stripped. `list` output:
  ```
  [0] original.eml  (message/rfc822)
  [1] authorized_keys  (application/pdf) [inside a forwarded message]
       wire name: ../../.ssh/authorized_keys
  ```
  `fetch-all` wrote both files inside the target directory - the traversal filename landed as `authorized_keys` with nothing created outside.
- [ ] Live mailbox run on a real install - not done here, no chassis Gmail credential available in this environment. The IMAP wire behaviour is unchanged from the new-jaxity original, which was verified live against a 752-message mailbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
