### PR TITLE
fix(observability): two guards that hid failures instead of reporting them

### DIFF
--- a/chassis/docs/heartbeats/daily-log.md
+++ b/chassis/docs/heartbeats/daily-log.md
@@ -77,6 +77,32 @@ Any missing env var degrades gracefully: the corresponding surface is
 skipped, a note is added to `warnings`, and the rest of the gather runs.
 The gather never crashes.
 
+### Per-surface status (`surfaces`)
+
+Alongside `warnings`, the gather emits a `surfaces` block giving each of the
+four surfaces a `status` of `ok`, `error`, or `skipped` plus an `error`
+string explaining anything that is not `ok`:
+
+```json
+"surfaces": {
+  "github":       { "status": "error", "error": "gh graphql viewer query failed" },
+  "gmail":        { "status": "skipped", "error": "DAILY_LOG_GMAIL_IDENTITY unset" },
+  "second_brain": { "status": "ok", "error": null },
+  "discord":      { "status": "ok", "error": null }
+}
+```
+
+This exists because `warnings` could not tell the prompt whether an empty
+bucket meant "nothing happened" or "we could not look". Both render as `{}`,
+so the prompt reported a quiet day on a day 8 PRs merged across three repos
+(new-jaxity#307). The prompt now reads `surfaces` first and writes an
+explicit blind-spot line for anything that is not `ok`, rather than narrating
+an absence it cannot vouch for.
+
+`warnings` is retained unchanged for installs whose on-disk
+`daily-log-prompt.md` predates this - bootstrap copies the template once and
+never rewrites it.
+
 ## Customer-install setup
 
 1. Copy the prompt template into the customer install:

--- a/chassis/scheduled-tasks/daily-log-prompt.md.template
+++ b/chassis/scheduled-tasks/daily-log-prompt.md.template
@@ -80,6 +80,12 @@ as the "context" for this prompt. It has this shape:
     "heartbeat_failures": N, "dating_sessions": N,
     "custom": { ... }
   },
+  "surfaces": {
+    "github":       { "status": "ok|error|skipped", "error": "... or null" },
+    "gmail":        { "status": "ok|error|skipped", "error": "... or null" },
+    "second_brain": { "status": "ok|error|skipped", "error": "... or null" },
+    "discord":      { "status": "ok|error|skipped", "error": "... or null" }
+  },
   "warnings": ["strings for any surface that failed gracefully"]
 }
 ```
@@ -88,9 +94,48 @@ If `gmail_scan_deferred` is `true`, use the Gmail MCP to search sent mail:
 `in:sent from:{{ CUSTOMER_ORG_HANDLES }} newer_than:1d` and merge the
 results into your "Shipped" analysis under the operational bullet block.
 
-If `warnings` is non-empty, note it briefly at the bottom of the Metrics
-section so the operator can see which surfaces silently degraded. Do not
-fail the whole log because a surface was skipped.
+### Reading `surfaces` before you write a single line
+
+`surfaces` tells you, per source, whether the gather could see it. Check it
+FIRST. An empty bucket means two completely different things depending on
+that status, and conflating them is the failure this section exists to
+prevent - see new-jaxity#307, where the GitHub query failed, `prs_by_repo`
+came back `{}`, and the log reported a quiet day with nothing shipped on a
+day 8 PRs merged across three repos.
+
+Handle each source by its status. There are exactly three cases:
+
+1. **`status` is `error` or `skipped`** - the source was not read. You do not
+   know what happened there. Do NOT write that nothing happened, and do NOT
+   leave the section silently empty. Write an explicit blind-spot line in the
+   affected section naming the source and the reason from `error`, e.g.
+   `- GitHub not read this run (gh graphql viewer query failed) - shipping
+   activity for the day is unknown.` Then carry on with the sources that did
+   report.
+2. **`status` is `ok` and the bucket is empty** - a real zero. Say so plainly:
+   nothing shipped, no mail sent, no writing. This is the ONLY case in which
+   "quiet day" is an honest sentence.
+3. **`status` is `ok` and the bucket has content** - synthesize it per Step 2.
+
+Two rules that hold in every case:
+
+- **Never invent a cause for an empty result.** Do not write "quiet day
+  because Sean was travelling", "nothing shipped - focus was elsewhere", or
+  any other explanation you reasoned your way to. You may state a cause only
+  when another source in the same payload establishes it - a calendar-derived
+  custom metric, a postmortem excerpt that says it outright. Absent that,
+  report the zero and stop.
+- **Never let a whole-day verdict rest on a source that failed.** If any
+  surface is `error` or `skipped`, the day's summary line in Step 4 says so
+  ("partial - GitHub unreadable") rather than characterizing the day.
+
+Do not fail the whole log because a surface was unavailable. Report the gap
+and write everything else.
+
+`surfaces` is the key to read. `warnings` is a flat legacy list kept for
+older on-disk prompts; if `surfaces` is absent from the payload the install
+is running a pre-#307 gather, so fall back to treating a non-empty
+`warnings` as "one or more sources unread" and apply case 1 conservatively.
 
 ## Step 2: Synthesize
 
@@ -181,6 +226,8 @@ empty)` keep their `##` header but leave the body blank.
   link(s). Include operational bullets: emails sent (from operational_email),
   second-brain writing (from second_brain_activity), and any
   custom-metric-worthy work.]
+- [One blind-spot line per surface whose status is error or skipped, naming
+  the source and the reason. Omit entirely when every surface is ok.]
 
 ## Learnings & Tribal Knowledge
 (skip body if empty)
@@ -205,7 +252,10 @@ empty)` keep their `##` header but leave the body blank.
 - Dating swipe sessions: N (if the install runs any)
 - [Any custom metrics from metrics.custom, one per line]
 
-_Warnings from gather:_ [only shown if warnings array non-empty; comma-joined]
+_Sources unread:_ [one line per surface whose status is error or skipped:
+`<surface>: <error>`. Omit the line entirely when every surface is ok. A
+metric derived from an unread source is not zero, it is unknown - mark those
+counts `unknown`, never `0`.]
 
 ## Reflection
 (skip body if empty)
@@ -231,7 +281,10 @@ Log to stdout (the dispatcher captures this):
 - Confirm the doc created: the parent it was written under, plus the id and
   deeplink `create_doc` returned
 - List section headings that had non-empty bodies
-- One-line summary of the day (for morning briefing context)
+- One-line summary of the day (for morning briefing context). If any surface
+  was error or skipped, prefix it `partial (<surface> unread):` - the morning
+  briefing consumes this line and must not inherit a confident verdict built
+  on a source nobody read.
 
 Do NOT post to Discord - this is a silent background task. The morning
 briefing pulls from these logs.

--- a/chassis/scripts/daily-log-gather.py
+++ b/chassis/scripts/daily-log-gather.py
@@ -61,6 +61,43 @@ the adapter factory, so they need no DAILY_LOG_* vars of their own.
 Unset env vars degrade gracefully: the corresponding surface is skipped, a
 warning is emitted into the `warnings` array, and the rest of the gather
 proceeds.
+
+Per-surface status (2026-07-19, new-jaxity#307)
+===============================================
+`warnings` alone could not answer the only question the prompt actually needs
+answered: for a bucket that came back empty, did nothing happen, or could we
+not look? It is a flat list of strings with no surface attribution, so the
+prompt collapsed both cases into "quiet day". On a day 8 PRs merged across
+three repos the GitHub query failed, `prs_by_repo` was `{}`, and the log said
+nothing shipped.
+
+`surfaces` carries the distinction structurally:
+
+    "surfaces": {
+      "github":       {"status": "ok",      "error": null},
+      "gmail":        {"status": "skipped", "error": "..."},
+      "second_brain": {"status": "error",   "error": "..."},
+      "discord":      {"status": "ok",      "error": null}
+    }
+
+  - ok      - the surface was queried and answered. An empty bucket under `ok`
+              is a real zero and may be narrated as such.
+  - skipped - never attempted, because a precondition (env var, credential)
+              was absent before the call. `error` holds the skip reason, not a
+              failure.
+  - error   - attempted, did not fully succeed. `error` holds the reason.
+
+Status is classified at the call site in `build_output` from facts it already
+holds - whether it invoked the gather function at all, and whether that call
+returned warnings - rather than by pattern-matching warning strings. A surface
+that was attempted and produced a warning is never `ok`; this is the same
+doctrine as chassis/scripts/_chassis-update-health.sh, "a healthcheck that
+cannot read the container does not get to report success".
+
+`warnings` is retained verbatim alongside `surfaces` for the same reason
+`siyuan_activity` is retained alongside `second_brain_activity`: bootstrap
+copies the prompt to disk once and never rewrites it, so every existing
+install is still reading the old key.
 """
 
 from __future__ import annotations
@@ -662,6 +699,30 @@ def gather_metrics(chassis_home: Path, prs_by_repo: dict, open_issues: list,
     return metrics
 
 
+# --- Surface status -------------------------------------------------------
+
+
+def surface_ok() -> dict:
+    return {"status": "ok", "error": None}
+
+
+def surface_skipped(reason: str) -> dict:
+    """A surface we never attempted. `error` holds the reason, not a failure."""
+    return {"status": "skipped", "error": reason}
+
+
+def surface_from_warnings(warns: list[str]) -> dict:
+    """Classify an ATTEMPTED surface from the warnings its gather returned.
+
+    Any warning at all demotes the surface out of `ok`. Deliberately blunt:
+    the caller cannot know which warnings are benign, and guessing wrong in
+    the permissive direction is the failure this whole block exists to stop.
+    """
+    if warns:
+        return {"status": "error", "error": "; ".join(warns)}
+    return surface_ok()
+
+
 # --- Main -----------------------------------------------------------------
 
 
@@ -684,6 +745,7 @@ def build_output(now: datetime | None = None, *, verbose: bool = False) -> dict:
     email_deferred = False
     siyuan_activity: list[dict] = []
     postmortems: list[dict] = []
+    surfaces: dict[str, dict] = {}
 
     # GitHub.
     gh_user = os.environ.get("DAILY_LOG_GH_USER", "").strip()
@@ -692,8 +754,11 @@ def build_output(now: datetime | None = None, *, verbose: bool = False) -> dict:
             gh_user, since, until, verbose=verbose
         )
         warnings.extend(gh_warn)
+        surfaces["github"] = surface_from_warnings(gh_warn)
     else:
-        warnings.append("DAILY_LOG_GH_USER unset - skipped GitHub scan")
+        reason = "DAILY_LOG_GH_USER unset - skipped GitHub scan"
+        warnings.append(reason)
+        surfaces["github"] = surface_skipped(reason)
 
     # Gmail.
     gmail_identity = os.environ.get("DAILY_LOG_GMAIL_IDENTITY", "").strip()
@@ -702,8 +767,21 @@ def build_output(now: datetime | None = None, *, verbose: bool = False) -> dict:
             gmail_identity, since, until, verbose=verbose
         )
         warnings.extend(gmail_warn)
+        if gmail_warn:
+            surfaces["gmail"] = surface_from_warnings(gmail_warn)
+        elif email_deferred:
+            # Deferral is not a result. This script did not read the mailbox;
+            # the prompt does it over MCP. Reporting `ok` here would license
+            # the prompt to narrate an empty inbox it never actually opened.
+            surfaces["gmail"] = surface_skipped(
+                "Gmail retrieval deferred to the prompt's MCP tools"
+            )
+        else:
+            surfaces["gmail"] = surface_ok()
     else:
-        warnings.append("DAILY_LOG_GMAIL_IDENTITY unset - skipped Gmail scan")
+        reason = "DAILY_LOG_GMAIL_IDENTITY unset - skipped Gmail scan"
+        warnings.append(reason)
+        surfaces["gmail"] = surface_skipped(reason)
 
     # Second brain. SiYuan keeps the direct-HTTP path it has always used; the
     # other backends go through the adapter. See the module docstring for why
@@ -720,13 +798,17 @@ def build_output(now: datetime | None = None, *, verbose: bool = False) -> dict:
                 siyuan_url, siyuan_token, since, until, verbose=verbose
             )
             warnings.extend(siyuan_warn)
+            surfaces["second_brain"] = surface_from_warnings(siyuan_warn)
         else:
-            warnings.append("DAILY_LOG_SIYUAN_URL / SIYUAN_URL unset - skipped SiYuan scan")
+            reason = "DAILY_LOG_SIYUAN_URL / SIYUAN_URL unset - skipped SiYuan scan"
+            warnings.append(reason)
+            surfaces["second_brain"] = surface_skipped(reason)
     else:
         siyuan_activity, adapter_warn = gather_via_adapter(
             backend, since, until, verbose=verbose
         )
         warnings.extend(adapter_warn)
+        surfaces["second_brain"] = surface_from_warnings(adapter_warn)
 
     # Discord postmortems.
     channel_id = os.environ.get("DAILY_LOG_DISCORD_CHANNEL_ID", "").strip()
@@ -737,10 +819,15 @@ def build_output(now: datetime | None = None, *, verbose: bool = False) -> dict:
             channel_id, discord_token, since, verbose=verbose
         )
         warnings.extend(discord_warn)
+        surfaces["discord"] = surface_from_warnings(discord_warn)
     elif not channel_id:
-        warnings.append("DAILY_LOG_DISCORD_CHANNEL_ID unset - skipped Discord scan")
+        reason = "DAILY_LOG_DISCORD_CHANNEL_ID unset - skipped Discord scan"
+        warnings.append(reason)
+        surfaces["discord"] = surface_skipped(reason)
     else:
-        warnings.append("DISCORD_TOKEN / DISCORD_BOT_TOKEN unset - skipped Discord scan")
+        reason = "DISCORD_TOKEN / DISCORD_BOT_TOKEN unset - skipped Discord scan"
+        warnings.append(reason)
+        surfaces["discord"] = surface_skipped(reason)
 
     # Metrics.
     extra_script = os.environ.get("DAILY_LOG_EXTRA_METRICS_SCRIPT", "").strip() or None
@@ -770,6 +857,9 @@ def build_output(now: datetime | None = None, *, verbose: bool = False) -> dict:
         "siyuan_activity": siyuan_activity,
         "postmortems": postmortems,
         "metrics": metrics,
+        "surfaces": surfaces,
+        # Retained alongside `surfaces` for installs whose on-disk prompt
+        # predates it. See the per-surface status note in the module docstring.
         "warnings": warnings,
     }
 
@@ -808,6 +898,14 @@ def main() -> int:
             "siyuan_activity": [],
             "postmortems": [],
             "metrics": {},
+            # A crash means no surface was read to completion. Every one of
+            # them reports error, so the prompt cannot read this payload as a
+            # quiet day.
+            "surfaces": {
+                name: {"status": "error",
+                       "error": f"gather crashed: {type(e).__name__}: {e}"}
+                for name in ("github", "gmail", "second_brain", "discord")
+            },
             "warnings": [f"gather crashed: {type(e).__name__}: {e}"],
         }
 

--- a/chassis/scripts/gather-local-health.sh
+++ b/chassis/scripts/gather-local-health.sh
@@ -23,6 +23,8 @@
 #   low_memory_<n>MB               - available memory < MEM_MB_FLOOR (default 2048)
 #   dispatcher_stuck_<n>s          - dispatcher.lock older than LOCK_STALE_S (default 1800)
 #   dispatcher_silent_<n>s         - no heartbeat-state update for > SILENCE_S (default 7200)
+#   heartbeat_state_unreadable     - heartbeat-state.json exists but jq could not
+#                                    parse it, so the silence check could not run
 #
 # Customer-specific health checks (Ollama presence, launchd / systemd unit
 # state, Mac-Mini-specific peripherals, etc.) live in a sibling hook at
@@ -78,7 +80,27 @@ fi
 # script erroring before set_state).
 state_file="${CHASSIS_HOME}/scheduled-tasks/heartbeat-state.json"
 if [[ -f "$state_file" ]]; then
-    last_any=$(jq -r '[.[] | .last_checked // empty] | sort | last // empty' "$state_file" 2>/dev/null || echo "")
+    state_err="$(mktemp)"
+    # `select(type == "object")` before indexing, because the state file's top
+    # level is not uniformly objects - a scalar sibling key (a schema version,
+    # a bare timestamp) makes `.[] | .last_checked` abort with "Cannot index
+    # number with last_checked". The old form of this line paired that with a
+    # blanket `2>/dev/null || echo ""`, so the abort was indistinguishable from
+    # "no timestamps yet": last_any came back empty, the silence check below
+    # was skipped, and dispatcher_silent_<n>s could never fire. The alarm for a
+    # dead dispatcher was itself dead.
+    #
+    # jq failure is now caught explicitly and reported as its own issue rather
+    # than suppressed. It is not `|| echo ""` (which is the bug) and not an
+    # unguarded call under `set -e` (which would abort before the JSON contract
+    # is emitted, taking every other finding with it). A probe that cannot read
+    # the state file does not get to report an all-clear about it.
+    if ! last_any=$(jq -r '[.[] | select(type == "object") | .last_checked // empty] | sort | last // empty' "$state_file" 2>"$state_err"); then
+        issues+=("heartbeat_state_unreadable")
+        last_any=""
+        echo "gather-local-health: cannot read $state_file: $(tr '\n' ' ' <"$state_err")" >&2
+    fi
+    rm -f "$state_err"
     if [[ -n "$last_any" ]]; then
         # macOS `date -j -f` and GNU `date -d`. Try macOS first then fall back.
         last_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$last_any" +%s 2>/dev/null || \

--- a/chassis/scripts/test-daily-log-gather.sh
+++ b/chassis/scripts/test-daily-log-gather.sh
@@ -7,6 +7,9 @@
 #   2. Individual surfaces can be independently disabled via env var absence.
 #   3. Output is parseable JSON in every scenario.
 #   4. The `warnings` array reports each skipped surface.
+#   5. The `surfaces` block reports a per-surface status, and a surface that
+#      was attempted and failed reports `error` rather than a bare empty
+#      bucket the prompt would read as a quiet day (new-jaxity#307).
 #
 # No real API calls: every scenario runs with the required auth env vars
 # unset, so each surface short-circuits into the "skipped, warning added"
@@ -115,6 +118,37 @@ assert_warning_contains() {
     return 0
 }
 
+assert_surface_status() {
+    local name="$1"
+    local surface="$2"
+    local expected="$3"
+    local actual
+    actual=$(jq -r --arg s "$surface" '.surfaces[$s].status // "MISSING"' \
+        "$TMPHOME/last-output.json")
+    if [[ "$actual" != "$expected" ]]; then
+        echo "FAIL [$name] surfaces.$surface.status: expected '$expected', got '$actual'"
+        fail=$((fail + 1))
+        return 1
+    fi
+    return 0
+}
+
+# A surface reporting `error` must say why. An error with a null reason is
+# useless to the prompt, which is required to name the unread source.
+assert_surface_error_nonempty() {
+    local name="$1"
+    local surface="$2"
+    local detail
+    detail=$(jq -r --arg s "$surface" '.surfaces[$s].error // ""' \
+        "$TMPHOME/last-output.json")
+    if [[ -z "$detail" ]]; then
+        echo "FAIL [$name] surfaces.$surface.status is error but .error is empty"
+        fail=$((fail + 1))
+        return 1
+    fi
+    return 0
+}
+
 # ------------------------------------------------------------------------
 # Scenario 1: bare invocation, zero env config. Every surface skips with a
 # warning. All buckets empty. Metrics all zeros.
@@ -142,6 +176,14 @@ if [[ -f "$TMPHOME/last-output.json" ]]; then
     assert_warning_contains "bare" "DAILY_LOG_GMAIL_IDENTITY"
     assert_warning_contains "bare" "DAILY_LOG_SIYUAN_URL"
     assert_warning_contains "bare" "DAILY_LOG_DISCORD_CHANNEL_ID"
+    # Nothing was configured, so nothing was attempted. Every surface must say
+    # `skipped` - NOT `ok`, which would license the prompt to call this a day
+    # on which nothing happened.
+    assert_key "bare" ".surfaces"
+    assert_surface_status "bare" "github" "skipped"
+    assert_surface_status "bare" "gmail" "skipped"
+    assert_surface_status "bare" "second_brain" "skipped"
+    assert_surface_status "bare" "discord" "skipped"
 fi
 
 # ------------------------------------------------------------------------
@@ -158,6 +200,12 @@ if [[ -f "$TMPHOME/last-output.json" ]]; then
         fail=$((fail + 1))
     fi
     assert_empty_array "siyuan-unreachable" ".siyuan_activity"
+    # The load-bearing assertion for new-jaxity#307. SiYuan WAS configured and
+    # WAS attempted; the query failed. second_brain_activity is empty either
+    # way, so an empty bucket cannot carry this - only the status can. `ok`
+    # here is what produced "quiet day" on a day with real activity.
+    assert_surface_status "siyuan-unreachable" "second_brain" "error"
+    assert_surface_error_nonempty "siyuan-unreachable" "second_brain"
 fi
 
 # ------------------------------------------------------------------------
@@ -169,6 +217,38 @@ run_scenario "discord-no-token" \
 if [[ -f "$TMPHOME/last-output.json" ]]; then
     assert_warning_contains "discord-no-token" "DISCORD_TOKEN"
     assert_empty_array "discord-no-token" ".postmortems"
+    # Channel known, credential absent: never attempted, so `skipped`.
+    assert_surface_status "discord-no-token" "discord" "skipped"
+    assert_surface_error_nonempty "discord-no-token" "discord"
+fi
+
+# ------------------------------------------------------------------------
+# Scenario 3b (new-jaxity#307 REGRESSION): GitHub is configured, so the scan
+# IS attempted, and the `gh` call fails. This is the shape of the incident:
+# prs_by_repo comes back `{}` exactly as it would on a day with no PRs, so
+# nothing in the buckets can distinguish "nothing shipped" from "we could not
+# look" - the status has to. A `gh` shim on PATH keeps it offline; a failing
+# `gh api graphql` is precisely what happened on the day 8 merged PRs were
+# reported as a quiet day.
+# ------------------------------------------------------------------------
+mkdir -p "$TMPHOME/fakebin"
+cat >"$TMPHOME/fakebin/gh" <<'FAKEGH'
+#!/bin/bash
+echo "gh: could not authenticate" >&2
+exit 1
+FAKEGH
+chmod +x "$TMPHOME/fakebin/gh"
+run_scenario "github-gh-failing" \
+    PATH="$TMPHOME/fakebin:$PATH" \
+    DAILY_LOG_GH_USER="testuser"
+if [[ -f "$TMPHOME/last-output.json" ]]; then
+    assert_surface_status "github-gh-failing" "github" "error"
+    assert_surface_error_nonempty "github-gh-failing" "github"
+    # Empty buckets, same as a genuinely quiet day. Only the status differs.
+    if [[ "$(jq -r '.prs_by_repo | length' "$TMPHOME/last-output.json")" != "0" ]]; then
+        echo "FAIL [github-gh-failing] expected empty prs_by_repo"
+        fail=$((fail + 1))
+    fi
 fi
 
 # ------------------------------------------------------------------------

--- a/chassis/scripts/test-gather-local-health.sh
+++ b/chassis/scripts/test-gather-local-health.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# test-gather-local-health.sh - Unit tests for gather-local-health.sh's
+# dispatcher-silence check.
+#
+# The bug these lock down
+# =======================
+# The silence check read the newest `last_checked` with:
+#
+#   last_any=$(jq -r '[.[] | .last_checked // empty] | sort | last // empty' \
+#              "$state_file" 2>/dev/null || echo "")
+#
+# heartbeat-state.json's top level is not uniformly objects - a scalar sibling
+# key (schema_version, a bare timestamp) makes `.[] | .last_checked` abort with
+# "Cannot index number with last_checked". The blanket `2>/dev/null || echo ""`
+# swallowed that, `last_any` came back empty, and the `if [[ -n "$last_any" ]]`
+# guard skipped the entire silence check. dispatcher_silent_<n>s could never
+# fire: the alarm that reports a dead dispatcher was itself dead, silently, on
+# every install whose state file carried a scalar key.
+#
+# Scenario 1 is the regression: a state file with a scalar sibling AND a
+# last_checked six years stale must produce dispatcher_silent_<n>s. Against the
+# unfixed script it produces count=0.
+#
+# No network, no daemon - the tests build state files in a temp CHASSIS_HOME.
+#
+# Exit codes:
+#   0 - all scenarios passed
+#   1 - one or more scenarios failed
+#   2 - test harness itself broke (missing jq)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATHER="${SCRIPT_DIR}/gather-local-health.sh"
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "test-gather-local-health: required dep missing: jq" >&2
+    exit 2
+fi
+if [[ ! -f "$GATHER" ]]; then
+    echo "test-gather-local-health: script not found at $GATHER" >&2
+    exit 2
+fi
+
+fail=0
+pass=0
+
+TMPHOME="$(mktemp -d)"
+trap 'rm -rf "$TMPHOME"' EXIT
+mkdir -p "$TMPHOME/scheduled-tasks"
+STATE="$TMPHOME/scheduled-tasks/heartbeat-state.json"
+
+# Run the gather against the current STATE file, capturing stdout only.
+# DISK_PCT_THRESHOLD / MEM_MB_FLOOR are pinned out of the way so the host's
+# real disk and memory can never inject an unrelated issue tag and make an
+# assertion about `issues` pass or fail for the wrong reason.
+run_gather() {
+    CHASSIS_HOME="$TMPHOME" \
+    DISK_PCT_THRESHOLD=100 \
+    MEM_MB_FLOOR=0 \
+    bash "$GATHER" 2>/dev/null
+}
+
+assert_has_issue() {
+    local name="$1" prefix="$2" out="$3"
+    if echo "$out" | jq -e --arg p "$prefix" \
+        '.issues | map(select(startswith($p))) | length > 0' >/dev/null 2>&1; then
+        pass=$((pass + 1))
+    else
+        echo "FAIL [$name] expected an issue starting with '$prefix'"
+        echo "-- output --"
+        echo "$out"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_no_issues() {
+    local name="$1" out="$2"
+    local count
+    count=$(echo "$out" | jq -r '.count')
+    if [[ "$count" == "0" ]]; then
+        pass=$((pass + 1))
+    else
+        echo "FAIL [$name] expected count=0, got $count"
+        echo "-- output --"
+        echo "$out"
+        fail=$((fail + 1))
+    fi
+}
+
+# ------------------------------------------------------------------------
+# Scenario 1 (REGRESSION): scalar sibling key at top level, stale timestamp.
+# The scalar is what broke jq. The stale timestamp is what must still be
+# found despite it.
+# ------------------------------------------------------------------------
+cat >"$STATE" <<'EOF'
+{
+  "schema_version": 2,
+  "daily-log": { "last_checked": "2020-01-01T00:00:00" },
+  "morning-briefing": { "last_checked": "2020-01-02T00:00:00" }
+}
+EOF
+out=$(run_gather)
+assert_has_issue "scalar-sibling-stale" "dispatcher_silent_" "$out"
+
+# ------------------------------------------------------------------------
+# Scenario 2: same scalar sibling, but the newest timestamp is current. The
+# select() must not swallow live heartbeats into a false alarm.
+# ------------------------------------------------------------------------
+now_iso=$(date -u +%Y-%m-%dT%H:%M:%S)
+cat >"$STATE" <<EOF
+{
+  "schema_version": 2,
+  "daily-log": { "last_checked": "2020-01-01T00:00:00" },
+  "morning-briefing": { "last_checked": "$now_iso" }
+}
+EOF
+out=$(run_gather)
+assert_no_issues "scalar-sibling-fresh" "$out"
+
+# ------------------------------------------------------------------------
+# Scenario 3: objects only, stale. The pre-existing happy path - the fix must
+# not have changed it.
+# ------------------------------------------------------------------------
+cat >"$STATE" <<'EOF'
+{
+  "daily-log": { "last_checked": "2020-01-01T00:00:00" }
+}
+EOF
+out=$(run_gather)
+assert_has_issue "objects-only-stale" "dispatcher_silent_" "$out"
+
+# ------------------------------------------------------------------------
+# Scenario 4: unparseable state file. Must report heartbeat_state_unreadable
+# rather than degrade into an all-clear, and must still emit the gather JSON
+# contract so the dispatcher does not choke.
+# ------------------------------------------------------------------------
+echo 'not json at all {{{' >"$STATE"
+out=$(run_gather)
+if ! echo "$out" | jq . >/dev/null 2>&1; then
+    echo "FAIL [malformed-state] gather did not emit valid JSON"
+    fail=$((fail + 1))
+else
+    pass=$((pass + 1))
+fi
+assert_has_issue "malformed-state" "heartbeat_state_unreadable" "$out"
+
+# ------------------------------------------------------------------------
+# Scenario 5: top level is a flat scalar. The literal shape named in the jq
+# error ("Cannot index string with last_checked").
+# ------------------------------------------------------------------------
+echo '"just-a-string"' >"$STATE"
+out=$(run_gather)
+assert_has_issue "flat-scalar-state" "heartbeat_state_unreadable" "$out"
+
+# ------------------------------------------------------------------------
+# Scenario 6: no state file at all. Genuinely nothing to check - stays quiet.
+# ------------------------------------------------------------------------
+rm -f "$STATE"
+out=$(run_gather)
+assert_no_issues "no-state-file" "$out"
+
+echo
+echo "test-gather-local-health: $pass passed, $fail failed"
+if [[ $fail -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/chassis/scripts/tests/test_daily_log_surfaces.py
+++ b/chassis/scripts/tests/test_daily_log_surfaces.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""test_daily_log_surfaces.py - per-surface status in the daily-log gather.
+
+The bug this locks down (new-jaxity#307)
+========================================
+The gather returned `warnings: []` and nothing else about surface health. A
+flat list of strings with no surface attribution cannot answer the one
+question the daily-log prompt has to ask about an empty bucket: did nothing
+happen, or could we not look? So the prompt collapsed both into "quiet day".
+On a day 8 PRs merged across three repos, the GitHub query failed,
+`prs_by_repo` came back `{}`, and the log reported nothing shipped.
+
+The distinction cannot live in the buckets. A failed GitHub scan and a
+genuinely quiet day produce byte-identical `prs_by_repo` values. It has to
+live in a status field, which is what `surfaces` is.
+
+The property under test throughout: a surface that was NOT successfully read
+must never report `ok`. `skipped` and `error` are both acceptable answers for
+an unread surface - conflating those two is a cosmetic bug, whereas reporting
+either as `ok` is the incident.
+
+Run:
+    python3 -m pytest chassis/scripts/tests/test_daily_log_surfaces.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+GATHER_PATH = REPO_ROOT / "chassis" / "scripts" / "daily-log-gather.py"
+_spec = importlib.util.spec_from_file_location("daily_log_gather_surfaces", GATHER_PATH)
+gather = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gather)
+
+UNTIL = datetime(2026, 7, 19, tzinfo=timezone.utc)
+
+SURFACES = ("github", "gmail", "second_brain", "discord")
+
+# Every surface configured, so build_output attempts all four and the status
+# is decided by what the gather functions return rather than by a missing var.
+FULL_ENV = {
+    "CHASSIS_HOME": "/nonexistent-chassis-home",
+    "DAILY_LOG_GH_USER": "testuser",
+    "DAILY_LOG_GMAIL_IDENTITY": "jax@example.com",
+    "DAILY_LOG_SIYUAN_URL": "http://127.0.0.1:1",
+    "DAILY_LOG_DISCORD_CHANNEL_ID": "1234567890123456789",
+    "DISCORD_TOKEN": "test-token",
+}
+
+
+def build(env: dict, **patches):
+    """Run build_output with a controlled env and stubbed surface gathers.
+
+    Defaults every gather to a clean success so each test can make exactly one
+    of them fail and attribute the resulting status unambiguously.
+    """
+    defaults = {
+        "gather_github": ({}, [], []),
+        "gather_gmail": ([], False, []),
+        "gather_siyuan": ([], []),
+        "gather_discord_postmortems": ([], []),
+    }
+    defaults.update(patches)
+    with mock.patch.dict("os.environ", env, clear=True), \
+         mock.patch.object(gather, "resolve_second_brain_backend", return_value="siyuan"), \
+         mock.patch.object(gather, "gather_metrics", return_value={}), \
+         mock.patch.object(gather, "gather_github", return_value=defaults["gather_github"]), \
+         mock.patch.object(gather, "gather_gmail", return_value=defaults["gather_gmail"]), \
+         mock.patch.object(gather, "gather_siyuan", return_value=defaults["gather_siyuan"]), \
+         mock.patch.object(gather, "gather_discord_postmortems",
+                           return_value=defaults["gather_discord_postmortems"]):
+        return gather.build_output(now=UNTIL, verbose=False)
+
+
+class SurfacesBlockShapeTest(unittest.TestCase):
+    def test_every_surface_is_present(self) -> None:
+        surfaces = build(FULL_ENV)["surfaces"]
+        self.assertEqual(set(surfaces), set(SURFACES))
+
+    def test_every_surface_has_status_and_error_keys(self) -> None:
+        surfaces = build(FULL_ENV)["surfaces"]
+        for name in SURFACES:
+            with self.subTest(surface=name):
+                self.assertIn("status", surfaces[name])
+                self.assertIn("error", surfaces[name])
+
+    def test_status_is_always_one_of_the_three_values(self) -> None:
+        surfaces = build({"CHASSIS_HOME": "/nonexistent-chassis-home"})["surfaces"]
+        for name, surface in surfaces.items():
+            with self.subTest(surface=name):
+                self.assertIn(surface["status"], ("ok", "error", "skipped"))
+
+    def test_warnings_is_retained_alongside_surfaces(self) -> None:
+        """Bootstrap copies the prompt to disk once. Installs still read this."""
+        payload = build({"CHASSIS_HOME": "/nonexistent-chassis-home"})
+        self.assertIn("warnings", payload)
+        self.assertTrue(payload["warnings"])
+
+
+class UnconfiguredSurfacesAreSkippedTest(unittest.TestCase):
+    """No credentials means nothing was attempted, which is not `ok`."""
+
+    def test_bare_env_skips_every_surface(self) -> None:
+        surfaces = build({"CHASSIS_HOME": "/nonexistent-chassis-home"})["surfaces"]
+        for name in SURFACES:
+            with self.subTest(surface=name):
+                self.assertEqual(surfaces[name]["status"], "skipped")
+
+    def test_skip_reason_is_reported(self) -> None:
+        surfaces = build({"CHASSIS_HOME": "/nonexistent-chassis-home"})["surfaces"]
+        for name in SURFACES:
+            with self.subTest(surface=name):
+                self.assertTrue(surfaces[name]["error"],
+                                f"{name} skipped without saying why")
+
+    def test_discord_channel_set_but_token_missing_is_skipped(self) -> None:
+        env = dict(FULL_ENV)
+        del env["DISCORD_TOKEN"]
+        surfaces = build(env)["surfaces"]
+        self.assertEqual(surfaces["discord"]["status"], "skipped")
+        self.assertIn("DISCORD_TOKEN", surfaces["discord"]["error"])
+
+
+class AttemptedAndFailedIsErrorTest(unittest.TestCase):
+    """The #307 shape: configured, attempted, failed, empty bucket."""
+
+    def test_failed_github_scan_reports_error_not_ok(self) -> None:
+        payload = build(
+            FULL_ENV,
+            gather_github=({}, [], ["gh graphql viewer query failed - skipped GitHub scan"]),
+        )
+        github = payload["surfaces"]["github"]
+        self.assertEqual(github["status"], "error")
+        self.assertIn("graphql", github["error"])
+
+    def test_failed_github_scan_bucket_is_indistinguishable_from_quiet_day(self) -> None:
+        """The reason status exists: the buckets alone cannot carry this.
+
+        A failed scan and a genuinely quiet day are byte-identical in
+        prs_by_repo. If this assertion ever fails, the bucket started carrying
+        the signal and the status field could in principle be retired - but
+        until then, status is the only place the distinction lives.
+        """
+        failed = build(
+            FULL_ENV,
+            gather_github=({}, [], ["gh graphql viewer query failed"]),
+        )
+        quiet = build(FULL_ENV, gather_github=({}, [], []))
+        self.assertEqual(failed["prs_by_repo"], quiet["prs_by_repo"])
+        self.assertNotEqual(
+            failed["surfaces"]["github"]["status"],
+            quiet["surfaces"]["github"]["status"],
+        )
+
+    def test_failed_second_brain_scan_reports_error(self) -> None:
+        payload = build(
+            FULL_ENV,
+            gather_siyuan=([], ["siyuan SQL query failed - skipped SiYuan scan"]),
+        )
+        self.assertEqual(payload["surfaces"]["second_brain"]["status"], "error")
+
+    def test_failed_discord_scan_reports_error(self) -> None:
+        payload = build(
+            FULL_ENV,
+            gather_discord_postmortems=([], ["discord fetch failed: HTTP 401"]),
+        )
+        discord = payload["surfaces"]["discord"]
+        self.assertEqual(discord["status"], "error")
+        self.assertIn("401", discord["error"])
+
+    def test_multiple_warnings_are_all_reported(self) -> None:
+        payload = build(
+            FULL_ENV,
+            gather_github=({}, [], ["first failure", "second failure"]),
+        )
+        detail = payload["surfaces"]["github"]["error"]
+        self.assertIn("first failure", detail)
+        self.assertIn("second failure", detail)
+
+    def test_one_failed_surface_does_not_demote_the_others(self) -> None:
+        payload = build(FULL_ENV, gather_github=({}, [], ["boom"]))
+        self.assertEqual(payload["surfaces"]["github"]["status"], "error")
+        self.assertEqual(payload["surfaces"]["second_brain"]["status"], "ok")
+        self.assertEqual(payload["surfaces"]["discord"]["status"], "ok")
+
+
+class SuccessfulSurfacesAreOkTest(unittest.TestCase):
+    """`ok` has to remain reachable, or the prompt can never say "quiet day"."""
+
+    def test_clean_scan_reports_ok_with_null_error(self) -> None:
+        surfaces = build(FULL_ENV)["surfaces"]
+        for name in ("github", "second_brain", "discord"):
+            with self.subTest(surface=name):
+                self.assertEqual(surfaces[name]["status"], "ok")
+                self.assertIsNone(surfaces[name]["error"])
+
+    def test_empty_bucket_under_ok_is_a_real_zero(self) -> None:
+        payload = build(FULL_ENV)
+        self.assertEqual(payload["prs_by_repo"], {})
+        self.assertEqual(payload["surfaces"]["github"]["status"], "ok")
+
+
+class GmailDeferralTest(unittest.TestCase):
+    """Deferral is not a result - this script never opened the mailbox."""
+
+    def test_deferred_gmail_is_not_ok(self) -> None:
+        payload = build(FULL_ENV, gather_gmail=([], True, []))
+        self.assertTrue(payload["gmail_scan_deferred"])
+        self.assertEqual(payload["surfaces"]["gmail"]["status"], "skipped")
+
+    def test_non_deferred_clean_gmail_is_ok(self) -> None:
+        payload = build(FULL_ENV, gather_gmail=([], False, []))
+        self.assertEqual(payload["surfaces"]["gmail"]["status"], "ok")
+
+
+class CrashPathTest(unittest.TestCase):
+    """A crashed gather read nothing, so it may not look like a quiet day."""
+
+    def test_crash_marks_every_surface_error(self) -> None:
+        argv = sys.argv
+        sys.argv = ["daily-log-gather.py"]
+        try:
+            with mock.patch.object(gather, "build_output",
+                                   side_effect=RuntimeError("kaboom")), \
+                 mock.patch("builtins.print") as printed:
+                rc = gather.main()
+        finally:
+            sys.argv = argv
+        self.assertEqual(rc, 0)
+        import json
+        payload = json.loads(printed.call_args[0][0])
+        for name in SURFACES:
+            with self.subTest(surface=name):
+                self.assertEqual(payload["surfaces"][name]["status"], "error")
+                self.assertIn("kaboom", payload["surfaces"][name]["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two live bugs, one principle. Both make a failure indistinguishable from an
all-clear, on every customer install. Neither is a crash, which is why both
survived this long.

Chassis already stated the correct doctrine once, in
`_chassis-update-health.sh` (PR 76): *"A healthcheck that cannot read the
container does not get to report success."* These two fixes are written to
exemplify it.

## Bug 1: the daily-log prompt was instructed to hide failures

`daily-log-prompt.md.template` told the model:

> If `warnings` is non-empty, note it briefly at the bottom of the Metrics
> section so the operator can see which surfaces silently degraded. Do not
> fail the whole log because a surface was skipped.

So when the GitHub query failed, `prs_by_repo` was `{}`, the Shipped section
was empty, the failure was a comma-joined footnote under Metrics, and the
model wrote "quiet day". That is new-jaxity#307: a briefing reporting
"0 commits, nothing shipped" on a day 8 PRs merged across three repos.

The gather compounded it. It returned only `warnings: []` - a flat list of
strings with no surface attribution. The prompt could not distinguish
"nothing happened" from "we could not look" because **the data did not carry
the distinction**. It cannot live in the buckets either: a failed GitHub scan
and a genuinely quiet day produce byte-identical `prs_by_repo` values. That
is asserted directly in
`test_failed_github_scan_bucket_is_indistinguishable_from_quiet_day`.

### (a) `daily-log-gather.py`

New `surfaces` block:

```json
"surfaces": {
  "github":       { "status": "error",   "error": "gh graphql viewer query failed" },
  "gmail":        { "status": "skipped", "error": "DAILY_LOG_GMAIL_IDENTITY unset" },
  "second_brain": { "status": "ok",      "error": null },
  "discord":      { "status": "ok",      "error": null }
}
```

- `ok` - queried and answered. An empty bucket here is a real zero.
- `skipped` - never attempted; a precondition was absent before the call.
  `error` holds the skip reason, not a failure.
- `error` - attempted, did not fully succeed.

Classified at the call site in `build_output` from facts it already holds
(did it invoke the gather at all, did that call return warnings) rather than
by pattern-matching warning strings. Any warning at all demotes a surface out
of `ok` - deliberately blunt, since guessing permissively is the exact
failure this block exists to stop.

Two judgement calls worth a reviewer's eye:

- **Gmail deferral is `skipped`, not `ok`.** `gather_gmail` returns
  `deferred=True` with no warnings; the prompt does the retrieval over MCP.
  This script never opened the mailbox, so reporting `ok` would license the
  prompt to narrate an empty inbox nobody read.
- **A crashed gather marks all four `error`.** The catch-all in `main()`
  emits a valid-JSON payload with empty buckets; without this it read as a
  perfectly quiet day.

No gather-function signature changed, so the existing mocks in
`test_daily_log_gather_backends.py` still bind. `warnings` is retained
verbatim - same reason `siyuan_activity` is retained alongside
`second_brain_activity`: bootstrap copies the prompt to disk once and never
rewrites it, so every existing install is still reading the old key.

### (b) the prompt template

The "note it briefly" instruction is replaced with a three-case rule keyed on
status - source failed / source genuinely returned zero / source has content -
where case 1 requires an explicit blind-spot line naming the source and
reason, and case 2 is identified as the only case in which "quiet day" is an
honest sentence. Plus:

- **A bar on inventing a cause for an empty result.** "quiet day because Sean
  was travelling" is forbidden unless another source in the same payload
  establishes it.
- **Metrics derived from an unread source are `unknown`, never `0`.**
- **The Step 4 day summary is prefixed `partial (<surface> unread)`** when
  anything went unread. The morning briefing consumes that line and must not
  inherit a confident verdict built on a source nobody read.
- A fallback clause: if `surfaces` is absent the install is running a
  pre-#307 gather, so treat non-empty `warnings` as "sources unread".

## Bug 2: a jq guard that silently skipped a health alert

`gather-local-health.sh`:

```bash
last_any=$(jq -r '[.[] | .last_checked // empty] | sort | last // empty' "$state_file" 2>/dev/null || echo "")
```

`heartbeat-state.json`'s top level is not uniformly objects. A scalar sibling
key makes `.[] | .last_checked` abort with "Cannot index number with
last_checked". The blanket suppression swallowed it, `last_any` came back
empty, and the `if [[ -n "$last_any" ]]` guard skipped the entire check - so
`dispatcher_silent_<n>s` could never fire. **The alarm that reports a dead
dispatcher was itself dead.**

Reproduced against a state file with `"schema_version": 2` plus a
`last_checked` from 2020:

```
before:  {"count":0,"issues":[]}
after:   {"count":1,"issues":["dispatcher_silent_206653106s"]}
```

Filters with `select(type == "object")` before indexing. The blanket
suppression is replaced with an explicit failure branch emitting a new
`heartbeat_state_unreadable` issue - deliberately **not** an unguarded call
under `set -e`, which would abort before the gather JSON contract is emitted
and take every other finding with it. No dispatcher code matches on issue
tags (it logs them verbatim), so the new tag is additive.

**`reconcile-heartbeats.sh` does NOT have this bug.** Line 107 is
`jq -r --arg n "$name" '.[$n].last_checked // ""'` - it indexes a named key
rather than iterating values, and carries no stderr suppression, so a
malformed state file aborts it loudly under `set -e`. That is the
doctrine-correct outcome. Left alone.

## Test plan

Every fix has a test that fails without it, verified by running the new tests
against unmodified `origin/main`:

- [x] `chassis/scripts/tests/test_daily_log_surfaces.py` (new, 18 tests):
      **20 of 22 fail against main.** The 2 that pass are the
      backwards-compatibility assertions that `warnings` survives, which
      correctly pass on both.
- [x] `chassis/scripts/test-daily-log-gather.sh` (extended): **11 assertion
      failures against main**, 0 after. New scenario `github-gh-failing`
      stubs a failing `gh` on PATH to reproduce the #307 shape offline - the
      suite's no-network design is preserved (an earlier draft using a bogus
      Discord token was dropped for this reason).
- [x] `chassis/scripts/test-gather-local-health.sh` (new, 7 assertions):
      **3 fail against main**, including scenario 1, the exact reported bug,
      which returns `count=0`. Covers scalar-sibling-stale,
      scalar-sibling-fresh (no false alarm), objects-only-stale (happy path
      unchanged), malformed state, flat-scalar state, and no state file.
      Disk/memory thresholds are pinned out of the way so the host's real
      posture cannot make an assertion pass for the wrong reason.
- [x] Full suite: **386 passed / 12 skipped before, 404 passed / 12 skipped
      after.** No regressions. (The brief's 370 baseline was stale by one
      missing dep - `psycopg[binary]`; without it 2 `db/tests` fail for
      environmental reasons on both branches.)
- [x] `test-chassis-update-health.sh` still passes.
- [x] `shellcheck` clean on both shell files.
- [x] End-to-end against a live SiYuan instance: `second_brain` reports `ok`
      on a real query returning zero rows, and flips to `skipped` when
      `SIYUAN_URL` is cleared - confirming `ok` is reachable and means what
      it claims.

## Not in scope

- `chassis/VERSION` untouched - separate bump PR.
- No CHANGELOG entry (unreleased version); detail lives here.
- Promoting the doctrine into a documented convention plus a lint is the
  larger piece of work these two fixes are written to exemplify, not to
  deliver.

## Nearby, broken, left alone

- `chassis/db/tests/test_connection.py` has 2 tests that fail purely on
  `psycopg` absence rather than skipping. Pre-existing on main, unrelated,
  arguably should be a `skipUnless`.
- `gather_gmail` is dead weight: it probes for `googleapiclient` and defers
  unconditionally either way, so both branches return the same thing. Not
  touched beyond classifying its deferral honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
