### PR TITLE
feat(plugins): make the fetched tree authoritative over the baked one (#82)

### DIFF
--- a/chassis/scripts/_env.sh
+++ b/chassis/scripts/_env.sh
@@ -72,10 +72,35 @@ if [[ -z "${CHASSIS_ROOT:-}" ]]; then
     fi
 fi
 
+# Plugin root resolution (behalfbot#82).
+#
+# Order of preference:
+#   1. $CUSTOMER_HOME/vendored-plugins - the tree fetched from
+#      scrollinondubs/behalfbot-plugins at the pinned tag+SHA. This is the
+#      authoritative source once a fetch has succeeded.
+#   2. /app/plugins - the image-baked tree. The fallback when no fetch has run
+#      yet, when the fetch failed, or on an air-gapped/frozen install.
+#   3. $CHASSIS_HOME/plugins - host-side installs with no container layout.
+#
+# The non-empty test on (1) is the important part and is not decoration. An
+# empty or half-written vendored-plugins directory must NOT shadow the baked
+# tree: that would turn a failed fetch into a chassis that silently loads no
+# plugins and reports nothing wrong. A directory only counts as a usable
+# plugin root if it actually contains at least one plugin manifest.
+_chassis_plugin_root_usable() {
+    local dir="$1"
+    [[ -d "$dir" ]] || return 1
+    compgen -G "$dir"/*/openclaw.plugin.json > /dev/null 2>&1
+}
+
 if [[ -z "${CHASSIS_PLUGINS_ROOT:-}" ]]; then
-    if [[ -d "/app/plugins" ]]; then
+    _vendored="${CUSTOMER_HOME:-${CHASSIS_HOME:-}}/vendored-plugins"
+    if _chassis_plugin_root_usable "$_vendored"; then
+        export CHASSIS_PLUGINS_ROOT="$_vendored"
+    elif [[ -d "/app/plugins" ]]; then
         export CHASSIS_PLUGINS_ROOT="/app/plugins"
     elif [[ -n "${CHASSIS_HOME:-}" && -d "$CHASSIS_HOME/plugins" ]]; then
         export CHASSIS_PLUGINS_ROOT="$CHASSIS_HOME/plugins"
     fi
+    unset _vendored
 fi


### PR DESCRIPTION
Closes the last code step of #82. **Merge order: after #87.**

## What this changes

The fetcher already wrote `$CUSTOMER_HOME/vendored-plugins` and a `plugins.lock`. **Nothing read either.** The chassis still resolved `CHASSIS_PLUGINS_ROOT` to the image-baked `/app/plugins`, so a successful fetch changed nothing observable - it produced artifacts and no behaviour.

Resolution order is now:

1. `$CUSTOMER_HOME/vendored-plugins` - the tree fetched at the pinned tag+SHA, **if it actually contains plugins**
2. `/app/plugins` - the image-baked tree
3. `$CHASSIS_HOME/plugins` - host-side installs with no container layout

An explicit `CHASSIS_PLUGINS_ROOT` in the environment still wins over all of it.

## The non-empty test is the point

`vendored-plugins` is only selected if it contains at least one `*/openclaw.plugin.json`.

Without that check, an empty or half-written directory shadows the baked tree and the chassis loads **zero plugins while reporting nothing wrong**. A failed fetch would present as a healthy boot with a mysteriously inert bot. Given this repo spent 2026-07-20 finding checks that could not fail, shipping a plugin loader that silently loads nothing seemed like the wrong way to end the day.

It also matters for the ordering in #82: the fetch hook is non-fatal by design, so a failed fetch *will* happen eventually. This is what makes that survivable.

## Verification

Six cases against the real `_env.sh`:

| Case | Result |
|---|---|
| No vendored dir, no plugins dir | unset (correct - nothing exists) |
| vendored dir **empty**, nothing else | unset - did **not** select the empty dir |
| vendored dir with a manifest | selects vendored-plugins |
| vendored **empty** + real `plugins/` present | selects **`plugins/`** - empty tree correctly does not shadow |
| vendored **populated** + `plugins/` present | selects **vendored-plugins** - fetch is authoritative |
| `CHASSIS_PLUGINS_ROOT` set explicitly | override respected |

`bash -n` clean.

## What this does not change

**Customer-local plugin overlay is still not implemented.** The #53 design has customer-private plugins in `plugins-local/` layering on top of the fetched set with higher precedence. This PR keeps the existing single-root model and only changes which root wins.

Practical effect on Sean's install: `plugins/midnight-oil` and `plugins/restaurant-booking` are customer-local, and inside the container they were **already** invisible - `/app/plugins` (baked) took precedence over `$CHASSIS_HOME/plugins` before this change. So this is not a regression, but it is not the fix either. The overlay wants its own issue.

## Remaining for #82 after this

- Rebuild the image and boot, confirming loom-vision arrives via the fetch path with a correct lockfile
- Bump chassis VERSION to `0.2.0` - now genuinely load-bearing, since #86 makes `0.1.1` skip loom-vision
