### PR TITLE
fix(hydrate): obsidian installs rendered no second-brain server at all (#91)

### DIFF
--- a/chassis/scripts/hydrate-mcp-json.py
+++ b/chassis/scripts/hydrate-mcp-json.py
@@ -386,6 +386,27 @@ def main():
         config = {}
     else:
         config = load_yaml(args.config)
+
+    # Obsidian has no native MCP server, so `mode: direct` (the default, and
+    # what a missing mode key means) renders an install with NO second-brain
+    # surface at all - the gating drops the native server that does not exist
+    # and the adapter server that was never asked for. The config is valid,
+    # the render is correct, and the installer silently has no second brain.
+    #
+    # SiYuan and Notion work on defaults; only Obsidian needs an extra key
+    # nobody is prompted for. Force it rather than emit a technically-correct
+    # config that cannot work (Sean's call, 2026-07-20).
+    sb = config.get('second_brain') if isinstance(config, dict) else None
+    if isinstance(sb, dict) and sb.get('backend') == 'obsidian':
+        mode = sb.get('mode')
+        if mode != 'adapter':
+            was = repr(mode) if mode is not None else 'unset'
+            print(f"WARN: second_brain.backend is 'obsidian' but mode is {was}. "
+                  "Obsidian has no native MCP server, so direct mode would render "
+                  "no second-brain server at all. Forcing mode='adapter'. "
+                  "Set second_brain.mode: adapter in chassis.config.yaml to silence this.",
+                  file=sys.stderr)
+            sb['mode'] = 'adapter'
     template = load_json(args.template)
     env = load_env(args.env)
 


### PR DESCRIPTION
Fixes #91.

## What was actually broken

#91 was reported as *"the hydrator leaves SiYuan placeholders on Obsidian installs"*. Reproducing it found something different, and worse.

I ran the hydrator across every backend/mode combination:

| Config | Rendered MCP servers |
|---|---|
| `obsidian`, mode unset | memory, playwright, context7, github — **no second-brain server at all** |
| `obsidian`, `mode: adapter` | + `secondbrain` |
| `siyuan`, mode unset | + `siyuan` |
| `notion`, mode unset | + `notion` |

There are no stray SiYuan placeholders. **An Obsidian install on default settings renders no second-brain surface whatsoever.**

The gating is working exactly as written: Obsidian has no native MCP server, so the native entry is correctly dropped; `mode` defaults to `direct`, so the adapter entry is also correctly dropped. Two correct decisions producing a useless config.

**SiYuan and Notion work on defaults. Only Obsidian needed an extra key nobody is prompted for**, and the failure is invisible until someone tries to use the second brain and finds no tools.

## The fix

`backend: obsidian` now forces `mode: adapter`, with a stderr warning naming what was set and why:

```
WARN: second_brain.backend is 'obsidian' but mode is unset. Obsidian has no
native MCP server, so direct mode would render no second-brain server at all.
Forcing mode='adapter'. Set second_brain.mode: adapter in chassis.config.yaml
to silence this.
```

Force-with-warning rather than refuse-to-render, per Sean: a working install beats a correct error message. Direct mode is meaningless for a backend with no native server, so there is no legitimate config this overrides.

## Verification

| backend | mode | warns | result |
|---|---|---|---|
| obsidian | unset | ✅ | `secondbrain` present |
| obsidian | `direct` | ✅ | `secondbrain` present |
| obsidian | `adapter` | no | `secondbrain` present |
| siyuan | unset | no | `siyuan` present |
| notion | unset | no | `notion` present |

No behaviour change for SiYuan or Notion, and no warning noise on configs that were already correct.

## Honest limitation

**This may not be the bug Hugues actually hit.** He reported SiYuan placeholders, and his Obsidian install demonstrably *worked* - he verified search, reads, deeplinks and the read-only `create_doc` refusal against a real vault - which means he already had adapter mode. So his symptom was probably separate config residue.

He is no longer a customer as of 2026-07-20, so there is no way to get his `.mcp.json` and confirm. This PR fixes a real, reproducible defect that would have hit every future Obsidian installer. It does not claim to have reproduced his specific report, and #91 should be read that way when it closes.
