### PR TITLE
fix(plugins): fetched plugin tree was never activated - resolve plugin root as a per-plugin overlay

### DIFF
--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -14,6 +14,10 @@ on:
       - 'chassis/scripts/_chassis-update-health.sh'
       - 'chassis/scripts/chassis-update.sh'
       - 'chassis/scripts/test-chassis-update-health.sh'
+      - 'chassis/scripts/_env.sh'
+      - 'chassis/scripts/resolve-plugin-root.sh'
+      - 'chassis/scripts/test-plugin-root-resolution.sh'
+      - 'docker/entrypoint.sh'
       - '.github/workflows/shell-tests.yml'
   push:
     branches: [main]
@@ -21,6 +25,10 @@ on:
       - 'chassis/scripts/_chassis-update-health.sh'
       - 'chassis/scripts/chassis-update.sh'
       - 'chassis/scripts/test-chassis-update-health.sh'
+      - 'chassis/scripts/_env.sh'
+      - 'chassis/scripts/resolve-plugin-root.sh'
+      - 'chassis/scripts/test-plugin-root-resolution.sh'
+      - 'docker/entrypoint.sh'
       - '.github/workflows/shell-tests.yml'
   workflow_dispatch:
 
@@ -31,3 +39,12 @@ jobs:
       - uses: actions/checkout@v4
       # No docker daemon needed - the suite stubs the docker CLI on PATH.
       - run: bash chassis/scripts/test-chassis-update-health.sh
+
+  plugin-root-resolution:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Behavioural coverage for the v0.2.0 inert-feature bug: asserts the
+      # resolved plugin root actually serves fetched plugins when a fetched
+      # tree is present. No docker daemon, runs against temp dirs.
+      - run: bash chassis/scripts/test-plugin-root-resolution.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,11 +72,16 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     CHASSIS_ROOT=/app/chassis \
-    CHASSIS_PLUGINS_ROOT=/app/plugins \
     CUSTOMER_HOME=/app/customer \
     CHASSIS_HOME=/app/customer \
     HOME=/home/chassis \
     PATH=/home/chassis/.local/bin:/home/chassis/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# CHASSIS_PLUGINS_ROOT is deliberately NOT baked as ENV. The entrypoint
+# resolves it at boot via chassis/scripts/resolve-plugin-root.sh, overlaying
+# $CUSTOMER_HOME/vendored-plugins over /app/plugins per plugin name. A baked
+# ENV value is indistinguishable from an operator override and is exactly what
+# made the v0.2.0 fetched-tree preference in _env.sh unreachable.
 
 # System dependencies. Note: NO bw CLI; rbw is the Vaultwarden client (HTTPS
 # enforcement bypass per V1 install lesson). NO cron daemon; entrypoint

--- a/chassis/CHANGELOG.md
+++ b/chassis/CHANGELOG.md
@@ -16,6 +16,19 @@ Semver:
 - `MINOR` (`0.3.0` → `0.4.0`): new features, optional fields, opt-in behaviors. Backwards-compatible.
 - `PATCH` (`0.3.1` → `0.3.2`): fixes, prompt tweaks, internal refactors. Always backwards-compatible.
 
+## Unreleased
+
+### Fixed
+- **v0.2.0's plugin-root preference never ran.** The Changed entry below ("`CHASSIS_PLUGINS_ROOT` now prefers `$CUSTOMER_HOME/vendored-plugins`") described behaviour that was unreachable in every container: the preference lived in `_env.sh` behind an is-unset guard, but the Dockerfile ENV baked `CHASSIS_PLUGINS_ROOT=/app/plugins` and `docker/entrypoint.sh` defaulted and exported the same value before `_env.sh` could ever run. The fetch worked, `vendored-plugins/` and `plugins.lock` were written, and every install silently kept loading the baked tree. Verified empirically on a live 0.2.0 install (dispatcher env showed `/app/plugins` while a usable fetched tree sat ignored). The "verified in a container both ways" claim in the v0.2.0 notes covered the fetch and the loader's selection logic in isolation, not the boot path that preloads the variable.
+
+### Changed
+- **Plugin root is now an overlay, not a tree swap.** `chassis/scripts/resolve-plugin-root.sh` (new) resolves plugins per plugin NAME: a plugin present in the fetched `vendored-plugins/` tree wins, anything only in the baked tree still loads. This replaces the v0.2.0 wholesale preference, which - had it been reachable - would have shrunk every install from 7 plugins to the 1 currently published in `behalfbot-plugins`. The result is materialised as a composed symlink root at `$CUSTOMER_HOME/state/plugins-root` so every existing single-root consumer (entrypoint `install-plugin`, `smoke-test` enumeration, plugin script paths) works unchanged. Per-plugin safety is kept: a fetched dir without an `openclaw.plugin.json` never shadows the baked copy, and an empty or failed fetch degrades to baked per plugin.
+- `CHASSIS_PLUGINS_ROOT` is no longer baked as Dockerfile ENV or defaulted by the entrypoint. A set value now reliably means an operator set it (compose environment, `docker -e`, or the customer `.env`) and is honoured verbatim with no overlay. The chassis default path is "unset", resolved at boot.
+- Boot now logs the resolved plugin root and writes `$CUSTOMER_HOME/plugins-root.state.json` (mode, source roots, per-plugin provenance). If a usable fetched tree exists but is not active, the resolver exits 5 and the entrypoint logs an unmissable ERROR - the v0.2.0 silent no-op class cannot recur quietly.
+
+### Added
+- `chassis/scripts/test-plugin-root-resolution.sh` + CI job `plugin-root-resolution` in `shell-tests.yml`: behavioural tests asserting the resolved root actually serves the fetched copy when a fetched tree is present. The pre-existing tests and CI were green throughout the period the feature did nothing.
+
 ## v0.2.0 — 2026-07-20
 
 Plugins move from image-baked to fetched-at-boot. This is the release that makes `behalfbot-plugins` real: the chassis now pulls its plugin tree from that repo at a pinned tag+SHA instead of carrying whatever was baked into the image.

--- a/chassis/scripts/_env.sh
+++ b/chassis/scripts/_env.sh
@@ -74,33 +74,29 @@ fi
 
 # Plugin root resolution (behalfbot#82).
 #
-# Order of preference:
-#   1. $CUSTOMER_HOME/vendored-plugins - the tree fetched from
-#      scrollinondubs/behalfbot-plugins at the pinned tag+SHA. This is the
-#      authoritative source once a fetch has succeeded.
-#   2. /app/plugins - the image-baked tree. The fallback when no fetch has run
-#      yet, when the fetch failed, or on an air-gapped/frozen install.
-#   3. $CHASSIS_HOME/plugins - host-side installs with no container layout.
+# Delegates to resolve-plugin-root.sh, which overlays the fetched tree
+# ($CUSTOMER_HOME/vendored-plugins) over the baked one PER PLUGIN NAME and
+# materialises the result as a composed symlink root under
+# $CUSTOMER_HOME/state/plugins-root. See that script for the full contract,
+# including the operator-override rule (a pre-set CHASSIS_PLUGINS_ROOT is
+# honoured verbatim - which is why nothing may default this variable before
+# resolution runs; the Dockerfile ENV that used to do so was what made the
+# v0.2.0 fetched-tree preference unreachable).
 #
-# The non-empty test on (1) is the important part and is not decoration. An
-# empty or half-written vendored-plugins directory must NOT shadow the baked
-# tree: that would turn a failed fetch into a chassis that silently loads no
-# plugins and reports nothing wrong. A directory only counts as a usable
-# plugin root if it actually contains at least one plugin manifest.
-_chassis_plugin_root_usable() {
-    local dir="$1"
-    [[ -d "$dir" ]] || return 1
-    compgen -G "$dir"/*/openclaw.plugin.json > /dev/null 2>&1
-}
-
+# The old single-root preference chain is kept only as a fallback for the
+# window where a stale chassis tree lacks the resolver script.
 if [[ -z "${CHASSIS_PLUGINS_ROOT:-}" ]]; then
-    _vendored="${CUSTOMER_HOME:-${CHASSIS_HOME:-}}/vendored-plugins"
-    if _chassis_plugin_root_usable "$_vendored"; then
-        export CHASSIS_PLUGINS_ROOT="$_vendored"
+    _cpr_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+    _cpr=""
+    if [[ -n "$_cpr_dir" && -x "$_cpr_dir/resolve-plugin-root.sh" ]]; then
+        _cpr="$(bash "$_cpr_dir/resolve-plugin-root.sh" 2>/dev/null)" || true
+    fi
+    if [[ -n "$_cpr" ]]; then
+        export CHASSIS_PLUGINS_ROOT="$_cpr"
     elif [[ -d "/app/plugins" ]]; then
         export CHASSIS_PLUGINS_ROOT="/app/plugins"
     elif [[ -n "${CHASSIS_HOME:-}" && -d "$CHASSIS_HOME/plugins" ]]; then
         export CHASSIS_PLUGINS_ROOT="$CHASSIS_HOME/plugins"
     fi
-    unset _vendored
+    unset _cpr _cpr_dir
 fi

--- a/chassis/scripts/resolve-plugin-root.sh
+++ b/chassis/scripts/resolve-plugin-root.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# resolve-plugin-root.sh - resolve the effective plugin root as an OVERLAY of
+# the image-baked tree and the fetched (vendored) tree.
+#
+# Fixes the v0.2.0 defect where the fetched-tree preference in _env.sh was
+# unreachable: the Dockerfile ENV and the entrypoint both pre-set
+# CHASSIS_PLUGINS_ROOT before _env.sh's [[ -z ]] guard ever ran, so every
+# install silently stayed on the baked tree while vendored-plugins/ sat
+# ignored on disk.
+#
+# Why an overlay and not a straight preference: the two trees are not
+# interchangeable. The baked tree carries plugins that were never published
+# to behalfbot-plugins (7 today), while the fetched tree currently publishes
+# 1. Selecting one tree wholesale would either ignore fetches (the v0.2.0
+# bug) or drop six working plugins (the naive fix). Resolution is therefore
+# per plugin NAME: a usable fetched copy wins, anything only baked still
+# loads, and a failed or partial fetch degrades per plugin instead of wiping
+# the set.
+#
+# Mechanism: every consumer of CHASSIS_PLUGINS_ROOT treats it as a single
+# directory (entrypoint install-plugin, smoke-test's `for dir in $ROOT/*`,
+# plugin script paths), so the overlay is materialised as a composed
+# directory of symlinks at $CUSTOMER_HOME/state/plugins-root, rebuilt from
+# scratch and swapped into place whole. Consumers keep their single-root
+# contract unchanged. A resolver-plus-search-path list was the alternative
+# and was rejected because it would push merge logic into every consumer,
+# including plain globs. Composing also filters the non-plugin dirs the
+# fetched tree carries at its top level (docs/, tools/, registry.json).
+#
+# Operator override contract: if CHASSIS_PLUGINS_ROOT is already set when
+# this script runs, that value is honoured VERBATIM - no overlay, no
+# reordering. The Dockerfile and entrypoint no longer default the variable,
+# precisely so that "set" reliably means "an operator set it" (compose
+# environment, docker -e, or the customer .env). The chassis default path is
+# "unset", which lands here.
+#
+# Safety property (kept from v0.2.0): a directory only counts as a usable
+# plugin source if it contains at least one */openclaw.plugin.json, and a
+# fetched plugin dir without a manifest never shadows the baked copy. An
+# empty or half-written fetch degrades to baked, per plugin.
+#
+# Output: the resolved root on stdout. All logging goes to stderr. Writes
+# $CUSTOMER_HOME/plugins-root.state.json (adjacent to plugins.lock)
+# recording mode, roots, and per-plugin provenance.
+#
+# Env seams:
+#   CHASSIS_BAKED_PLUGINS_ROOT - override the baked-tree location (tests,
+#       host installs with a non-standard layout). Defaults to /app/plugins,
+#       then $CHASSIS_HOME/plugins.
+#   CHASSIS_PLUGINS_FETCH_ROOT - override the fetched-tree location.
+#       Defaults to $CUSTOMER_HOME/vendored-plugins (matches fetch-plugins.sh).
+#
+# Exit codes:
+#   0 - resolved (any mode)
+#   5 - ASSERTION FAILED: a usable fetched tree exists but its plugins are
+#       not active in the resolved root. The best-available root is still
+#       printed and the state file records the error. Callers must surface
+#       this loudly; it exists so the v0.2.0 silent no-op cannot recur.
+
+set -uo pipefail
+
+: "${CUSTOMER_HOME:=${CHASSIS_HOME:-/app/customer}}"
+
+log() { printf '[resolve-plugin-root] %s\n' "$*" >&2; }
+
+usable() {
+    local dir="$1"
+    [[ -d "$dir" ]] || return 1
+    compgen -G "$dir"/*/openclaw.plugin.json > /dev/null 2>&1
+}
+
+STATE_FILE="$CUSTOMER_HOME/plugins-root.state.json"
+
+# MODE is one of: explicit | baked | overlay
+# PROVENANCE lines are "name<TAB>baked|fetched" pairs for the state file.
+write_state() {
+    local mode="$1" root="$2" error="${3:-}"
+    MODE="$mode" ROOT="$root" ERROR="$error" \
+    BAKED="${BAKED_ROOT:-}" FETCHED="${FETCHED_ROOT:-}" \
+    PROVENANCE="${PROVENANCE:-}" \
+    python3 - "$STATE_FILE" <<'PY' 2>/dev/null || log "WARN: could not write $STATE_FILE"
+import datetime, json, os, sys
+prov = {}
+for line in os.environ.get("PROVENANCE", "").splitlines():
+    if "\t" in line:
+        name, src = line.split("\t", 1)
+        prov[name] = src
+state = {
+    "schema": 1,
+    "mode": os.environ["MODE"],
+    "resolved_root": os.environ["ROOT"],
+    "baked_root": os.environ["BAKED"] or None,
+    "fetched_root": os.environ["FETCHED"] or None,
+    "resolved_at": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "plugins": prov,
+    "error": os.environ["ERROR"] or None,
+}
+with open(sys.argv[1], "w") as f:
+    json.dump(state, f, indent=2)
+    f.write("\n")
+PY
+}
+
+# --- operator override: set means set, honour verbatim ----------------------
+if [[ -n "${CHASSIS_PLUGINS_ROOT:-}" ]]; then
+    BAKED_ROOT="" FETCHED_ROOT="${CHASSIS_PLUGINS_FETCH_ROOT:-$CUSTOMER_HOME/vendored-plugins}"
+    if usable "$FETCHED_ROOT" && [[ "$CHASSIS_PLUGINS_ROOT" != "$FETCHED_ROOT" ]]; then
+        log "operator override: CHASSIS_PLUGINS_ROOT=$CHASSIS_PLUGINS_ROOT (explicitly set)"
+        log "note: a usable fetched tree exists at $FETCHED_ROOT and is being ignored BY EXPLICIT CHOICE"
+    fi
+    write_state explicit "$CHASSIS_PLUGINS_ROOT"
+    printf '%s\n' "$CHASSIS_PLUGINS_ROOT"
+    exit 0
+fi
+
+# --- locate the two source trees --------------------------------------------
+BAKED_ROOT=""
+if [[ -n "${CHASSIS_BAKED_PLUGINS_ROOT:-}" && -d "${CHASSIS_BAKED_PLUGINS_ROOT}" ]]; then
+    BAKED_ROOT="$CHASSIS_BAKED_PLUGINS_ROOT"
+elif [[ -d /app/plugins ]]; then
+    BAKED_ROOT="/app/plugins"
+elif [[ -n "${CHASSIS_HOME:-}" && -d "$CHASSIS_HOME/plugins" ]]; then
+    BAKED_ROOT="$CHASSIS_HOME/plugins"
+fi
+
+FETCHED_ROOT="${CHASSIS_PLUGINS_FETCH_ROOT:-$CUSTOMER_HOME/vendored-plugins}"
+
+# --- no usable fetched tree: baked only, exactly the pre-#82 behaviour ------
+if ! usable "$FETCHED_ROOT"; then
+    PROVENANCE=""
+    if [[ -n "$BAKED_ROOT" ]]; then
+        for d in "$BAKED_ROOT"/*/; do
+            [[ -d "$d" ]] || continue
+            PROVENANCE+="$(basename "$d")"$'\t'"baked"$'\n'
+        done
+    fi
+    write_state baked "$BAKED_ROOT"
+    printf '%s\n' "$BAKED_ROOT"
+    exit 0
+fi
+
+# --- compose the overlay -----------------------------------------------------
+COMPOSED_ROOT="$CUSTOMER_HOME/state/plugins-root"
+compose_failed=""
+
+staging=""
+if mkdir -p "$CUSTOMER_HOME/state" 2>/dev/null; then
+    staging=$(mktemp -d "$CUSTOMER_HOME/state/.plugins-root.XXXXXX" 2>/dev/null) || staging=""
+fi
+
+PROVENANCE=""
+if [[ -n "$staging" ]]; then
+    if [[ -n "$BAKED_ROOT" ]]; then
+        for d in "$BAKED_ROOT"/*/; do
+            [[ -d "$d" ]] || continue
+            ln -s "${d%/}" "$staging/$(basename "$d")"
+            PROVENANCE+="$(basename "$d")"$'\t'"baked"$'\n'
+        done
+    fi
+    for d in "$FETCHED_ROOT"/*/; do
+        [[ -d "$d" ]] || continue
+        name=$(basename "$d")
+        if [[ ! -f "$d/openclaw.plugin.json" ]]; then
+            # docs/, tools/, or a half-written plugin: never shadows baked.
+            if [[ -e "$staging/$name" ]]; then
+                log "fetched $name has no manifest - keeping the baked copy"
+            fi
+            continue
+        fi
+        rm -f "$staging/$name"
+        ln -s "${d%/}" "$staging/$name"
+        PROVENANCE=$(printf '%s' "$PROVENANCE" | grep -v "^$name"$'\t' || true)
+        PROVENANCE+=$'\n'"$name"$'\t'"fetched"$'\n'
+    done
+    # Swap whole so consumers never see a half-built root.
+    old=""
+    if [[ -e "$COMPOSED_ROOT" ]]; then
+        old="$CUSTOMER_HOME/state/.plugins-root.old.$$"
+        mv "$COMPOSED_ROOT" "$old" 2>/dev/null || { rm -rf "$staging"; compose_failed=yes; }
+    fi
+    if [[ -z "$compose_failed" ]]; then
+        if mv "$staging" "$COMPOSED_ROOT" 2>/dev/null; then
+            [[ -n "$old" ]] && rm -rf "$old"
+        else
+            [[ -n "$old" ]] && mv "$old" "$COMPOSED_ROOT" 2>/dev/null
+            rm -rf "$staging"
+            compose_failed=yes
+        fi
+    fi
+else
+    compose_failed=yes
+fi
+
+if [[ -n "$compose_failed" ]]; then
+    # Fetched tree is usable but we cannot activate it. Fall back to baked
+    # (the larger set) and fail LOUDLY - this is the exact silent-no-op class
+    # v0.2.0 shipped, so it must never pass quietly.
+    log "ERROR: fetched plugin tree at $FETCHED_ROOT is usable but could NOT be activated (compose failed under $CUSTOMER_HOME/state)"
+    write_state baked "$BAKED_ROOT" "compose failed - fetched tree present but not active"
+    printf '%s\n' "$BAKED_ROOT"
+    exit 5
+fi
+
+# --- boot-time assertion: every usable fetched plugin must be active --------
+# This check exists because v0.2.0's fetched-tree preference shipped fully
+# inert while every artifact looked correct and CI stayed green. If it fires,
+# the resolver itself has regressed.
+assert_error=""
+for d in "$FETCHED_ROOT"/*/; do
+    [[ -f "$d/openclaw.plugin.json" ]] || continue
+    name=$(basename "$d")
+    target=$(readlink "$COMPOSED_ROOT/$name" 2>/dev/null || true)
+    if [[ "$target" != "${d%/}" ]]; then
+        assert_error="fetched plugin '$name' is not active in $COMPOSED_ROOT (resolves to '${target:-missing}')"
+        log "ERROR: PLUGIN ROOT ASSERTION FAILED - $assert_error"
+        break
+    fi
+done
+
+write_state overlay "$COMPOSED_ROOT" "$assert_error"
+printf '%s\n' "$COMPOSED_ROOT"
+[[ -z "$assert_error" ]] || exit 5
+exit 0

--- a/chassis/scripts/smoke-test.sh
+++ b/chassis/scripts/smoke-test.sh
@@ -29,6 +29,12 @@ set -uo pipefail
 
 : "${CHASSIS_HOME:?CHASSIS_HOME must be set}"
 : "${CHASSIS_ROOT:=/app/chassis}"
+# Entrypoint-launched runs inherit the resolved overlay root. Standalone runs
+# (docker exec, host shell) resolve it the same way instead of assuming the
+# baked tree, so both paths test the plugin set that is actually live.
+if [[ -z "${CHASSIS_PLUGINS_ROOT:-}" && -x "$CHASSIS_ROOT/scripts/resolve-plugin-root.sh" ]]; then
+    CHASSIS_PLUGINS_ROOT="$(bash "$CHASSIS_ROOT/scripts/resolve-plugin-root.sh" 2>/dev/null)" || true
+fi
 : "${CHASSIS_PLUGINS_ROOT:=/app/plugins}"
 
 JSON_OUTPUT="false"

--- a/chassis/scripts/test-plugin-root-resolution.sh
+++ b/chassis/scripts/test-plugin-root-resolution.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+# test-plugin-root-resolution.sh - Unit tests for resolve-plugin-root.sh and
+# the _env.sh plugin-root wiring.
+#
+# The bug these lock down
+# =======================
+# Chassis v0.2.0 shipped "plugins move from image-baked to fetched-at-boot".
+# The fetch worked; the switch never happened. _env.sh's fetched-tree
+# preference sat behind `[[ -z "${CHASSIS_PLUGINS_ROOT:-}" ]]`, and both the
+# Dockerfile ENV and docker/entrypoint.sh pre-set that variable to
+# /app/plugins before _env.sh could ever run. Every install stayed on the
+# baked tree while vendored-plugins/ sat ignored on disk. All existing tests
+# and CI passed while the feature did nothing.
+#
+# The core assertion here is therefore behavioural: given a usable fetched
+# tree, the RESOLVED root must actually serve the fetched copy of each
+# fetched plugin, while plugins that exist only in the baked tree keep
+# loading (overlay, not wholesale replacement).
+#
+# No docker daemon, no network. Everything runs against temp directories.
+#
+# Exit codes:
+#   0 - all scenarios passed
+#   1 - one or more scenarios failed
+#   2 - test harness itself broke
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVER="${SCRIPT_DIR}/resolve-plugin-root.sh"
+ENV_SH="${SCRIPT_DIR}/_env.sh"
+
+for f in "$RESOLVER" "$ENV_SH"; do
+    if [[ ! -f "$f" ]]; then
+        echo "test-plugin-root-resolution: missing $f" >&2
+        exit 2
+    fi
+done
+
+fail=0
+pass=0
+
+check() {
+    local name="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        pass=$((pass + 1))
+    else
+        echo "FAIL [$name] expected '$expected', got '$actual'"
+        fail=$((fail + 1))
+    fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+manifest() {
+    # manifest <dir> <name> <version>
+    mkdir -p "$1"
+    printf '{"id": "%s", "version": "%s"}\n' "$2" "$3" > "$1/openclaw.plugin.json"
+}
+
+state_field() {
+    # state_field <customer_home> <jq-ish path expr for python>
+    python3 - "$1/plugins-root.state.json" "$2" <<'PY' 2>/dev/null
+import json, sys
+data = json.load(open(sys.argv[1]))
+cur = data
+for key in sys.argv[2].split("."):
+    cur = cur.get(key) if isinstance(cur, dict) else None
+print("" if cur is None else cur)
+PY
+}
+
+fresh_env() {
+    # fresh_env <label> -> sets CUSTOMER, BAKED globals and builds the
+    # standard 7-plugin baked tree.
+    CUSTOMER="$TMP/$1/customer"
+    BAKED="$TMP/$1/baked"
+    mkdir -p "$CUSTOMER" "$BAKED"
+    local p
+    for p in angel-protocol bfl dating loom-vision remarkable restaurant-booking whatsapp; do
+        manifest "$BAKED/$p" "$p" "0.1.0"
+    done
+}
+
+run_resolver() {
+    # -> RESOLVED_ROOT, RESOLVER_RC
+    RESOLVED_ROOT="$(env -u CHASSIS_PLUGINS_ROOT \
+        CUSTOMER_HOME="$CUSTOMER" CHASSIS_HOME="$CUSTOMER" \
+        CHASSIS_BAKED_PLUGINS_ROOT="$BAKED" \
+        bash "$RESOLVER" 2>>"$TMP/resolver.log")"
+    RESOLVER_RC=$?
+}
+
+# --- scenario 1: no fetched tree -> baked root, all plugins present ---------
+fresh_env s1
+run_resolver
+check "s1 exit" "0" "$RESOLVER_RC"
+check "s1 root is baked" "$BAKED" "$RESOLVED_ROOT"
+check "s1 plugin count" "7" "$(ls -d "$RESOLVED_ROOT"/*/ | wc -l | tr -d ' ')"
+check "s1 state mode" "baked" "$(state_field "$CUSTOMER" mode)"
+
+# --- scenario 2: fetched tree present -> overlay, fetched copy wins ---------
+# THE regression test for the v0.2.0 no-op. The fetched tree mirrors the real
+# behalfbot-plugins layout: one plugin plus non-plugin top-level dirs.
+fresh_env s2
+FETCHED="$CUSTOMER/vendored-plugins"
+manifest "$FETCHED/loom-vision" "loom-vision" "0.2.0"
+mkdir -p "$FETCHED/docs" "$FETCHED/tools"
+echo '{}' > "$FETCHED/registry.json"
+run_resolver
+check "s2 exit" "0" "$RESOLVER_RC"
+check "s2 root is composed" "$CUSTOMER/state/plugins-root" "$RESOLVED_ROOT"
+check "s2 plugin count" "7" "$(ls -d "$RESOLVED_ROOT"/*/ | wc -l | tr -d ' ')"
+check "s2 fetched plugin is ACTIVE" "0.2.0" \
+    "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$RESOLVED_ROOT/loom-vision/openclaw.plugin.json")"
+check "s2 baked-only plugin still loads" "0.1.0" \
+    "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$RESOLVED_ROOT/bfl/openclaw.plugin.json")"
+check "s2 non-plugin dirs filtered" "no" "$([[ -e "$RESOLVED_ROOT/docs" || -e "$RESOLVED_ROOT/tools" ]] && echo yes || echo no)"
+check "s2 state mode" "overlay" "$(state_field "$CUSTOMER" mode)"
+check "s2 provenance loom-vision" "fetched" "$(state_field "$CUSTOMER" plugins.loom-vision)"
+check "s2 provenance bfl" "baked" "$(state_field "$CUSTOMER" plugins.bfl)"
+check "s2 no error recorded" "" "$(state_field "$CUSTOMER" error)"
+
+# --- scenario 3: empty fetched dir must not shadow the baked tree -----------
+fresh_env s3
+mkdir -p "$CUSTOMER/vendored-plugins"
+run_resolver
+check "s3 exit" "0" "$RESOLVER_RC"
+check "s3 root is baked" "$BAKED" "$RESOLVED_ROOT"
+
+# --- scenario 4: fetched plugin without a manifest keeps the baked copy -----
+fresh_env s4
+FETCHED="$CUSTOMER/vendored-plugins"
+manifest "$FETCHED/loom-vision" "loom-vision" "0.2.0"
+mkdir -p "$FETCHED/bfl"   # half-written: dir exists, no manifest
+run_resolver
+check "s4 exit" "0" "$RESOLVER_RC"
+check "s4 half-written plugin stays baked" "0.1.0" \
+    "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$RESOLVED_ROOT/bfl/openclaw.plugin.json")"
+check "s4 usable fetched plugin still wins" "0.2.0" \
+    "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$RESOLVED_ROOT/loom-vision/openclaw.plugin.json")"
+
+# --- scenario 5: fetched-only plugin appears in the resolved set ------------
+fresh_env s5
+FETCHED="$CUSTOMER/vendored-plugins"
+manifest "$FETCHED/brand-new" "brand-new" "1.0.0"
+run_resolver
+check "s5 exit" "0" "$RESOLVER_RC"
+check "s5 plugin count" "8" "$(ls -d "$RESOLVED_ROOT"/*/ | wc -l | tr -d ' ')"
+check "s5 new plugin present" "1.0.0" \
+    "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$RESOLVED_ROOT/brand-new/openclaw.plugin.json")"
+
+# --- scenario 6: operator override wins verbatim ----------------------------
+fresh_env s6
+FETCHED="$CUSTOMER/vendored-plugins"
+manifest "$FETCHED/loom-vision" "loom-vision" "0.2.0"
+RESOLVED_ROOT="$(CHASSIS_PLUGINS_ROOT="/operator/choice" \
+    CUSTOMER_HOME="$CUSTOMER" CHASSIS_HOME="$CUSTOMER" \
+    CHASSIS_BAKED_PLUGINS_ROOT="$BAKED" \
+    bash "$RESOLVER" 2>>"$TMP/resolver.log")"
+RESOLVER_RC=$?
+check "s6 exit" "0" "$RESOLVER_RC"
+check "s6 override honoured" "/operator/choice" "$RESOLVED_ROOT"
+check "s6 state mode" "explicit" "$(state_field "$CUSTOMER" mode)"
+
+# --- scenario 7: rerun is idempotent and drops stale entries ----------------
+fresh_env s7
+FETCHED="$CUSTOMER/vendored-plugins"
+manifest "$FETCHED/loom-vision" "loom-vision" "0.2.0"
+run_resolver
+first="$RESOLVED_ROOT"
+rm -rf "$FETCHED/loom-vision"
+manifest "$FETCHED/other" "other" "0.3.0"
+run_resolver
+check "s7 stable path" "$first" "$RESOLVED_ROOT"
+check "s7 stale fetched link replaced by baked" "0.1.0" \
+    "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$RESOLVED_ROOT/loom-vision/openclaw.plugin.json")"
+check "s7 new fetched plugin picked up" "0.3.0" \
+    "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$RESOLVED_ROOT/other/openclaw.plugin.json")"
+
+# --- scenario 8: compose failure fails LOUDLY (exit 5), never silently ------
+if [[ "$(id -u)" != "0" ]]; then
+    fresh_env s8
+    FETCHED="$CUSTOMER/vendored-plugins"
+    manifest "$FETCHED/loom-vision" "loom-vision" "0.2.0"
+    mkdir -p "$CUSTOMER/state" && chmod 500 "$CUSTOMER/state"
+    run_resolver
+    chmod 755 "$CUSTOMER/state"
+    check "s8 loud failure exit" "5" "$RESOLVER_RC"
+    check "s8 falls back to baked" "$BAKED" "$RESOLVED_ROOT"
+else
+    echo "SKIP [s8] running as root - permission-based failure not simulable"
+fi
+
+# --- scenario 9: _env.sh end to end exports the overlay root ----------------
+# This is the integration the v0.2.0 release believed it had.
+fresh_env s9
+FETCHED="$CUSTOMER/vendored-plugins"
+manifest "$FETCHED/loom-vision" "loom-vision" "0.2.0"
+RESOLVED_ROOT="$(env -u CHASSIS_PLUGINS_ROOT -u CHASSIS_ROOT \
+    CUSTOMER_HOME="$CUSTOMER" CHASSIS_HOME="$CUSTOMER" \
+    CHASSIS_BAKED_PLUGINS_ROOT="$BAKED" \
+    bash -c "source '$ENV_SH' && printf '%s' \"\$CHASSIS_PLUGINS_ROOT\"" 2>>"$TMP/resolver.log")"
+check "s9 _env.sh resolves overlay" "$CUSTOMER/state/plugins-root" "$RESOLVED_ROOT"
+check "s9 fetched active via _env.sh" "0.2.0" \
+    "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$RESOLVED_ROOT/loom-vision/openclaw.plugin.json")"
+
+# ---------------------------------------------------------------------------
+echo
+echo "test-plugin-root-resolution: $pass passed, $fail failed"
+[[ "$fail" -eq 0 ]] || exit 1
+exit 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,10 +56,12 @@ services:
       # mount; CHASSIS_HOME is kept as an alias to the SAME path so legacy
       # chassis scripts (which read $CHASSIS_HOME/.env, $CHASSIS_HOME/briefings,
       # etc.) continue to work without modification. New / updated code should
-      # prefer CUSTOMER_HOME for customer-side paths and CHASSIS_ROOT /
-      # CHASSIS_PLUGINS_ROOT (defined in the Dockerfile ENV) for chassis-side
-      # code paths. The Dockerfile bakes /app/chassis + /app/plugins as
-      # read-only image layers; only /app/customer is bind-mounted.
+      # prefer CUSTOMER_HOME for customer-side paths and CHASSIS_ROOT for
+      # chassis-side code paths. The Dockerfile bakes /app/chassis +
+      # /app/plugins as read-only image layers; only /app/customer is
+      # bind-mounted. CHASSIS_PLUGINS_ROOT is resolved by the entrypoint at
+      # boot (overlay of vendored-plugins over the baked tree) - setting it
+      # here counts as an operator override and disables that overlay.
       CUSTOMER_HOME: /app/customer
       CHASSIS_HOME: /app/customer
       DISPATCHER_INTERVAL_SECONDS: ${DISPATCHER_INTERVAL_SECONDS:-900}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -20,14 +20,18 @@
 set -euo pipefail
 
 : "${CHASSIS_ROOT:=/app/chassis}"
-: "${CHASSIS_PLUGINS_ROOT:=/app/plugins}"
+# CHASSIS_PLUGINS_ROOT is deliberately NOT defaulted here (or in the
+# Dockerfile ENV). resolve_plugin_root() sets it after source_env, so a value
+# that is already present reliably means an operator set it (compose
+# environment, docker -e, or the customer .env). Defaulting it up here is
+# exactly what made the v0.2.0 fetched-tree preference in _env.sh unreachable.
 # Issue #6 customer-state split. CUSTOMER_HOME is the canonical name for the
 # customer-state mount inside the container; CHASSIS_HOME is kept as an alias
 # pointing at the SAME path so legacy chassis scripts (which read
 # $CHASSIS_HOME/.env, $CHASSIS_HOME/briefings, etc.) keep working untouched.
 : "${CUSTOMER_HOME:=/app/customer}"
 : "${CHASSIS_HOME:=$CUSTOMER_HOME}"
-export CUSTOMER_HOME CHASSIS_HOME CHASSIS_ROOT CHASSIS_PLUGINS_ROOT
+export CUSTOMER_HOME CHASSIS_HOME CHASSIS_ROOT
 : "${DISPATCHER_INTERVAL_SECONDS:=900}"
 : "${DISPATCHER_SCRIPT:=$CHASSIS_ROOT/scheduled-tasks/heartbeat-dispatcher.sh}"
 
@@ -66,6 +70,34 @@ source_env() {
     # billing, not PAYG. Matches the rationale in
     # chassis/scheduled-tasks/heartbeat-dispatcher.sh lines 67-80.
     unset ANTHROPIC_API_KEY || true
+}
+
+resolve_plugin_root() {
+    # Overlay resolution (behalfbot#82 fix): a plugin present in the fetched
+    # vendored-plugins tree wins by name; anything only in the baked tree
+    # still loads. Runs AFTER source_env so a CHASSIS_PLUGINS_ROOT from the
+    # customer .env or the compose environment counts as an operator override
+    # (the resolver honours it verbatim). Runs AFTER run_plugin_fetch in the
+    # boot modes so a fresh fetch is active on the same boot.
+    local resolver="$CHASSIS_ROOT/scripts/resolve-plugin-root.sh"
+    if [[ ! -x "$resolver" ]]; then
+        export CHASSIS_PLUGINS_ROOT="${CHASSIS_PLUGINS_ROOT:-/app/plugins}"
+        log "WARN: plugin-root resolver missing at $resolver - using $CHASSIS_PLUGINS_ROOT"
+        return 0
+    fi
+    local resolved rc=0
+    resolved="$(bash "$resolver")" || rc=$?
+    if [[ -n "$resolved" ]]; then
+        export CHASSIS_PLUGINS_ROOT="$resolved"
+    else
+        export CHASSIS_PLUGINS_ROOT="${CHASSIS_PLUGINS_ROOT:-/app/plugins}"
+    fi
+    if [[ "$rc" -ne 0 ]]; then
+        log "ERROR: PLUGIN ROOT ASSERTION FAILED (rc=$rc) - a usable fetched plugin tree exists but is NOT active."
+        log "ERROR: running on $CHASSIS_PLUGINS_ROOT - see $CUSTOMER_HOME/plugins-root.state.json for the resolution record."
+    else
+        log "plugin root: $CHASSIS_PLUGINS_ROOT"
+    fi
 }
 
 run_dispatcher_once() {
@@ -125,6 +157,7 @@ cmd_dispatcher() {
     ensure_customer_layout
     source_env
     run_plugin_fetch
+    resolve_plugin_root
     run_chassis_migrations
     log "dispatcher loop starting - tick=${DISPATCHER_INTERVAL_SECONDS}s, CHASSIS_HOME=$CHASSIS_HOME"
     # Touch sentinel up-front so healthcheck doesn't fail before first tick.
@@ -143,6 +176,7 @@ cmd_bootstrap() {
     ensure_customer_layout
     source_env
     run_plugin_fetch
+    resolve_plugin_root
     run_chassis_migrations
     log "running bootstrap.sh against CHASSIS_HOME=$CHASSIS_HOME"
     CHASSIS_HOME="$CHASSIS_HOME" bash /app/bootstrap.sh "$@"
@@ -152,6 +186,7 @@ cmd_install_plugin() {
     local name="${1:?install-plugin requires a plugin name}"
     ensure_customer_layout
     source_env
+    resolve_plugin_root
     local installer="$CHASSIS_PLUGINS_ROOT/$name/install.sh"
     if [[ ! -x "$installer" ]]; then
         log "FATAL: plugin installer not found at $installer"
@@ -182,6 +217,7 @@ cmd_hydrate_env() {
 cmd_smoke_test() {
     ensure_customer_layout
     source_env
+    resolve_plugin_root
     log "running chassis smoke tests"
     CHASSIS_HOME="$CHASSIS_HOME" bash "$CHASSIS_ROOT/scripts/smoke-test.sh" "$@"
 }
@@ -189,12 +225,14 @@ cmd_smoke_test() {
 cmd_claude() {
     ensure_customer_layout
     source_env
+    resolve_plugin_root
     exec claude "$@"
 }
 
 cmd_shell() {
     ensure_customer_layout
     source_env
+    resolve_plugin_root
     exec /usr/bin/zsh
 }
 


### PR DESCRIPTION
## Summary

Chassis v0.2.0 shipped "plugins move from image-baked to fetched-at-boot". The fetch worked; the switch to the fetched tree never happened. The preference lived in `_env.sh` behind `[[ -z "${CHASSIS_PLUGINS_ROOT:-}" ]]`, and both the Dockerfile ENV (`CHASSIS_PLUGINS_ROOT=/app/plugins`) and `docker/entrypoint.sh` (`: "${CHASSIS_PLUGINS_ROOT:=/app/plugins}"` + export) satisfied that guard before `_env.sh` could ever run. Confirmed empirically on a live 0.2.0 install: dispatcher env showed `/app/plugins` while a usable `/app/customer/vendored-plugins/loom-vision/openclaw.plugin.json` sat ignored.

Making the old preference reachable would also have been wrong: it selects one tree wholesale, the baked tree carries 7 plugins, and the fetched tree publishes 1 - so the naive fix takes every install from 7 plugins to 1. Six of the baked plugins were never published to `behalfbot-plugins`.

## Mechanism chosen: composed symlink root (overlay per plugin name)

Every consumer of `CHASSIS_PLUGINS_ROOT` was checked before picking a mechanism:

- `docker/entrypoint.sh` `cmd_install_plugin` - `$CHASSIS_PLUGINS_ROOT/<name>/install.sh` and `validate.sh`
- `chassis/scripts/smoke-test.sh` - plain enumeration: `for plugin_dir in "$CHASSIS_PLUGINS_ROOT"/*`
- `bootstrap.sh` - documents `$CHASSIS_PLUGINS_ROOT/whatsapp/scripts/wacli-safe.sh`
- `chassis/launchd/*.plist.template` - sets it host-side (legacy)

All of them treat the var as ONE directory, including a bare glob, so a single-root env var genuinely cannot express an overlay. Of the two honest options, I picked **(a) a composed root directory built at boot from symlinks** over (b) a resolver function plus search-path list, because (b) pushes merge logic into every consumer including the glob enumeration, while (a) leaves every consumer untouched and keeps the single-root contract true.

`chassis/scripts/resolve-plugin-root.sh` (new) builds `$CUSTOMER_HOME/state/plugins-root`: one symlink per plugin name, baked entries first, fetched entries (only dirs that contain `openclaw.plugin.json`) overriding by name, staged in a temp dir and swapped whole so consumers never see a half-built root. Side benefit: it filters the non-plugin dirs the fetched tree carries at top level (`docs/`, `tools/`, `registry.json`), which the old "point at vendored-plugins" approach would have exposed to the smoke-test glob as fake plugins.

### Operator override contract

The Dockerfile no longer bakes `CHASSIS_PLUGINS_ROOT` as ENV and the entrypoint no longer defaults it. That is what makes "explicitly set by an operator" recoverable: a value already present when the resolver runs (compose `environment:`, `docker -e`, or the customer `.env`, which is sourced before resolution) now reliably means an operator set it, and it is honoured verbatim with no overlay, logged as an explicit choice. Empty string counts as unset. The contract is stated in comments in the resolver, the entrypoint, and the Dockerfile.

### Safety properties kept

- A directory only counts as a usable fetched source if it contains at least one `*/openclaw.plugin.json` (the `_chassis_plugin_root_usable` property, moved into the resolver).
- New, finer-grained: a fetched plugin DIR without a manifest never shadows the baked copy - a partial fetch degrades per plugin, not per tree.

### Boot-time assertion - no silent no-op possible again

The resolver writes `$CUSTOMER_HOME/plugins-root.state.json` (adjacent to `plugins.lock`): mode (`explicit|baked|overlay`), source roots, per-plugin provenance, error. If a usable fetched tree exists but its plugins are not active in the resolved root, the resolver exits 5 and the entrypoint logs `ERROR: PLUGIN ROOT ASSERTION FAILED ... fetched plugin tree exists but is NOT active`, and the state file records the error. The dispatcher still boots (a plugin problem must never take the bot down), but the failure is unmissable and machine-readable.

## Tests that would have caught this

`chassis/scripts/test-plugin-root-resolution.sh` (new, wired into `shell-tests.yml` as job `plugin-root-resolution`): 32 behavioural assertions across 9 scenarios - no fetched tree, overlay with the real behalfbot-plugins layout, empty fetched dir, manifest-less fetched dir, fetched-only plugin, operator override, idempotent rerun with stale-entry cleanup, loud exit-5 on compose failure, and `_env.sh` end to end. The core one asserts the RESOLVED root serves the fetched copy (version 0.2.0, not baked 0.1.0) while baked-only plugins keep loading.

**Note: the entire pre-existing test suite and CI were green for the whole period this feature did nothing.** Nothing asserted behaviour of the resolved root; the artifacts (lockfile, vendored tree) all looked correct.

## Verification - actual container output

BEFORE, stock `ghcr.io/scrollinondubs/behalfbot:latest` (v0.2.0), scratch customer dir with a copy of the live fetched tree:

```
CHASSIS_PLUGINS_ROOT=/app/plugins
loom-vision version loaded: 0.1.0
fetched tree exists+usable: /app/customer/vendored-plugins/loom-vision/openclaw.plugin.json
```

AFTER, same image, this branch's `entrypoint.sh` + `_env.sh` + `resolve-plugin-root.sh` bind-mounted, env var cleared to simulate the rebuilt image:

```
CHASSIS_PLUGINS_ROOT=/app/customer/state/plugins-root
plugins seen: angel-protocol bfl dating loom-vision remarkable restaurant-booking whatsapp
loom-vision version loaded: 0.2.0
bfl (baked-only) version loaded: 0.1.0
loom-vision symlink -> /app/customer/vendored-plugins/loom-vision
state: mode=overlay, plugins={6x baked, loom-vision: fetched}, error=null
```

Real entrypoint boot path (install-plugin mode), same mounts:

```
[entrypoint 06:00:39] plugin root: /app/customer/state/plugins-root
```

Also exercised: running the new entrypoint against the STOCK image without clearing the env - the baked ENV is correctly detected as an explicit override and logged loudly (`a usable fetched tree exists ... ignored BY EXPLICIT CHOICE`) instead of silently. That state only exists in mixed old-image/new-scripts setups; the entrypoint ships inside the image, so normal deploys cannot hit it.

Unit suite: `bash chassis/scripts/test-plugin-root-resolution.sh` -> `32 passed, 0 failed` (run on macOS bash 3.2; CI runs it on ubuntu).

## CHANGELOG

Added an `## Unreleased` correction entry stating that v0.2.0's Changed entry described unreachable behaviour, and what actually changed now. v0.2.0's own text is untouched (no silent history rewrite). `chassis/VERSION` not bumped - Sean decides version numbers. The updater's awk window keys on `## v<version>` headings, so the `## Unreleased` heading is invisible to it until versioned.

## Adjacent findings (not addressed here, flagging)

1. `chassis/scripts/merge-plugin-triggers.sh` reads manifests from `$CHASSIS_HOME/plugins/<name>/` - NOT `CHASSIS_PLUGINS_ROOT`. In-container that is `/app/customer/plugins` (customer-local plugins like midnight-oil). So trigger declarations from fetched OR baked chassis plugins do not flow into `triggers.yaml` through that path, independent of this bug. Deserves its own issue.
2. `chassis/launchd/com.behalfbot.heartbeat-dispatcher.plist.template` sets `CHASSIS_PLUGINS_ROOT=$CHASSIS_HOME/plugins` for legacy host-side installs - under the new contract that is an explicit override, which matches how those installs behaved anyway. Left alone since the LaunchAgent dispatcher is retired post-containerization.
3. The fix takes full effect on the next published image (the Dockerfile ENV removal ships via docker-publish on merge). Installs running the current image with an updated chassis clone would see the loud "explicit override" log rather than the overlay - visible, not silent.

## Test plan

- [x] `bash chassis/scripts/test-plugin-root-resolution.sh` - 32 passed, 0 failed
- [x] `bash -n` + shellcheck clean (error severity, matching CI) on all touched scripts
- [x] Container-level before/after on the real ghcr v0.2.0 image (output above)
- [x] Both new scripts committed mode 100755 (the v0.2.0 fetcher shipped 100644 and was inert for exactly that reason)
- [ ] After merge + image publish: on a live install, confirm boot log shows `plugin root: /app/customer/state/plugins-root` and `plugins-root.state.json` shows `loom-vision: fetched`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
