### PR TITLE
feat(second-brain): Phase 1 hardening of Notion and Obsidian adapters

### DIFF
--- a/chassis/second_brain/factory.py
+++ b/chassis/second_brain/factory.py
@@ -291,6 +291,12 @@ def get_adapter(config_path: Path | None = None) -> SecondBrainAdapter:
             vault_path=_resolve_env(backend_config.get("vault_path", "")),
             vault_name=_resolve_env(backend_config.get("vault_name", "")) or None,
             read_only=bool(backend_config.get("read_only", False)),
+            # Frontmatter emit is opt-in; tags may arrive as a YAML list
+            # (PyYAML) or a comma-separated string (the minimal fallback
+            # parser cannot represent lists) - the adapter normalizes both.
+            frontmatter=bool(backend_config.get("frontmatter", False)),
+            frontmatter_tags=backend_config.get("frontmatter_tags"),
+            daily_notes_dir=_first_set(backend_config.get("daily_notes_dir")),
         )
     raise ValueError(
         f"Unsupported second_brain.backend={backend!r}. "

--- a/chassis/second_brain/notion.py
+++ b/chassis/second_brain/notion.py
@@ -31,7 +31,9 @@ natural-key value, patch if found, create if not.
 
 from __future__ import annotations
 
+import email.utils
 import json
+import time
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
@@ -51,6 +53,22 @@ NOTION_API_ROOT = "https://api.notion.com/v1"
 # window. Cap the scan so a huge workspace cannot turn one call into an
 # unbounded crawl - 500 pages (5 API calls) covers any sane daily window.
 _LIST_RECENT_SCAN_CAP = 500
+
+# Notion API hard ceilings (https://developers.notion.com/reference/request-limits):
+# at most 100 block children per create/append request, and at most 2000
+# characters per rich_text content field. Exceeding either is an opaque 400.
+_MAX_BLOCKS_PER_REQUEST = 100
+_MAX_RICH_TEXT_CHARS = 2000
+# A block also caps its rich_text array at 100 elements, so one paragraph tops
+# out at 200_000 chars. Lines beyond that are truncated - a single 200k-char
+# line is a pathological input, not a briefing.
+_MAX_RICH_TEXT_PARTS = 100
+
+# 429 handling: Notion averages ~3 requests/second per integration. Retries
+# are bounded and each sleep is capped so a hostile Retry-After header cannot
+# park the process for minutes.
+_MAX_RATE_LIMIT_RETRIES = 5
+_MAX_RETRY_AFTER_SECONDS = 30.0
 
 
 def _to_utc(value: datetime) -> datetime:
@@ -73,27 +91,90 @@ class NotionError(RuntimeError):
     """Raised when Notion API returns a non-2xx response."""
 
 
+class NotionPartialWriteError(NotionError):
+    """A chunked write failed after some chunks already landed.
+
+    Chunked create/append is NOT atomic - Notion has no batch-write
+    transaction, so a failure partway through leaves a half-written page.
+    We deliberately leave the partial content in place rather than trying to
+    roll it back (a rollback delete can itself fail, and for append_to_doc the
+    adapter cannot tell its own blocks from pre-existing ones). The error
+    carries enough state for a non-blind retry: the page id and how many
+    chunks landed out of how many.
+    """
+
+    def __init__(self, doc_id: str, chunks_written: int, chunks_total: int, cause: str) -> None:
+        self.doc_id = doc_id
+        self.chunks_written = chunks_written
+        self.chunks_total = chunks_total
+        super().__init__(
+            f"Notion chunked write to {doc_id} landed {chunks_written} of "
+            f"{chunks_total} chunks (up to {_MAX_BLOCKS_PER_REQUEST} blocks each) "
+            f"before failing: {cause}. The page holds the first {chunks_written} "
+            f"chunks - retry by appending only the remaining content, or delete "
+            f"the page and re-create it. Do not blindly re-send the full body: "
+            f"that duplicates what already landed."
+        )
+
+
+def _retry_after_seconds(exc: urllib.error.HTTPError, attempt: int) -> float:
+    """Delay before retrying a 429. Honours Retry-After (seconds or HTTP-date),
+    falls back to linear backoff, and is always capped."""
+    raw = (exc.headers.get("Retry-After") or "").strip() if exc.headers else ""
+    delay: float | None = None
+    if raw:
+        try:
+            delay = float(raw)
+        except ValueError:
+            try:
+                parsed = email.utils.parsedate_to_datetime(raw)
+                delay = (parsed - datetime.now(timezone.utc)).total_seconds()
+            except (TypeError, ValueError):
+                delay = None
+    if delay is None or delay < 0:
+        delay = float(attempt + 1)
+    return min(delay, _MAX_RETRY_AFTER_SECONDS)
+
+
 def _request(token: str, method: str, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    """One Notion API call, with bounded retry on 429 only.
+
+    Retrying a rate-limited request is safe even for non-idempotent writes:
+    a 429 means Notion's limiter rejected the request BEFORE executing it, so
+    a retried append cannot double-write. Network errors and 5xx responses are
+    deliberately NOT retried - there the request may have been applied before
+    the failure surfaced, and a blind retry of an append double-writes.
+    """
     url = NOTION_API_ROOT + path
     body = json.dumps(payload).encode("utf-8") if payload is not None else None
-    req = urllib.request.Request(
-        url,
-        data=body,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Notion-Version": NOTION_API_VERSION,
-            "Content-Type": "application/json",
-        },
-        method=method,
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            return json.loads(resp.read().decode("utf-8"))
-    except urllib.error.HTTPError as exc:
-        detail = exc.read().decode("utf-8", errors="replace")[:500]
-        raise NotionError(f"Notion {method} {path} → HTTP {exc.code}: {detail}") from exc
-    except urllib.error.URLError as exc:
-        raise NotionError(f"Notion {method} {path} request failed: {exc}") from exc
+    for attempt in range(_MAX_RATE_LIMIT_RETRIES + 1):
+        req = urllib.request.Request(
+            url,
+            data=body,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Notion-Version": NOTION_API_VERSION,
+                "Content-Type": "application/json",
+            },
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")[:500]
+            if exc.code == 429:
+                if attempt < _MAX_RATE_LIMIT_RETRIES:
+                    time.sleep(_retry_after_seconds(exc, attempt))
+                    continue
+                raise NotionError(
+                    f"Notion {method} {path} → HTTP 429 (rate limited) after "
+                    f"{_MAX_RATE_LIMIT_RETRIES + 1} attempts, giving up: {detail}"
+                ) from exc
+            raise NotionError(f"Notion {method} {path} → HTTP {exc.code}: {detail}") from exc
+        except urllib.error.URLError as exc:
+            raise NotionError(f"Notion {method} {path} request failed: {exc}") from exc
+    raise NotionError(f"Notion {method} {path}: retry loop exited without a response")
 
 
 def _markdown_to_blocks(markdown: str) -> list[dict[str, Any]]:
@@ -103,6 +184,9 @@ def _markdown_to_blocks(markdown: str) -> list[dict[str, Any]]:
     for briefings + Pacman proposals, which read fine as flat prose. Heading and
     list parsing is a follow-up; the current <v1-reference-install> briefings already render as
     plain prose in SiYuan, so feature-parity is preserved.
+
+    Lines over 2000 chars are split across multiple rich_text parts within the
+    same paragraph (Notion's per-field ceiling) rather than truncated.
     """
     blocks: list[dict[str, Any]] = []
     for line in markdown.splitlines():
@@ -114,11 +198,38 @@ def _markdown_to_blocks(markdown: str) -> list[dict[str, Any]]:
                 "object": "block",
                 "type": "paragraph",
                 "paragraph": {
-                    "rich_text": [{"type": "text", "text": {"content": text[:2000]}}],
+                    "rich_text": _split_rich_text(text),
                 },
             }
         )
     return blocks
+
+
+def _split_rich_text(text: str) -> list[dict[str, Any]]:
+    """Split one line into rich_text parts of at most 2000 chars each.
+
+    Notion renders consecutive parts inside one paragraph with no visible
+    seam, so a long line survives intact instead of being truncated at 2000.
+    Capped at 100 parts (Notion's per-block rich_text ceiling); anything
+    beyond 200k chars in a single line is dropped.
+    """
+    parts = [
+        {"type": "text", "text": {"content": text[i : i + _MAX_RICH_TEXT_CHARS]}}
+        for i in range(0, len(text), _MAX_RICH_TEXT_CHARS)
+    ]
+    return parts[:_MAX_RICH_TEXT_PARTS]
+
+
+def _chunk_blocks(blocks: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+    """Split a block list into request-sized chunks (at most 100 blocks each).
+
+    Notion caps block children at 100 per create/append request; an unchunked
+    briefing-sized document is an opaque HTTP 400.
+    """
+    return [
+        blocks[i : i + _MAX_BLOCKS_PER_REQUEST]
+        for i in range(0, len(blocks), _MAX_BLOCKS_PER_REQUEST)
+    ]
 
 
 def _blocks_to_markdown(blocks: list[dict[str, Any]]) -> str:
@@ -155,6 +266,8 @@ class NotionNotes(NotesAdapter):
 
     def create_doc(self, parent: str, title: str, body: str) -> str:
         parent_id = parent or self._notes_root
+        chunks = _chunk_blocks(_markdown_to_blocks(body))
+        first = chunks[0] if chunks else []
         result = _request(
             self._token,
             "POST",
@@ -164,18 +277,51 @@ class NotionNotes(NotesAdapter):
                 "properties": {
                     "title": [{"type": "text", "text": {"content": title[:200]}}],
                 },
-                "children": _markdown_to_blocks(body),
+                "children": first,
             },
         )
-        return result.get("id", "")
+        page_id = result.get("id", "")
+        if len(chunks) > 1:
+            # Not atomic: the page exists with chunk 1 already in it. A failure
+            # below raises NotionPartialWriteError carrying the page id and the
+            # count of landed chunks - see that class for the retry contract.
+            self._append_chunks(page_id, chunks[1:], chunks_done=1, chunks_total=len(chunks))
+        return page_id
 
     def append_to_doc(self, doc_id: str, content: str) -> None:
-        _request(
-            self._token,
-            "PATCH",
-            f"/blocks/{doc_id}/children",
-            {"children": _markdown_to_blocks(content)},
-        )
+        chunks = _chunk_blocks(_markdown_to_blocks(content))
+        if not chunks:
+            return  # nothing but blank lines - Notion 400s on an empty children array
+        self._append_chunks(doc_id, chunks, chunks_done=0, chunks_total=len(chunks))
+
+    def _append_chunks(
+        self,
+        doc_id: str,
+        chunks: list[list[dict[str, Any]]],
+        chunks_done: int,
+        chunks_total: int,
+    ) -> None:
+        """Append chunks sequentially (order matters - blocks land append-only).
+
+        Sequential on purpose: parallel appends would interleave chunks and
+        scramble the document. On failure, raise with exact progress so the
+        caller's retry is not blind.
+        """
+        for offset, chunk in enumerate(chunks):
+            try:
+                _request(
+                    self._token,
+                    "PATCH",
+                    f"/blocks/{doc_id}/children",
+                    {"children": chunk},
+                )
+            except NotionError as exc:
+                raise NotionPartialWriteError(
+                    doc_id=doc_id,
+                    chunks_written=chunks_done + offset,
+                    chunks_total=chunks_total,
+                    cause=str(exc),
+                ) from exc
 
     def read_doc(self, doc_id: str) -> str:
         children = _request(self._token, "GET", f"/blocks/{doc_id}/children?page_size=100")

--- a/chassis/second_brain/obsidian.py
+++ b/chassis/second_brain/obsidian.py
@@ -24,12 +24,24 @@ Config (chassis.config.yaml):
         vault_path: /home/user/second-brain   # absolute path to the vault root
         vault_name: second-brain               # for obsidian:// deeplinks; defaults to the directory name
         read_only: false                       # true for pull-only vault clones
+        frontmatter: false                     # emit YAML frontmatter (created, tags) on create_doc
+        frontmatter_tags: jax, briefing        # tags for emitted frontmatter (list under PyYAML,
+                                               # comma-separated string under the fallback parser)
+        daily_notes_dir: Journal/Daily         # where YYYY-MM-DD.md daily notes live ('' = vault root)
+
+Frontmatter handling is deliberately conservative: the adapter only ever
+PREPENDS frontmatter to documents it creates itself, and only when the body
+does not already start with a `---` fence. It never rewrites existing notes,
+so Templater syntax, Dataview blocks, and hand-written frontmatter in a real
+vault are never touched. On read, frontmatter is stripped from search /
+list_recent SNIPPETS only - `read_doc` always returns the raw file verbatim.
 """
 
 from __future__ import annotations
 
 import os
 import tempfile
+from datetime import date as _date
 from datetime import datetime
 from pathlib import Path
 from urllib.parse import quote
@@ -45,6 +57,45 @@ from chassis.second_brain.base import (
 _SKIP_DIRS = {".obsidian", ".git", ".trash", ".github"}
 
 _SNIPPET_LEN = 200
+
+
+def _strip_frontmatter(text: str) -> str:
+    """Return the body with a leading YAML frontmatter fence removed.
+
+    Only strips when the note STARTS with a `---` line and a closing `---` (or
+    `...`) line exists - Obsidian's own definition of frontmatter. An
+    unterminated fence returns the text unchanged: guessing where frontmatter
+    ends risks eating body content. Templater/Dataview syntax inside the fence
+    is irrelevant here - everything up to the closing delimiter is skipped
+    verbatim, never parsed.
+
+    Display-only: used for search/list_recent snippets. Files on disk are
+    never rewritten through this.
+    """
+    if not text.startswith("---"):
+        return text
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        return text
+    for index in range(1, len(lines)):
+        if lines[index].strip() in ("---", "..."):
+            return "".join(lines[index + 1 :]).lstrip("\n")
+    return text
+
+
+def _split_tags(raw: object) -> tuple[str, ...]:
+    """Normalize a tags config value to a tuple of non-empty strings.
+
+    Accepts a YAML list (PyYAML path) or a comma-separated string (the
+    minimal fallback parser in factory.py cannot represent lists).
+    """
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        return tuple(tag.strip() for tag in raw.split(",") if tag.strip())
+    if isinstance(raw, (list, tuple)):
+        return tuple(str(tag).strip() for tag in raw if str(tag).strip())
+    return ()
 
 
 class ObsidianError(RuntimeError):
@@ -65,6 +116,9 @@ class ObsidianNotes(NotesAdapter):
         vault_path: str,
         vault_name: str | None = None,
         read_only: bool = False,
+        frontmatter: bool = False,
+        frontmatter_tags: object = None,
+        daily_notes_dir: str = "",
     ) -> None:
         if not vault_path:
             raise ObsidianError(
@@ -78,6 +132,9 @@ class ObsidianNotes(NotesAdapter):
             )
         self._vault_name = vault_name or self._vault.name
         self._read_only = read_only
+        self._frontmatter = frontmatter
+        self._frontmatter_tags = _split_tags(frontmatter_tags)
+        self._daily_notes_dir = (daily_notes_dir or "").strip().strip("/")
 
     # -- path safety ---------------------------------------------------------
 
@@ -157,6 +214,23 @@ class ObsidianNotes(NotesAdapter):
                 pass
             raise
 
+    # -- frontmatter ---------------------------------------------------------
+
+    def _compose_frontmatter(self) -> str:
+        """YAML frontmatter block for adapter-created notes.
+
+        Emitted only when `frontmatter: true` in config and only on
+        create_doc for bodies that do not already start with a `---` fence -
+        never merged into existing frontmatter, never applied to appends.
+        """
+        created = datetime.now().astimezone().isoformat(timespec="seconds")
+        lines = ["---", f"created: {created}"]
+        if self._frontmatter_tags:
+            lines.append("tags:")
+            lines.extend(f"  - {tag}" for tag in self._frontmatter_tags)
+        lines.append("---")
+        return "\n".join(lines) + "\n\n"
+
     # -- NotesAdapter --------------------------------------------------------
 
     def create_doc(self, parent: str, title: str, body: str) -> str:
@@ -172,6 +246,8 @@ class ObsidianNotes(NotesAdapter):
                 f"refusing to overwrite. Use append_to_doc to add to it."
             )
         self._ensure_writable("create_doc", target.parent)
+        if self._frontmatter and not body.startswith("---"):
+            body = self._compose_frontmatter() + body
         target.parent.mkdir(parents=True, exist_ok=True)
         self._atomic_write(target, body)
         return self._rel_id(target)
@@ -194,6 +270,38 @@ class ObsidianNotes(NotesAdapter):
                 f"read_doc: doc {doc_id!r} not found in vault {str(self._vault)!r}."
             )
         return target.read_text(encoding="utf-8")
+
+    # -- daily notes ---------------------------------------------------------
+
+    def daily_note_id(self, day: _date | None = None) -> str:
+        """Doc id of the daily note for `day` (default: today, local time).
+
+        Follows the Daily Notes plugin's default `YYYY-MM-DD.md` convention
+        under `second_brain.obsidian.daily_notes_dir` (vault root when the key
+        is unset). Custom plugin date formats are not supported - installs
+        that renamed the format need a Phase 2 config key.
+        """
+        chosen = day or datetime.now().date()
+        name = chosen.strftime("%Y-%m-%d")
+        if self._daily_notes_dir:
+            return f"{self._daily_notes_dir}/{name}.md"
+        return f"{name}.md"
+
+    def append_to_daily_note(self, content: str, day: _date | None = None) -> str:
+        """Append `content` to the daily note, creating it if absent.
+
+        The create/append seam other callers have to handle themselves is
+        folded in here because it is THE daily-note usage pattern: briefing
+        and daily-log writers do not care whether today's note exists yet.
+        Returns the doc id either way.
+        """
+        doc_id = self.daily_note_id(day)
+        target = self._resolve(doc_id)
+        if target.is_file():
+            self.append_to_doc(doc_id, content)
+            return doc_id
+        chosen = day or datetime.now().date()
+        return self.create_doc(self._daily_notes_dir, chosen.strftime("%Y-%m-%d"), content)
 
     def get_deeplink(self, doc_id: str) -> str:
         rel = self._rel_id(self._resolve(doc_id))
@@ -221,17 +329,26 @@ class ObsidianNotes(NotesAdapter):
                 text = path.read_text(encoding="utf-8")
             except (OSError, UnicodeDecodeError):
                 continue
+            # Match against the full text (so a query hitting only frontmatter
+            # - e.g. a tag - still finds the note), but build snippets from
+            # the frontmatter-stripped body so they show prose, not YAML noise.
+            body = _strip_frontmatter(text)
             name_match = needle in path.stem.lower()
-            body_index = text.lower().find(needle)
-            if not name_match and body_index < 0:
+            body_index = body.lower().find(needle)
+            frontmatter_match = body_index < 0 and needle in text.lower()
+            if not name_match and body_index < 0 and not frontmatter_match:
                 continue
             if body_index >= 0:
                 start = max(0, body_index - 60)
-                snippet = text[start : start + _SNIPPET_LEN].strip()
+                snippet = body[start : start + _SNIPPET_LEN].strip()
             else:
-                snippet = text[:_SNIPPET_LEN].strip()
+                snippet = body[:_SNIPPET_LEN].strip()
             rel = self._rel_id(path)
-            score = (2.0 if name_match else 0.0) + (1.0 if body_index >= 0 else 0.0)
+            score = (
+                (2.0 if name_match else 0.0)
+                + (1.0 if body_index >= 0 else 0.0)
+                + (0.5 if frontmatter_match else 0.0)
+            )
             hits.append(
                 SearchHit(
                     id=rel,
@@ -285,7 +402,7 @@ class ObsidianNotes(NotesAdapter):
         hits: list[SearchHit] = []
         for mtime, size, path in candidates[: int(limit)]:
             try:
-                snippet = path.read_text(encoding="utf-8")[:_SNIPPET_LEN].strip()
+                snippet = _strip_frontmatter(path.read_text(encoding="utf-8"))[:_SNIPPET_LEN].strip()
             except (OSError, UnicodeDecodeError):
                 snippet = ""
             rel = self._rel_id(path)
@@ -309,6 +426,16 @@ class ObsidianAdapter(SecondBrainAdapter):
         vault_path: str,
         vault_name: str | None = None,
         read_only: bool = False,
+        frontmatter: bool = False,
+        frontmatter_tags: object = None,
+        daily_notes_dir: str = "",
     ) -> None:
-        self.notes = ObsidianNotes(vault_path, vault_name, read_only)
+        self.notes = ObsidianNotes(
+            vault_path,
+            vault_name,
+            read_only,
+            frontmatter=frontmatter,
+            frontmatter_tags=frontmatter_tags,
+            daily_notes_dir=daily_notes_dir,
+        )
         self.database = NotImplementedDatabase("obsidian")

--- a/chassis/second_brain/tests/test_notion.py
+++ b/chassis/second_brain/tests/test_notion.py
@@ -35,7 +35,9 @@ from chassis.second_brain import notion as notion_mod  # noqa: E402
 from chassis.second_brain.notion import (  # noqa: E402
     NotionError,
     NotionNotes,
+    NotionPartialWriteError,
     _blocks_to_markdown,
+    _chunk_blocks,
     _markdown_to_blocks,
 )
 
@@ -109,6 +111,137 @@ class TestCreateDoc(NotionNotesTestCase):
         # is easier to trace than a KeyError from deep inside a heartbeat.
         self.response = {}
         self.assertEqual(self.notes.create_doc("", "T", "b"), "")
+
+
+class TestChunkedCreate(NotionNotesTestCase):
+    """THE Phase 1 bug: Notion caps block children at 100 per request, and an
+    unchunked briefing-sized create_doc was an opaque HTTP 400. These tests
+    assert the >100-block path explicitly."""
+
+    def test_create_over_100_blocks_chunks_into_create_plus_appends(self):
+        self.response = {"id": "page-1"}
+        body = "\n".join(f"line {i}" for i in range(250))
+        new_id = self.notes.create_doc("", "Morning Briefing", body)
+
+        self.assertEqual(new_id, "page-1")
+        self.assertEqual(len(self.calls), 3)
+
+        _, method, path, payload = self.calls[0]
+        self.assertEqual((method, path), ("POST", "/pages"))
+        self.assertEqual(len(payload["children"]), 100)
+        first_text = payload["children"][0]["paragraph"]["rich_text"][0]["text"]["content"]
+        self.assertEqual(first_text, "line 0")
+
+        _, method, path, payload = self.calls[1]
+        self.assertEqual((method, path), ("PATCH", "/blocks/page-1/children"))
+        self.assertEqual(len(payload["children"]), 100)
+        self.assertEqual(
+            payload["children"][0]["paragraph"]["rich_text"][0]["text"]["content"],
+            "line 100",
+        )
+
+        _, method, path, payload = self.calls[2]
+        self.assertEqual((method, path), ("PATCH", "/blocks/page-1/children"))
+        self.assertEqual(len(payload["children"]), 50)
+        self.assertEqual(
+            payload["children"][-1]["paragraph"]["rich_text"][0]["text"]["content"],
+            "line 249",
+        )
+
+    def test_create_exactly_100_blocks_is_a_single_request(self):
+        self.response = {"id": "page-1"}
+        self.notes.create_doc("", "T", "\n".join(f"l{i}" for i in range(100)))
+        self.assertEqual(len(self.calls), 1)
+
+    def test_create_101_blocks_appends_one_chunk_of_one(self):
+        self.response = {"id": "page-1"}
+        self.notes.create_doc("", "T", "\n".join(f"l{i}" for i in range(101)))
+        self.assertEqual(len(self.calls), 2)
+        self.assertEqual(len(self.calls[1][3]["children"]), 1)
+
+    def test_no_block_ever_exceeds_100_children_per_request(self):
+        self.response = {"id": "page-1"}
+        self.notes.create_doc("", "T", "\n".join(f"l{i}" for i in range(731)))
+        for _, _, _, payload in self.calls:
+            self.assertLessEqual(len(payload["children"]), 100)
+
+    def test_partial_create_failure_reports_progress_and_page_id(self):
+        # Create succeeds, first append succeeds, second append blows up. The
+        # page now holds 2 of 3 chunks - the error must say so, or a retry is
+        # blind and either duplicates content or deletes good data.
+        responses = iter(
+            [
+                {"id": "page-1"},
+                {},
+                NotionError("Notion PATCH /blocks/page-1/children → HTTP 500: boom"),
+            ]
+        )
+
+        def scripted(token, method, path, payload=None):
+            self.calls.append((token, method, path, payload))
+            step = next(responses)
+            if isinstance(step, Exception):
+                raise step
+            return step
+
+        with mock.patch.object(notion_mod, "_request", side_effect=scripted):
+            with self.assertRaises(NotionPartialWriteError) as ctx:
+                self.notes.create_doc("", "T", "\n".join(f"l{i}" for i in range(250)))
+
+        exc = ctx.exception
+        self.assertEqual(exc.doc_id, "page-1")
+        self.assertEqual(exc.chunks_written, 2)
+        self.assertEqual(exc.chunks_total, 3)
+        self.assertIn("2 of 3", str(exc))
+        self.assertIn("page-1", str(exc))
+        self.assertIsInstance(exc, NotionError)  # callers catching NotionError still see it
+
+
+class TestChunkedAppend(NotionNotesTestCase):
+    def test_append_over_100_blocks_issues_sequential_patches(self):
+        self.notes.append_to_doc("doc-1", "\n".join(f"line {i}" for i in range(250)))
+        self.assertEqual(len(self.calls), 3)
+        for _, method, path, payload in self.calls:
+            self.assertEqual((method, path), ("PATCH", "/blocks/doc-1/children"))
+            self.assertLessEqual(len(payload["children"]), 100)
+        # Order preserved - chunk boundaries must not scramble the document.
+        self.assertEqual(
+            self.calls[2][3]["children"][-1]["paragraph"]["rich_text"][0]["text"]["content"],
+            "line 249",
+        )
+
+    def test_append_blank_content_makes_no_request(self):
+        # Notion 400s on an empty children array; an all-blank append is a no-op.
+        self.notes.append_to_doc("doc-1", "\n\n\n")
+        self.assertEqual(self.calls, [])
+
+    def test_partial_append_failure_reports_progress(self):
+        attempts = {"n": 0}
+
+        def flaky(token, method, path, payload=None):
+            attempts["n"] += 1
+            if attempts["n"] == 2:
+                raise NotionError("HTTP 502")
+            return {}
+
+        with mock.patch.object(notion_mod, "_request", side_effect=flaky):
+            with self.assertRaises(NotionPartialWriteError) as ctx:
+                self.notes.append_to_doc("doc-1", "\n".join(f"l{i}" for i in range(250)))
+
+        self.assertEqual(ctx.exception.chunks_written, 1)
+        self.assertEqual(ctx.exception.chunks_total, 3)
+        self.assertIn("1 of 3", str(ctx.exception))
+
+
+class TestChunkBlocks(unittest.TestCase):
+    def test_empty_list_yields_no_chunks(self):
+        self.assertEqual(_chunk_blocks([]), [])
+
+    def test_chunk_sizes_and_order(self):
+        blocks = [{"i": i} for i in range(205)]
+        chunks = _chunk_blocks(blocks)
+        self.assertEqual([len(c) for c in chunks], [100, 100, 5])
+        self.assertEqual([b["i"] for c in chunks for b in c], list(range(205)))
 
 
 class TestAppendAndRead(NotionNotesTestCase):
@@ -189,10 +322,25 @@ class TestMarkdownConversion(unittest.TestCase):
     def test_blank_lines_skipped(self):
         self.assertEqual(len(_markdown_to_blocks("a\n\n\nb")), 2)
 
-    def test_long_line_truncated_at_2000(self):
+    def test_long_line_splits_into_2000_char_rich_text_parts(self):
+        # Notion caps a single rich_text content field at 2000 chars. A long
+        # line used to be silently truncated there; now it splits into
+        # multiple parts within the same paragraph and nothing is lost.
         blocks = _markdown_to_blocks("x" * 5000)
-        content = blocks[0]["paragraph"]["rich_text"][0]["text"]["content"]
-        self.assertEqual(len(content), 2000)
+        self.assertEqual(len(blocks), 1)
+        parts = blocks[0]["paragraph"]["rich_text"]
+        self.assertEqual([len(p["text"]["content"]) for p in parts], [2000, 2000, 1000])
+        self.assertEqual("".join(p["text"]["content"] for p in parts), "x" * 5000)
+
+    def test_short_line_stays_a_single_part(self):
+        blocks = _markdown_to_blocks("hello")
+        self.assertEqual(len(blocks[0]["paragraph"]["rich_text"]), 1)
+
+    def test_pathological_line_caps_at_100_parts(self):
+        # Notion also caps rich_text arrays at 100 elements per block. A
+        # 200k+ char single line truncates there rather than 400ing.
+        blocks = _markdown_to_blocks("x" * 300_000)
+        self.assertEqual(len(blocks[0]["paragraph"]["rich_text"]), 100)
 
     def test_paragraph_roundtrip(self):
         # _markdown_to_blocks emits text.content; the API echoes plain_text.
@@ -287,6 +435,142 @@ class TestRequestErrorMapping(unittest.TestCase):
         self.assertEqual(captured["method"], "POST")
 
 
+def _http_error(code: int, body: bytes = b"{}", retry_after: str | None = None) -> urllib.error.HTTPError:
+    import email.message
+
+    headers = email.message.Message()
+    if retry_after is not None:
+        headers["Retry-After"] = retry_after
+    err = urllib.error.HTTPError(
+        url="https://api.notion.com/v1/pages",
+        code=code,
+        msg="err",
+        hdrs=headers,
+        fp=None,
+    )
+    err.read = lambda: body  # type: ignore[method-assign]
+    return err
+
+
+class TestRateLimitRetry(unittest.TestCase):
+    """429 handling in _request: bounded retry honouring Retry-After.
+
+    Retrying 429 is safe for writes because Notion's limiter rejects the
+    request BEFORE executing it - a rate-limited append never half-landed.
+    That is also why ONLY 429 retries: a 5xx or network error may have
+    applied the write, and retrying those would double-write.
+    """
+
+    def test_429_retries_and_honours_retry_after(self):
+        sleeps: list[float] = []
+        outcomes = iter([_http_error(429, retry_after="7"), _http_error(429, retry_after="2"), None])
+
+        class FakeResp:
+            def read(self):
+                return b'{"id": "ok"}'
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def fake_urlopen(req, timeout=None):
+            step = next(outcomes)
+            if step is not None:
+                raise step
+            return FakeResp()
+
+        with mock.patch.object(notion_mod.urllib.request, "urlopen", side_effect=fake_urlopen):
+            with mock.patch.object(notion_mod.time, "sleep", side_effect=sleeps.append):
+                result = notion_mod._request(TOKEN, "PATCH", "/blocks/x/children", {"children": []})
+
+        self.assertEqual(result, {"id": "ok"})
+        self.assertEqual(sleeps, [7.0, 2.0])
+
+    def test_429_exhaustion_raises_with_attempt_count(self):
+        def always_429(req, timeout=None):
+            raise _http_error(429, body=b'{"message":"rate limited"}', retry_after="1")
+
+        with mock.patch.object(notion_mod.urllib.request, "urlopen", side_effect=always_429):
+            with mock.patch.object(notion_mod.time, "sleep") as sleep:
+                with self.assertRaises(NotionError) as ctx:
+                    notion_mod._request(TOKEN, "GET", "/pages/x")
+
+        self.assertEqual(sleep.call_count, notion_mod._MAX_RATE_LIMIT_RETRIES)
+        message = str(ctx.exception)
+        self.assertIn("429", message)
+        self.assertIn(f"{notion_mod._MAX_RATE_LIMIT_RETRIES + 1} attempts", message)
+        self.assertIn("rate limited", message)
+
+    def test_missing_retry_after_falls_back_to_backoff(self):
+        sleeps: list[float] = []
+
+        def always_429(req, timeout=None):
+            raise _http_error(429)
+
+        with mock.patch.object(notion_mod.urllib.request, "urlopen", side_effect=always_429):
+            with mock.patch.object(notion_mod.time, "sleep", side_effect=sleeps.append):
+                with self.assertRaises(NotionError):
+                    notion_mod._request(TOKEN, "GET", "/pages/x")
+
+        self.assertEqual(sleeps, [1.0, 2.0, 3.0, 4.0, 5.0])
+
+    def test_absurd_retry_after_is_capped(self):
+        sleeps: list[float] = []
+        outcomes = iter([_http_error(429, retry_after="86400")])
+
+        class FakeResp:
+            def read(self):
+                return b"{}"
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def fake_urlopen(req, timeout=None):
+            try:
+                raise next(outcomes)
+            except StopIteration:
+                return FakeResp()
+
+        with mock.patch.object(notion_mod.urllib.request, "urlopen", side_effect=fake_urlopen):
+            with mock.patch.object(notion_mod.time, "sleep", side_effect=sleeps.append):
+                notion_mod._request(TOKEN, "GET", "/pages/x")
+
+        self.assertEqual(sleeps, [notion_mod._MAX_RETRY_AFTER_SECONDS])
+
+    def test_non_429_http_errors_are_not_retried(self):
+        attempts = {"n": 0}
+
+        def fail_500(req, timeout=None):
+            attempts["n"] += 1
+            raise _http_error(500, body=b'{"message":"server error"}')
+
+        with mock.patch.object(notion_mod.urllib.request, "urlopen", side_effect=fail_500):
+            with mock.patch.object(notion_mod.time, "sleep") as sleep:
+                with self.assertRaises(NotionError):
+                    notion_mod._request(TOKEN, "PATCH", "/blocks/x/children", {"children": []})
+
+        self.assertEqual(attempts["n"], 1)
+        sleep.assert_not_called()
+
+    def test_network_errors_are_not_retried(self):
+        attempts = {"n": 0}
+
+        def offline(req, timeout=None):
+            attempts["n"] += 1
+            raise urllib.error.URLError("offline")
+
+        with mock.patch.object(notion_mod.urllib.request, "urlopen", side_effect=offline):
+            with self.assertRaises(NotionError):
+                notion_mod._request(TOKEN, "POST", "/pages", {})
+
+        self.assertEqual(attempts["n"], 1)
+
+
 @unittest.skipUnless(
     os.environ.get("NOTION_TOKEN") and os.environ.get("NOTION_TEST_PAGE_ID"),
     "live Notion tests need NOTION_TOKEN and NOTION_TEST_PAGE_ID",
@@ -320,6 +604,19 @@ class LiveNotionTestCase(unittest.TestCase):
         body = self.notes.read_doc(doc_id)
         self.assertIn("first line", body)
         self.assertIn("second line", body)
+
+    def test_chunked_create_over_100_blocks_live(self):
+        # The Phase 1 bug: >100 blocks in one request was HTTP 400. Prove the
+        # chunked path against the real API and read the whole doc back.
+        stamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        body = "\n".join(f"chunk test line {i}" for i in range(120))
+        doc_id = self.notes.create_doc("", f"adapter chunk test {stamp}", body)
+        self.assertTrue(doc_id, "create_doc returned no page id")
+        readback = self.notes.read_doc(doc_id)
+        self.assertIn("chunk test line 0", readback)
+        # read_doc fetches the first 100 blocks only (documented V1 limit), so
+        # assert block 99 rather than 119 - the write itself is what is under test.
+        self.assertIn("chunk test line 99", readback)
 
     def test_search_returns_wellformed_hits(self):
         hits = self.notes.search("adapter test", limit=5)

--- a/chassis/second_brain/tests/test_obsidian.py
+++ b/chassis/second_brain/tests/test_obsidian.py
@@ -32,6 +32,7 @@ from chassis.second_brain.obsidian import (  # noqa: E402
     ObsidianError,
     ObsidianNotes,
     ObsidianReadOnlyError,
+    _strip_frontmatter,
 )
 
 
@@ -207,6 +208,194 @@ class TestReadOnlyVault(ObsidianVaultTestCase):
         self.assertFalse((self.vault / "Scratch.md").exists())
 
 
+_TEMPLATER_NOTE = (
+    "---\n"
+    "created: <% tp.date.now() %>\n"
+    "tags:\n"
+    "  - notary\n"
+    "  - templater\n"
+    "---\n"
+    "\n"
+    "Body about the notary appointment.\n"
+    "\n"
+    "```dataview\n"
+    "LIST FROM #notary\n"
+    "```\n"
+)
+
+
+class TestStripFrontmatter(unittest.TestCase):
+    def test_strips_leading_fence(self):
+        self.assertEqual(
+            _strip_frontmatter("---\ntags: [a]\n---\nbody line\n"),
+            "body line\n",
+        )
+
+    def test_no_frontmatter_untouched(self):
+        self.assertEqual(_strip_frontmatter("plain body\n"), "plain body\n")
+
+    def test_unterminated_fence_untouched(self):
+        # Guessing where an unterminated fence ends risks eating body content.
+        text = "---\ntags: [a]\nno closing fence\n"
+        self.assertEqual(_strip_frontmatter(text), text)
+
+    def test_templater_syntax_inside_fence_is_skipped_verbatim(self):
+        body = _strip_frontmatter(_TEMPLATER_NOTE)
+        self.assertTrue(body.startswith("Body about the notary"))
+        self.assertNotIn("tp.date.now", body)
+        # The dataview block is BODY content and must survive.
+        self.assertIn("```dataview", body)
+
+    def test_dots_closing_delimiter(self):
+        self.assertEqual(_strip_frontmatter("---\na: 1\n...\nbody\n"), "body\n")
+
+    def test_mid_document_rules_not_treated_as_frontmatter(self):
+        text = "intro\n---\nnot frontmatter\n---\nmore\n"
+        self.assertEqual(_strip_frontmatter(text), text)
+
+
+class TestFrontmatterEmit(ObsidianVaultTestCase):
+    def _fm_notes(self, **kwargs) -> ObsidianNotes:
+        return ObsidianNotes(str(self.vault), frontmatter=True, **kwargs)
+
+    def test_create_doc_emits_created_and_tags(self):
+        notes = self._fm_notes(frontmatter_tags="jax, briefing")
+        doc_id = notes.create_doc("Briefings/", "2026-07-21", "# Today\n")
+        raw = notes.read_doc(doc_id)
+        self.assertTrue(raw.startswith("---\ncreated: "))
+        self.assertIn("tags:\n  - jax\n  - briefing\n", raw)
+        # Frontmatter closes and the body survives below it.
+        self.assertIn("---\n\n# Today\n", raw)
+
+    def test_tags_accept_a_real_list_too(self):
+        notes = self._fm_notes(frontmatter_tags=["a", "b"])
+        raw = notes.read_doc(notes.create_doc("", "Listy", "body"))
+        self.assertIn("  - a\n  - b\n", raw)
+
+    def test_no_tags_config_omits_tags_key(self):
+        raw = self._fm_notes().read_doc(self._fm_notes().create_doc("", "NoTags", "body"))
+        self.assertIn("created: ", raw)
+        self.assertNotIn("tags:", raw)
+
+    def test_disabled_by_default(self):
+        doc_id = self.notes.create_doc("", "Plain", "just the body\n")
+        self.assertEqual(self.notes.read_doc(doc_id), "just the body\n")
+
+    def test_body_with_own_frontmatter_is_not_double_wrapped(self):
+        # A caller (or template) that already supplies frontmatter wins - the
+        # adapter must never stack a second fence on top.
+        notes = self._fm_notes(frontmatter_tags="jax")
+        doc_id = notes.create_doc("", "OwnFm", _TEMPLATER_NOTE)
+        raw = notes.read_doc(doc_id)
+        self.assertEqual(raw, _TEMPLATER_NOTE)
+        self.assertNotIn("created: 2", raw.split("---")[1])
+
+    def test_append_never_adds_frontmatter(self):
+        notes = self._fm_notes(frontmatter_tags="jax")
+        notes.append_to_doc("Inbox.md", "appended line\n")
+        body = notes.read_doc("Inbox.md")
+        self.assertTrue(body.endswith("appended line\n"))
+        self.assertNotIn("---", body)
+
+
+class TestFrontmatterStrippedFromSnippets(ObsidianVaultTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        (self.vault / "Templated.md").write_text(_TEMPLATER_NOTE, encoding="utf-8")
+
+    def test_search_snippet_excludes_frontmatter(self):
+        hits = [h for h in self.notes.search("notary appointment") if h.id == "Templated.md"]
+        self.assertEqual(len(hits), 1)
+        self.assertNotIn("tp.date.now", hits[0].snippet)
+        self.assertNotIn("---", hits[0].snippet)
+        self.assertIn("notary appointment", hits[0].snippet)
+
+    def test_frontmatter_only_match_still_returns_the_note(self):
+        # 'templater' appears ONLY inside the frontmatter (as a tag). The note
+        # must still be findable; the snippet falls back to the body head.
+        hits = [h for h in self.notes.search("templater") if h.id == "Templated.md"]
+        self.assertEqual(len(hits), 1)
+        self.assertTrue(hits[0].snippet.startswith("Body about the notary"))
+        self.assertGreater(hits[0].score, 0.0)
+
+    def test_search_does_not_corrupt_the_note(self):
+        self.notes.search("notary")
+        self.assertEqual(
+            (self.vault / "Templated.md").read_text(encoding="utf-8"), _TEMPLATER_NOTE
+        )
+
+    def test_list_recent_snippet_excludes_frontmatter(self):
+        from datetime import datetime, timedelta
+
+        hits = self.notes.list_recent(
+            since=datetime.now() - timedelta(hours=1),
+            until=datetime.now() + timedelta(hours=1),
+            limit=50,
+        )
+        templated = [h for h in hits if h.id == "Templated.md"]
+        self.assertEqual(len(templated), 1)
+        self.assertTrue(templated[0].snippet.startswith("Body about the notary"))
+        self.assertNotIn("---", templated[0].snippet)
+
+
+class TestDailyNotes(ObsidianVaultTestCase):
+    def _daily_notes(self, **kwargs) -> ObsidianNotes:
+        return ObsidianNotes(str(self.vault), daily_notes_dir="Journal/Daily", **kwargs)
+
+    def test_daily_note_id_uses_configured_dir_and_date_format(self):
+        from datetime import date
+
+        notes = self._daily_notes()
+        self.assertEqual(notes.daily_note_id(date(2026, 7, 21)), "Journal/Daily/2026-07-21.md")
+
+    def test_daily_note_id_defaults_to_today(self):
+        from datetime import datetime
+
+        notes = self._daily_notes()
+        today = datetime.now().date().strftime("%Y-%m-%d")
+        self.assertEqual(notes.daily_note_id(), f"Journal/Daily/{today}.md")
+
+    def test_daily_note_id_without_dir_lands_in_vault_root(self):
+        from datetime import date
+
+        self.assertEqual(self.notes.daily_note_id(date(2026, 7, 21)), "2026-07-21.md")
+
+    def test_append_creates_then_appends(self):
+        from datetime import date
+
+        notes = self._daily_notes()
+        day = date(2026, 7, 21)
+        doc_id = notes.append_to_daily_note("- first entry\n", day)
+        self.assertEqual(doc_id, "Journal/Daily/2026-07-21.md")
+        self.assertEqual(notes.read_doc(doc_id), "- first entry\n")
+
+        doc_id_2 = notes.append_to_daily_note("- second entry\n", day)
+        self.assertEqual(doc_id_2, doc_id)
+        body = notes.read_doc(doc_id)
+        self.assertIn("- first entry\n", body)
+        self.assertTrue(body.endswith("- second entry\n"))
+
+    def test_created_daily_note_gets_frontmatter_when_enabled(self):
+        from datetime import date
+
+        notes = self._daily_notes(frontmatter=True, frontmatter_tags="daily")
+        doc_id = notes.append_to_daily_note("- entry\n", date(2026, 7, 21))
+        raw = notes.read_doc(doc_id)
+        self.assertTrue(raw.startswith("---\ncreated: "))
+        self.assertIn("  - daily\n", raw)
+        self.assertTrue(raw.endswith("- entry\n"))
+
+    def test_read_only_vault_refuses_daily_note_write(self):
+        from datetime import date
+
+        notes = ObsidianNotes(
+            str(self.vault), read_only=True, daily_notes_dir="Journal/Daily"
+        )
+        with self.assertRaises(ObsidianReadOnlyError):
+            notes.append_to_daily_note("- entry\n", date(2026, 7, 21))
+        self.assertFalse((self.vault / "Journal").exists())
+
+
 class TestPathTraversal(ObsidianVaultTestCase):
     def test_read_traversal_rejected(self):
         with self.assertRaises(ObsidianError) as ctx:
@@ -253,6 +442,35 @@ class TestFactory(ObsidianVaultTestCase):
         adapter = get_adapter(self._write_config("    read_only: true\n"))
         with self.assertRaises(ObsidianReadOnlyError):
             adapter.notes.create_doc("", "Scratch", "body")
+
+    def test_factory_passes_frontmatter_config_through(self):
+        adapter = get_adapter(
+            self._write_config(
+                "    frontmatter: true\n"
+                "    frontmatter_tags: jax, briefing\n"
+            )
+        )
+        doc_id = adapter.notes.create_doc("", "FromFactory", "body")
+        raw = adapter.notes.read_doc(doc_id)
+        self.assertTrue(raw.startswith("---\ncreated: "))
+        self.assertIn("  - jax\n  - briefing\n", raw)
+
+    def test_factory_passes_daily_notes_dir_through(self):
+        from datetime import date
+
+        adapter = get_adapter(self._write_config("    daily_notes_dir: Journal/Daily\n"))
+        self.assertEqual(
+            adapter.notes.daily_note_id(date(2026, 7, 21)),
+            "Journal/Daily/2026-07-21.md",
+        )
+
+    def test_factory_defaults_leave_frontmatter_off_and_daily_dir_root(self):
+        from datetime import date
+
+        adapter = get_adapter(self._write_config())
+        doc_id = adapter.notes.create_doc("", "Defaults", "plain body\n")
+        self.assertEqual(adapter.notes.read_doc(doc_id), "plain body\n")
+        self.assertEqual(adapter.notes.daily_note_id(date(2026, 7, 21)), "2026-07-21.md")
 
     def test_factory_unknown_backend_lists_all_three(self):
         config = self._tmp / "chassis.config.yaml"

--- a/docs/second-brain-adapters.md
+++ b/docs/second-brain-adapters.md
@@ -98,6 +98,12 @@ second_brain:
     active_database: lp_crm                             # default for upsert/query
 ```
 
+**Large documents are chunked.** Notion caps block children at 100 per request and rich_text content at 2000 chars per field ([request limits](https://developers.notion.com/reference/request-limits)); before chunking, any document over ~100 non-empty lines - every morning briefing - was an opaque HTTP 400. `create_doc` now sends the first 100 blocks with the page create and appends the rest in sequential 100-block PATCH chunks; `append_to_doc` chunks the same way. Lines over 2000 chars split across multiple rich_text parts inside one paragraph (rendered seamlessly, nothing truncated) up to Notion's 100-parts-per-block ceiling.
+
+**Chunked writes are NOT atomic.** Notion has no batch transaction, so a failure partway leaves a half-written page. The adapter leaves partial content in place (a rollback delete can itself fail, and on `append_to_doc` the adapter cannot tell its own blocks from pre-existing ones) and raises `NotionPartialWriteError` - a `NotionError` subclass carrying `doc_id`, `chunks_written`, `chunks_total`, with a message stating exactly how many chunks landed. Retry by sending only the remaining content; blindly re-sending the full body duplicates what already landed.
+
+**429s are retried, bounded.** Notion allows ~3 requests/second per integration, and chunked writes plus `list_recent` scans will trip that. `_request` retries HTTP 429 up to 5 times, honouring the `Retry-After` header (seconds or HTTP-date, capped at 30s per sleep; linear backoff fallback when absent), then gives up with an error naming the attempt count. Retrying a 429 is safe even for writes - Notion's limiter rejects the request before executing it, so a rate-limited append never half-landed. Network errors and 5xx are deliberately NOT retried: there the write may have been applied before the failure surfaced, and a blind retry double-writes.
+
 ### Obsidian
 
 ```yaml
@@ -107,11 +113,24 @@ second_brain:
     vault_path: /home/hugues/second-brain   # absolute path to the vault root
     vault_name: second-brain                 # for obsidian:// deeplinks; defaults to the directory name
     read_only: true                          # pull-only vault clone (e.g. read-only deploy key)
+    frontmatter: false                       # emit YAML frontmatter (created, tags) on create_doc
+    frontmatter_tags: jax, briefing          # tags for emitted frontmatter (YAML list under PyYAML,
+                                             # comma-separated string under the fallback parser)
+    daily_notes_dir: Journal/Daily           # where YYYY-MM-DD.md daily notes live; unset = vault root
 ```
 
 Doc ids are vault-relative paths (`Briefings/2026-07-09.md`; the `.md` suffix is optional on input). `create_doc` treats `parent` as a vault-relative directory and empty `parent` as the vault root. No Obsidian process or plugin is required - the adapter reads and writes the vault files directly.
 
 Read-only vaults are first-class: with `read_only: true`, or when the filesystem itself denies writes (pull-only git clone through a read-only deploy key), `create_doc` / `append_to_doc` raise `ObsidianReadOnlyError` naming the cause. Config states intent, the filesystem states truth - a write is refused if either side blocks it, and the error says which. Writes that do proceed are atomic (temp file + rename), doc ids that resolve outside the vault root are rejected, and `create_doc` refuses to overwrite an existing note.
+
+**Frontmatter** is opt-in and conservative. With `frontmatter: true`, `create_doc` prepends a YAML fence carrying `created` (local-time ISO-8601) and the configured `frontmatter_tags` - but ONLY when the body does not already start with a `---` fence, so a caller- or template-supplied fence always wins and is never double-wrapped. Appends never touch frontmatter, and the adapter never rewrites existing notes - Templater syntax and Dataview blocks in a real vault pass through untouched. On the read side, `search` and `list_recent` build their SNIPPETS from the frontmatter-stripped body (no more YAML noise at the top of every hit), while matching still runs against the full text so a query that hits only a tag still finds the note (scored 0.5, below a body match). `read_doc` always returns the raw file verbatim. Stripping only happens when the note starts with a `---` line and a closing `---`/`...` line exists (Obsidian's own definition); an unterminated fence is returned unchanged rather than guessed at.
+
+**Daily notes** follow the Daily Notes plugin's default `YYYY-MM-DD.md` convention. `second_brain.obsidian.daily_notes_dir` names the folder the plugin is configured to use (unset = vault root). Two helpers on `ObsidianNotes`:
+
+- `daily_note_id(day=None)` - the doc id for a given date (default today, local time), e.g. `Journal/Daily/2026-07-21.md`.
+- `append_to_daily_note(content, day=None)` - append to the daily note, creating it first (with frontmatter, when enabled) if it does not exist yet. Returns the doc id. This is the call briefing and daily-log writers should use - they cannot know whether today's note exists.
+
+Custom plugin date formats (anything other than `YYYY-MM-DD`) are not supported - that is a Phase 2 config key if an install needs it.
 
 `${VAR}` references resolve against `os.environ` at import time; chassis bootstrap loads `.env` before any plugin imports the adapter.
 
@@ -236,13 +255,14 @@ The `NotesAdapter` and `DatabaseAdapter` Protocols live in `chassis/second_brain
 - Raise the appropriate adapter-error subclass (e.g. `SiYuanError`, `NotionError`) on backend failures, not bare `Exception`.
 - Return real ids / urls — never empty strings on success.
 - Treat empty `parent` in `create_doc` as a signal to use the configured default (`notes_root` for Notion, hpath="/" for SiYuan).
-- Truncate single-line content over the backend's hard limit (Notion: 2000 chars per text block) rather than failing.
+- Survive content over the backend's hard limits rather than failing: Notion splits >2000-char lines across rich_text parts and chunks >100-block documents across sequential requests. Truncation is a last resort reserved for pathological input (a single line over 200k chars).
 
 The `SearchHit` dataclass is the canonical return shape for both `notes.search` and `database.query`. Adapters MAY put backend-specific extras under `raw` for callers that need them.
 
 ## V1 caveats
 
 - **No simultaneous writes.** One backend per install. Migration tools (e.g. SiYuan→Notion bulk migration for an installer who switches) are V2.
+- **Notion `read_doc` returns the first 100 blocks only.** Chunked writes mean pages can now exceed 100 blocks, but `read_doc` still fetches a single unpaginated children page. Paginated + recursive read is Phase 2; until then a briefing written in 3 chunks reads back truncated.
 - **Markdown↔block fidelity is paragraph-only in Notion adapter V1.** Headings + lists are read out cleanly but `create_doc` writes everything as paragraph blocks. Heading/list parsing is a follow-up — current <v1-reference-install> briefings render as plain prose in SiYuan, so feature-parity is preserved.
 - **Notion `database.query` filters are `equals`-only on rich_text properties.** Numeric/date filters land in the follow-up; the natural-key upsert flow only needs equality.
 - **Notion property type inference is heuristic.** For exact schema fidelity, callers can pass already-shaped Notion property dicts under the `_raw_properties` key (passes through verbatim).


### PR DESCRIPTION
Phase 1 hardening of the Notion and Obsidian second-brain adapters. Four work items, all landed; nothing out-of-scope built.

## 1. Notion large-document writes (the confirmed break)

Notion caps block children at 100 per request. `create_doc`/`append_to_doc` sent `_markdown_to_blocks(body)` unchunked, so any document over ~100 non-empty lines - every morning briefing - was an opaque HTTP 400.

- `create_doc` sends the first 100 blocks with the page create, then appends the rest in sequential 100-block PATCH chunks. `append_to_doc` chunks identically. Sequential on purpose: parallel appends would interleave chunks.
- Lines over 2000 chars now split across multiple `rich_text` parts inside one paragraph (Notion's per-field cap) instead of being silently truncated. Capped at 100 parts per block (Notion's other ceiling); beyond 200k chars in one line truncates.
- **Partial-write semantics:** chunked writes are not atomic and this PR does not pretend otherwise. On mid-chunk failure the adapter leaves partial content in place (a rollback delete can itself fail, and an append cannot tell its own blocks from pre-existing ones) and raises `NotionPartialWriteError` - a `NotionError` subclass carrying `doc_id`, `chunks_written`, `chunks_total`, message stating exactly how many chunks landed and warning against blindly re-sending the full body.

## 2. Notion rate limiting

`_request` retries HTTP 429 up to 5 times, honouring `Retry-After` (seconds or HTTP-date form, capped at 30s per sleep, linear backoff fallback when the header is absent), then fails with an error naming the attempt count.

**Double-write conclusion:** only 429 is retried. Notion's limiter rejects a request before executing it, so a retried append after a 429 cannot double-write. 5xx and network errors are deliberately NOT retried - there the write may have been applied before the failure surfaced, and a blind retry duplicates content.

## 3. Obsidian frontmatter

- Opt-in emit on `create_doc` via `second_brain.obsidian.frontmatter: true` + `frontmatter_tags` (YAML list under PyYAML, comma-separated string under the minimal fallback parser - which cannot represent lists). Emits `created` (local ISO-8601) + tags.
- Never emitted when the body already starts with a `---` fence (caller/template wins, no double-wrapping); appends never touch frontmatter; existing notes are never rewritten - Templater and Dataview content passes through byte-identical (test-asserted).
- `search`/`list_recent` snippets are built from the frontmatter-stripped body; matching still runs against full text so a tag-only hit survives (scored 0.5, below body matches). `read_doc` stays verbatim. Stripping requires a properly opened AND closed fence; unterminated fences are returned unchanged rather than guessed at.

## 4. Obsidian daily notes

- New config key `second_brain.obsidian.daily_notes_dir`, resolved in `factory.py` following the existing pattern.
- `daily_note_id(day=None)` and `append_to_daily_note(content, day=None)` on `ObsidianNotes` - the latter folds in the create-if-absent seam, since briefing/daily-log writers cannot know whether today's note exists. Default `YYYY-MM-DD.md` convention only; custom plugin date formats are Phase 2.

## Verification

Test-verified (mocked HTTP, CI-matching venv: pytest + pyyaml + mcp==1.28.1, Python 3.14 locally / 3.12 in CI):
- Full suite: **299 passed, 4 skipped** (the skips are the opt-in live Notion tests when creds are absent).
- The chunking tests assert the >100-block case explicitly: 250 lines -> 1 create with 100 children + PATCH x100 + PATCH x50, order preserved; partial-failure tests assert `chunks_written`/`chunks_total` and the "2 of 3" message.
- 429 tests assert Retry-After honoured (7s then 2s then success), backoff fallback, 30s cap on absurd headers, exhaustion message with attempt count, and that 500/URLError get exactly one attempt.

Live-verified against the real Notion API (workspace from the `notion-adapter-test` Vaultwarden item):
- **Pre-fix bug reproduced live:** unchunked 120-block create -> `HTTP 400: body.children.length should be <= 100, instead was 120`.
- **Fix verified live:** `LiveNotionTestCase` all 4 pass, including the new `test_chunked_create_over_100_blocks_live` (120-line create, readback confirms content) - `4 passed in 8.02s`.
- 4500-char single line created live and read back byte-identical (`roundtrip intact: True len: 4500`).

Real-surface-verified for Obsidian (direct file IO IS the real surface): drove a throwaway on-disk vault end to end - frontmatter emit, daily-note create-then-append, snippet stripping, frontmatter-only tag match, and a Templater/Dataview note read back byte-identical.

Not verified: adapter-mode MCP server behavior with these changes on a running install (no config/interface changes to `mcp_server.py`, so none expected), and Notion behavior under a genuine sustained 3 rps+ storm (the live tests never tripped a real 429).

## Description vs reality

- The description said long paragraphs "need splitting too" - correct, and the previous code was silently truncating at 2000 chars, so this was a data-loss bug as well as a 400 risk.
- No hard blockers found with chunking; the file-upload alternative was not needed.
- One adjacent honesty note added to docs: `read_doc` still fetches only the first 100 blocks, so a 3-chunk briefing reads back truncated. Paginated read is explicitly Phase 2 per the task's out-of-scope list, so it was documented, not built.

## Not touched

`chassis/scripts/_env.sh`, `docker/entrypoint.sh`, `Dockerfile`, and `chassis/CHANGELOG.md` are being edited concurrently on another branch, so this PR deliberately leaves them alone. The CHANGELOG entry and any VERSION bump for this change are left for merge time - Sean decides the bump per chassis convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
