### PR TITLE
docs(dating): remove real names and installer-identifying references from the public plugin

### DIFF
--- a/docs/plugins/dating.md
+++ b/docs/plugins/dating.md
@@ -93,12 +93,12 @@ Three things must be in place before enabling:
 - **Android emulator** — a host GUI process (Android Studio / qemu), screen-attached, with adb-server listening on host:5037. The chassis container has no display, no adb-server, and can only reach the host's adb via a `tcp:host.docker.internal:5037` bridge — which gets the emulator state but not the rest of the stack.
 - **Playwright + Chromium** — Tinder runs through the Playwright web flow with a persistent browser profile. Bundling Chromium-on-arm64 into the chassis image is ~600MB of additional bloat for a single plugin.
 - **CLIP scorer + taste-refs / negative-refs** — the calibration engine (`scripts/score-calibrate.py`, `scripts/dating-reconcile.py`) reads / writes large ML model caches + reference image directories that live on the host filesystem.
-- **Sean's `~/Desktop/dating-swipes/seans-picks/` feedback loop** — installer hand-sorts screenshots into like/super-like/pass folders. The subagent reads those folders to update calibration. Mounting `~/Desktop` into the container would be a security-model regression.
-- **dating-context subagent skill bundle** — the cwd loads its own CLAUDE.md + skill files + sean-facts.md from the host's dating-context directory tree.
+- **The installer's hand-sorted picks feedback loop** (`${CHASSIS_HOME}/rhl-picks/` by default) - the installer sorts screenshots into like/super-like/pass folders and the subagent reads them to update calibration. Mounting a folder from the installer's host home directory into the container would be a security-model regression.
+- **dating-context subagent skill bundle** - the cwd loads its own CLAUDE.md + skill files + installer-facts.md from the host's dating-context directory tree.
 
 The chassis-runtime "everything in a container heartbeat" path doesn't fit. Dating is the canonical "fat-client plugin" tier: schedule via host launchd, fire `claude -p` against the dating subagent's cwd, let it use Keychain auth + full host filesystem. The dispatcher's other heartbeats stay in-container.
 
-Reference install (scrollinondubs/new-jaxity, post-2026-05-25 cutover):
+Reference install (<v1-reference-install>, post-2026-05-25 cutover):
 - `scheduled-tasks/com.<assistant>.dating-swipe-{1,2,3}.plist` — launchd plists fire 10:00 / 14:00 / 18:00 local.
 - `scripts/dating-swipe-host.sh` — wrapper script: 0-30 min random jitter (preserves the chassis dispatcher's anti-detection profile), `gather-dating-swipe.sh` gate, then `claude -p --max-budget-usd 6` with the dating-swipe-prompt against the dating-context cwd.
 - HEARTBEATS.md keeps the dating-swipe-N blocks HTML-commented (so the reconciler doesn't false-positive on staleness) with an inline pointer to the host launchd jobs.
@@ -187,8 +187,8 @@ The plugin extracts the architectural pattern only — installer-personal data f
 - The V1 installer's specific Hinge profile, voice prompt, age, height, neighborhood, character preferences, vision board photos
 - Specific city venues, GPS coords, neighborhood rotation lists
 - Hard-coded Discord channel IDs (replaced with `${SOCIAL_CHANNEL_ID}` placeholder)
-- Memory entries from the V1 install (lead:darina, lead:eva, etc.)
-- Specific match incidents (Eva catfish, Jacqueline catfish, Whitney GO DARK, etc.)
+- Memory entries from the V1 install (the per-match `lead:` entities and their observation history)
+- Specific match incidents from the V1 install (confirmed-catfish cases where a photo set reverse-imaged to an unrelated person, matches marked GO DARK, and the rest of the per-match history)
 - The local CLIP face scorer + taste references (installer must build their own at install time — face-aesthetic preference is fundamentally per-installer)
 
 Each installer authors their own `installer-facts.md`, builds their own taste references if they enable the face scorer, and accumulates their own pending-instructions / cleared-matches state over time.

--- a/plugins/dating/scripts/_dating_db.py
+++ b/plugins/dating/scripts/_dating_db.py
@@ -4,7 +4,7 @@
 Ported from <v1-reference-install> PR #522. Chassis adaptations vs <v1-reference-install> source:
   - imports _chassis_db from plugins/dating/scripts/ (not from scripts/)
   - BEHALFBOT_PG_DSN env var used by _chassis_db (CHASSIS_PG_DSN accepted as V1-compat alias)
-  - No Sean-specific data; installer-neutral
+  - No installer-specific personal data; installer-neutral
 
 Public API
 ----------

--- a/plugins/dating/scripts/dating-reconcile.py
+++ b/plugins/dating/scripts/dating-reconcile.py
@@ -10,7 +10,7 @@ to `logs/dating/accuracy.jsonl`.
 Ported from <v1-reference-install> PR #534. Chassis adaptations vs <v1-reference-install> source:
   - CHASSIS_HOME env var used instead of $CHASSIS_HOME hardcoded root
   - RHL picks dir: ${CHASSIS_HOME}/rhl-picks/{like,super-like,pass,no-opinion}/
-    (installer-agnostic; <v1-reference-install> used ~/Desktop/dating-swipes/seans-picks/)
+    (installer-agnostic; the V1 reference install used a hand-sorted folder on the host Desktop)
   - TASTE_CALIBRATE + CLIP_VENV resolved relative to CHASSIS_HOME
 
 Filename contract (set by the swipe subagent at screenshot time):

--- a/plugins/dating/scripts/dating-swipe-host.sh
+++ b/plugins/dating/scripts/dating-swipe-host.sh
@@ -6,12 +6,12 @@
 #   - Android emulator (host process, screen-bound, adb-server on host:5037)
 #   - Playwright + Chromium for the Tinder web flow
 #   - CLIP scorer + taste-refs / negative-refs (ML model cache + host fs)
-#   - ~/Desktop/dating-swipes/seans-picks/{like,super-like,pass}/ feedback loop
+#   - the installer's hand-sorted picks feedback loop (rhl-picks/{like,super-like,pass}/)
 #   - dating-context subagent skill bundle under ${CHASSIS_HOME}/dating-context/
 #
 # Moving the whole stack into the chassis container would require shipping
 # Playwright + Chromium-on-arm64, headless emulator, host bind mounts for
-# Sean's Desktop, and substantial Dockerfile bloat. Today's host-launchd path
+# the installer's home directory, and substantial Dockerfile bloat. Today's host-launchd path
 # matches the V1 pattern + keeps the chassis runtime clean for installers
 # that don't run dating.
 #
@@ -34,7 +34,7 @@
 # Pause flags: the prompt itself reads HARD_PAUSE / SOFT_PAUSE flags from
 # dating-context/, so we don't need to short-circuit here.
 #
-# See: <v1-reference-install>#698 follow-up + Sean's #<primary> decision to run
+# See: <v1-reference-install>#698 follow-up + the installer's #<primary> decision to run
 # dating-stack host-side as a V1-pattern fat-client plugin.
 
 set -uo pipefail

--- a/plugins/dating/scripts/install-dating-swipe-plists.sh
+++ b/plugins/dating/scripts/install-dating-swipe-plists.sh
@@ -9,7 +9,7 @@
 # Why this exists instead of static plists in the plugin: launchd plists
 # embed absolute paths (PATH, WorkingDirectory, ProgramArguments). Those
 # paths are install-specific. Shipping concrete plists in the chassis
-# subtree would either bake one installer's paths in (Sean's) or punt
+# subtree would either bake one installer's paths in or punt
 # the path-resolution to the installer manually. This templater is the
 # clean middle: chassis ships the SHAPE + placeholder names; each
 # installer runs this script once at activation time and the resulting
@@ -46,7 +46,7 @@
 set -uo pipefail
 
 : "${CHASSIS_HOME:?CHASSIS_HOME must be exported (install root)}"
-: "${INSTALLER_LABEL:?INSTALLER_LABEL must be exported (e.g. com.<v1-reference-install>, com.benlakoff, etc.)}"
+: "${INSTALLER_LABEL:?INSTALLER_LABEL must be exported (e.g. com.<v1-reference-install>, com.<installer-name>, etc.)}"
 
 # Auto-detect optional env.
 if [[ -z "${HOMEBREW_PREFIX:-}" ]]; then
@@ -75,9 +75,9 @@ mkdir -p "$LAUNCHAGENTS_DIR"
 DRY_RUN=0
 [[ "${1:-}" == "--dry-run" ]] && DRY_RUN=1
 
-# Slot-to-hour mapping. Reference install ran 10:00 / 14:00 / 18:00 since
-# Sean's 2026-05-18 directive (#<primary> msg 1506002918736924703). Adjust here
-# if the installer wants different anchors — re-run the script after.
+# Slot-to-hour mapping. Reference install ran 10:00 / 14:00 / 18:00 per the
+# installer's standing directive. Adjust here if the installer wants
+# different anchors - re-run the script after.
 # Plain `case` keeps the script bash-3.2 compatible (macOS default).
 slot_to_hour() {
     case "$1" in

--- a/plugins/dating/scripts/verify-match.py
+++ b/plugins/dating/scripts/verify-match.py
@@ -46,8 +46,8 @@ Catfish keyword markers (in site titles):
 
 High-suspicion domains (direct hit → RED):
     onlyfans.com, leakedmodels.com, thothub.tv, aznude.com, wikifeet.com,
-    bellazon.com, fapello.com, plus Russian / Eastern-European escort
-    aggregators. Match is exact-or-subdomain.
+    bellazon.com, fapello.com, plus known escort-directory and
+    catfish-marketplace aggregators. Match is exact-or-subdomain.
 
 Low-suspicion filter (excluded from "distinct names" count):
     bbc.com, freepik.com, pinterest.com, xwhos.com, toolify.ai,
@@ -102,7 +102,8 @@ HIGH_SUSPICION_DOMAINS = (
     "aznude.com", "wikifeet.com", "bellazon.com", "thothd.com",
     "adultgallery.com", "fapello.com", "thotvideos.com", "scoreland.com",
     "yespornpics.com", "pornpics.com", "sxyprn.com", "eroticbeauties.net",
-    # Russian / Eastern-European catfish-marketplace + escort aggregators
+    # Escort-directory + catfish-marketplace aggregators where stolen photo
+    # sets recirculate
     "rusescort.com", "putana.org", "escort-russia.com",
 )
 LOW_SUSPICION_DOMAINS = (
@@ -119,7 +120,7 @@ LOW_SUSPICION_DOMAINS = (
     "imdb.com", "xwhos.com", "themoviedb.org",
     # Tech tutorials / blog content
     "toolify.ai", "iphonephotographyschool.com", "caraqu.com",
-    # Russian shopping / general e-commerce (false positives we hit a lot)
+    # General e-commerce (frequent visual-similarity false positives)
     "usadostavka.ru", "ozon.ru", "wildberries.ru",
 )
 # Stop-words and noise patterns we strip before counting "distinct names".
@@ -967,7 +968,7 @@ def run_verification(name: str, platform: str, photos: list[Path], output_root: 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Verify a dating-match profile photo via reverse image search.")
-    parser.add_argument("--name", required=True, help="Match's first name (e.g. 'Eva')")
+    parser.add_argument("--name", required=True, help="Match's first name (e.g. 'Jane')")
     parser.add_argument("--platform", required=True, help="Dating platform (tinder/hinge/bumble)")
     parser.add_argument("--photo", help="Path to a single profile photo")
     parser.add_argument("--photos", nargs="+", help="Paths to multiple profile photos (uses first as primary)")


### PR DESCRIPTION
## What changed

Follow-up to #99. That PR removed the nationality-screening defaults; this one removes the personally identifying content that remained in the public dating plugin. #99 merged before this branch was cut, so this branch includes it and there is no conflict.

**1. Real names attached to accusations (docs/plugins/dating.md)**
- `lead:darina, lead:eva, etc.` -> "the per-match \`lead:\` entities and their observation history"
- `Eva catfish, Jacqueline catfish, Whitney GO DARK, etc.` -> "confirmed-catfish cases where a photo set reverse-imaged to an unrelated person, matches marked GO DARK, and the rest of the per-match history" - the incident class is preserved, the identities are not, and no substitute names are used

**2. Installer identity (docs/plugins/dating.md)**
- `Sean's ~/Desktop/dating-swipes/seans-picks/` -> the installer's hand-sorted picks loop at `${CHASSIS_HOME}/rhl-picks/` (the path the shipped code actually reads)
- `sean-facts.md` -> `installer-facts.md` (matches the shipped template name)
- `scrollinondubs/new-jaxity` -> `<v1-reference-install>`, consistent with the rest of the repo

**3. Script comments (comments only - zero behaviour change)**
- `dating-swipe-host.sh`: `seans-picks` feedback-loop line, "Sean's Desktop", "Sean's #<primary> decision" -> installer-neutral wording
- `install-dating-swipe-plists.sh`: "(Sean's)", "Sean's 2026-05-18 directive (#<primary> msg 1506002918736924703)" -> installer-neutral wording, directive date and Discord message id dropped; example launchd label `com.benlakoff` (a real person, found in the sweep) -> `com.<installer-name>`
- `dating-reconcile.py` docstring: `seans-picks` path -> "a hand-sorted folder on the host Desktop"
- `_dating_db.py` docstring: "No Sean-specific data" -> "No installer-specific personal data"

**4. verify-match.py**
- "Russian / Eastern-European escort aggregators" comments (docstring + `HIGH_SUSPICION_DOMAINS`) reworded behaviourally: "escort-directory and catfish-marketplace aggregators where stolen photo sets recirculate". The domain lists themselves are unchanged - they are a legitimate adult-aggregator signal.
- `LOW_SUSPICION_DOMAINS` comment "Russian shopping / general e-commerce" -> "General e-commerce (frequent visual-similarity false positives)"
- CLI help example `'Eva'` (matches a real incident) -> `'Jane'`

## About `seans-picks`

It appears ONLY in comments and docstrings. The live code path is `${CHASSIS_HOME}/rhl-picks/` (`RHL_PICKS_ROOT` in `dating-reconcile.py`); no script references `seans-picks` as a path literal. So this PR fixes prose only - no path was renamed, no configurability added, no behaviour change.

## Deliberately NOT changed

- `pimeyes_russian_internet_only_presence` in `openclaw.plugin.json` + `CLAUDE.md` - #99's deprecated back-compat alias, kept on purpose
- `score-face.py` POS/NEG_PROMPTS - separate decision pending
- "Lisbon" in `skills/dating.md` location-dodge examples ("Lisbon" / "London" / "Berlin") - generic example-city list
- Dated operational notes not tied to a person ("post-2026-05-25 cutover", the 2026-05-25 SLOT-misfire note in `dating-swipe-host.sh`)

## Verification

- `python3 -m py_compile` clean on `verify-match.py`, `_dating_db.py`, `dating-reconcile.py`
- `bash -n` clean on `dating-swipe-host.sh`, `install-dating-swipe-plists.sh`
- Final grep for `sean|eva|jacqueline|whitney|darina|nadya|benlakoff|seans-picks|scrollinondubs/new-jaxity` across `docs/plugins/dating.md` + `plugins/dating/` returns only `model.eval()` calls, the `escort-russia.com` domain literal, and #99's deprecated config-key alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)