### PR TITLE
fix(update): stop chassis-update.sh silently reverting compose overrides (#100)

### DIFF
--- a/chassis/CHANGELOG.md
+++ b/chassis/CHANGELOG.md
@@ -16,6 +16,19 @@ Semver:
 - `MINOR` (`0.3.0` → `0.4.0`): new features, optional fields, opt-in behaviors. Backwards-compatible.
 - `PATCH` (`0.3.1` → `0.3.2`): fixes, prompt tweaks, internal refactors. Always backwards-compatible.
 
+## Unreleased
+
+### Fixed
+
+- **`chassis-update.sh` no longer silently reverts customer compose overrides (#100).** The updater brought the stack back with bare `docker compose pull` + `docker compose up -d`, dropping the per-install override (published ports, image pins, env_file, scaled-to-0 services) and then reporting success - its healthcheck polls the chassis container over the internal network and cannot see published ports. On the install that surfaced this, the update unpublished postgres's `127.0.0.1:5432` (breaking every host-side consumer and triggering a watchdog VM bounce mid-update) and created a fresh empty Vaultwarden the override scales to 0. Now:
+  - All updater compose calls (`pull`, `up -d`, and the rollback path's recovery `up`) route through `compose.sh`, which layers the override and hard-errors when the file it was told to use is missing. Installs that never had an override keep the exact legacy bare invocation, with a warning; the updater never creates an override on its own.
+  - Pre-flight refuses to update when the running stack's containers were built with an override that no longer exists on disk (read from the engine's `com.docker.compose.project.config_files` label), before the pull mutates anything.
+  - A new post-update verification step (`_compose-verify.sh`, exercised by `test-compose-verify.sh` against real containers) checks the docker engine against the merged `docker compose config`: every declared published port must be bound, every scaled-to-0 service must be down, and the chassis container's `config_files` label must include the override. With an override in play, a mismatch fails the update and rolls back; container-healthy is no longer treated as install-healthy.
+  - The effective merged config is snapshotted before and after the update (`state/chassis-update/compose-config-{pre,post}.yaml`, chmod 600 - it contains interpolated secrets) and a diff is reported when it changes, so drift leaves evidence.
+  - Migration scripts now resolve relative to the running script like `VERSION` does; the old `${CHASSIS_HOME}/chassis/scripts/...` literal only existed in canonical-clone mode, so vendored-subtree installs silently skipped every migration.
+
+**Migration:** `scripts/chassis-migrations/v0.3.0.sh`. Deliberately keyed to v0.3.0: an install upgrading TO v0.3.0 executes its OLD, pre-fix copy of the updater, whose bare `up -d` strips the override one last time. The old updater then runs this migration from the freshly pulled tree; it re-runs the stack through `compose.sh` and verifies published ports and scaled-to-0 services, repairing the stack within the same update run. No-override and host-mode installs: no-op.
+
 ## v0.3.0 - 2026-07-21
 
 The release that makes v0.2.0 real. The plugin fetcher shipped in v0.2.0 downloaded and verified a plugin tree that the chassis then never used; this release makes the fetched tree actually take effect, as an overlay rather than a swap. Also hardens the Notion and Obsidian second-brain adapters to the point where full-length documents survive a round trip, and removes nationality-based screening from the public dating plugin.

--- a/chassis/scripts/_compose-verify.sh
+++ b/chassis/scripts/_compose-verify.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# _compose-verify.sh - verify that a merged compose config is what the docker
+# engine is actually running.
+#
+# Sourced, never executed. Used by chassis-update.sh (post-update verification)
+# and chassis-migrations/v0.3.0.sh (post-repair verification). Exercised by
+# test-compose-verify.sh against a real scratch compose project.
+#
+# Why this exists (behalfbot#100)
+# ===============================
+# chassis-update.sh used to bring the stack back with bare `docker compose
+# up -d`, silently dropping the per-install override - published ports, image
+# pins, scaled-to-0 services. Its healthcheck polled the chassis container,
+# which stays healthy over the internal compose network and never touches a
+# published port, so every check that existed reported success on a broken
+# install. Container-healthy is not install-healthy.
+#
+# These helpers check the things the override actually changes, against the
+# MERGED config (`docker compose config --format json` over the chassis file
+# plus the override):
+#
+#   1. every fixed host port the merged config declares is actually published
+#      by a running container of that service
+#   2. every service the merged config scales to 0 has NO running container
+#   3. (separately callable) the chassis container's compose config_files
+#      label includes the override file - the engine's own record that the
+#      stack was built with the override layered in
+#
+# Contract: verification functions print human-readable "VERIFY-FAIL: ..."
+# lines to stdout and return 0 only when the running state matches the config.
+# They never mutate anything. jq is required - chassis-update.sh already
+# depends on it.
+#
+# Containers are located via compose's own labels
+# (com.docker.compose.project + com.docker.compose.service) rather than by
+# replaying -f flags, so the same functions work whether the stack was brought
+# up through compose.sh or bare compose. The project name is read from the
+# merged config's top-level `name:` field, which compose resolves the same way
+# `up` does (-p flag beats the yaml `name:` field beats the directory name).
+
+# Print "service|target|published|host_ip|protocol" lines for every fixed
+# published port in a merged config JSON document ($1 = path). Services scaled
+# to 0 are skipped (nothing should be running, let alone publishing). Port
+# entries without a fixed published port are skipped - ephemeral host ports
+# are allocated by the engine and cannot be asserted.
+compose_expected_ports() {
+    local config_json="$1"
+    jq -r '
+        .services | to_entries[]
+        | select(((.value.deploy.replicas // 1) | tonumber) > 0)
+        | .key as $svc
+        | (.value.ports // [])[]
+        | select(.published != null and .published != "")
+        | [$svc, (.target | tostring), (.published | tostring),
+           (.host_ip // ""), (.protocol // "tcp")]
+        | join("|")
+    ' "$config_json"
+}
+
+# Print the name of every service the merged config scales to zero.
+compose_zero_replica_services() {
+    local config_json="$1"
+    jq -r '
+        .services | to_entries[]
+        | select(((.value.deploy.replicas // 1) | tonumber) == 0)
+        | .key
+    ' "$config_json"
+}
+
+# Running container ids for a compose (project, service) pair.
+compose_service_containers() {
+    local project="$1" service="$2"
+    docker ps -q \
+        --filter "label=com.docker.compose.project=${project}" \
+        --filter "label=com.docker.compose.service=${service}" 2>/dev/null
+}
+
+# Verify the running state against a merged config JSON document ($1 = path).
+# Returns 0 when every declared published port is bound and every scaled-to-0
+# service is down; otherwise prints VERIFY-FAIL lines and returns 1.
+compose_verify_running_config() {
+    local config_json="$1"
+    local project fail=0 svc target published host_ip proto cids cid bound ok
+
+    project=$(jq -r '.name // empty' "$config_json")
+    if [[ -z "$project" ]]; then
+        echo "VERIFY-FAIL: merged compose config has no project name; cannot locate containers"
+        return 1
+    fi
+
+    while IFS='|' read -r svc target published host_ip proto; do
+        [[ -z "$svc" ]] && continue
+        cids=$(compose_service_containers "$project" "$svc")
+        if [[ -z "$cids" ]]; then
+            echo "VERIFY-FAIL: service '$svc' declares published port ${published}->${target}/${proto} but has no running container (project '$project')"
+            fail=1
+            continue
+        fi
+        ok=0
+        for cid in $cids; do
+            bound=$(docker port "$cid" "${target}/${proto}" 2>/dev/null)
+            if [[ -n "$host_ip" && "$host_ip" != "0.0.0.0" ]]; then
+                grep -q "^${host_ip}:${published}\$" <<<"$bound" && ok=1
+            else
+                grep -q ":${published}\$" <<<"$bound" && ok=1
+            fi
+        done
+        if [[ $ok -eq 0 ]]; then
+            echo "VERIFY-FAIL: service '$svc' should publish ${host_ip:+${host_ip}:}${published}->${target}/${proto} but no running container of it does"
+            fail=1
+        fi
+    done < <(compose_expected_ports "$config_json")
+
+    while read -r svc; do
+        [[ -z "$svc" ]] && continue
+        cids=$(compose_service_containers "$project" "$svc")
+        if [[ -n "$cids" ]]; then
+            echo "VERIFY-FAIL: service '$svc' is scaled to 0 in the merged config but is running: $(tr '\n' ' ' <<<"$cids")"
+            fail=1
+        fi
+    done < <(compose_zero_replica_services "$config_json")
+
+    return $fail
+}
+
+# Check that a service's container carries the override file in its
+# com.docker.compose.project.config_files label - the engine's own record of
+# which -f files built the stack the container belongs to.
+#
+# $1 = project name, $2 = override file path, $3 = service name (default
+# "chassis"). Returns 0 when present, 1 when the label exists without the
+# override (the #100 failure shape), 2 when there is no running container to
+# inspect (caller decides what that means - the updater's version healthcheck
+# has already established the container is up by the time this runs).
+#
+# Both the literal path and its physical (symlink-resolved) form are accepted:
+# compose records the -f argument as given, and CUSTOMER_HOME is commonly
+# reached through a symlink.
+compose_override_in_config_files() {
+    local project="$1" override="$2" service="${3:-chassis}"
+    local cid label real
+
+    cid=$(compose_service_containers "$project" "$service" | head -1)
+    [[ -z "$cid" ]] && return 2
+
+    label=$(docker inspect "$cid" \
+        --format '{{ index .Config.Labels "com.docker.compose.project.config_files" }}' 2>/dev/null)
+    real="$(cd "$(dirname "$override")" 2>/dev/null && pwd -P)/$(basename "$override")"
+
+    case ",${label}," in
+        *",${override},"* | *",${real},"*) return 0 ;;
+    esac
+    return 1
+}

--- a/chassis/scripts/chassis-migrations/v0.3.0.sh
+++ b/chassis/scripts/chassis-migrations/v0.3.0.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# v0.3.0.sh - re-assert the per-install compose override after the update.
+#
+# Why (behalfbot#100): every chassis-update.sh BEFORE the fix in this tree
+# brought the stack back with bare `docker compose pull` + `docker compose
+# up -d`, silently dropping the per-install override
+# ($CUSTOMER_HOME/chassis-compose.override.yml - image pins, published ports,
+# env_file, scaled-to-0 services) and then reporting success.
+#
+# An install upgrading TO v0.3.0 runs its OLD copy of the updater: the update
+# pulls the new tree to disk, but the process executing is still the pre-fix
+# script, so its `up -d` is the bare, override-stripping one. This migration
+# is the repair channel for exactly that window: the old updater's step 8
+# runs `chassis-migrations/v0.3.0.sh` FROM THE FRESHLY PULLED TREE, after its
+# bare `up -d` and healthcheck. We re-run the stack through compose.sh (which
+# layers the override) and then verify the result against the merged config.
+#
+# On the install that motivated this, the bare `up -d` unpublished postgres's
+# 127.0.0.1:5432 (breaking every host-side consumer and triggering a watchdog
+# VM bounce) and created a fresh empty Vaultwarden that the override scales to
+# 0. `compose.sh up -d` reconciles both: compose recreates services whose
+# config drifted and scales replicas-0 services down.
+#
+# No-override installs: exit 0 without touching anything - bare compose was
+# already the correct invocation for them. Host-mode installs (no docker or
+# no compose file): nothing was containerized, exit 0.
+#
+# Idempotent: re-running against an already-correct stack is a no-op `up -d`
+# plus a passing verification.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_SH="${SCRIPT_DIR}/../compose.sh"
+VERIFY_LIB="${SCRIPT_DIR}/../_compose-verify.sh"
+
+log() { printf '[migrate-v0.3.0] %s\n' "$*"; }
+
+# CUSTOMER_HOME resolution, explicit rather than via _env.sh: the pre-fix
+# updater keeps CUSTOMER_HOME as a shell variable and does not export it to
+# migrations, and _env.sh's legacy fallback (CUSTOMER_HOME := CHASSIS_HOME)
+# points at the chassis CLONE on new-layout installs - which has no override,
+# so this repair would silently no-op on exactly the installs it exists for.
+# Prefer whichever layout actually holds an override file.
+if [[ -z "${CUSTOMER_HOME:-}" ]]; then
+    if [[ -f "$HOME/.behalfbot/chassis-compose.override.yml" ]]; then
+        CUSTOMER_HOME="$HOME/.behalfbot"
+    elif [[ -n "${CHASSIS_HOME:-}" && -f "$CHASSIS_HOME/chassis-compose.override.yml" ]]; then
+        # Legacy co-located install: customer state lives in the chassis tree.
+        CUSTOMER_HOME="$CHASSIS_HOME"
+    elif [[ -d "$HOME/.behalfbot" ]]; then
+        CUSTOMER_HOME="$HOME/.behalfbot"
+    fi
+fi
+
+if [[ -z "${CUSTOMER_HOME:-}" ]]; then
+    log "CUSTOMER_HOME could not be resolved; nothing to repair"
+    exit 0
+fi
+
+# Mirror compose.sh's override semantics: ${VAR-} (no colon) so an explicitly
+# empty CHASSIS_COMPOSE_OVERRIDE (deliberate no-override, chassis dev /
+# smoke-test) is distinguishable from unset (use the default path).
+OVERRIDE_FILE="${CHASSIS_COMPOSE_OVERRIDE-${CUSTOMER_HOME}/chassis-compose.override.yml}"
+if [[ -z "$OVERRIDE_FILE" ]]; then
+    log "CHASSIS_COMPOSE_OVERRIDE explicitly empty - no override to re-assert"
+    exit 0
+fi
+if [[ ! -f "$OVERRIDE_FILE" ]]; then
+    log "no compose override at $OVERRIDE_FILE - default install, bare compose was correct, nothing to repair"
+    exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+    log "docker compose not available - host-mode install, nothing to repair"
+    exit 0
+fi
+
+if [[ ! -f "$COMPOSE_SH" ]]; then
+    log "FATAL: $COMPOSE_SH missing from the pulled tree - cannot re-assert the override"
+    log "FATAL: manual recovery: bash <chassis-repo>/chassis/scripts/compose.sh up -d"
+    exit 1
+fi
+
+export CUSTOMER_HOME
+log "re-running the stack through compose.sh so $OVERRIDE_FILE applies"
+if ! bash "$COMPOSE_SH" up -d; then
+    log "FATAL: compose.sh up -d failed - the stack may still be running WITHOUT the override"
+    log "FATAL: fix the error above, then run: bash $COMPOSE_SH up -d"
+    exit 1
+fi
+
+# Verify, don't assume: the whole point of #100 is that "the command ran" is
+# not evidence. Check the engine against the merged config.
+# shellcheck source=chassis/scripts/_compose-verify.sh
+source "$VERIFY_LIB" || { log "FATAL: $VERIFY_LIB missing from the pulled tree"; exit 1; }
+
+CONFIG_JSON="$(mktemp)"
+trap 'rm -f "$CONFIG_JSON"' EXIT
+if ! bash "$COMPOSE_SH" config --format json > "$CONFIG_JSON" || [[ ! -s "$CONFIG_JSON" ]]; then
+    log "FATAL: could not render the merged compose config for verification"
+    exit 1
+fi
+
+if verify_out=$(compose_verify_running_config "$CONFIG_JSON"); then
+    log "override re-asserted and verified: declared ports published, scaled-to-0 services down"
+    exit 0
+fi
+
+while IFS= read -r line; do log "$line"; done <<<"$verify_out"
+log "FATAL: running stack still does not match the merged compose config after compose.sh up -d"
+log "FATAL: manual recovery: bash $COMPOSE_SH up -d && docker ps"
+exit 1

--- a/chassis/scripts/chassis-update.sh
+++ b/chassis/scripts/chassis-update.sh
@@ -5,13 +5,17 @@
 #
 # Idempotent script that updates the chassis to upstream main:
 #   1. Pre-flight (clean working tree)
-#   2. Snapshot pre-update state
+#   2. Snapshot pre-update state + effective compose config
 #   3. Drain in-flight heartbeats (state file lock)
 #   4. Pull upstream (canonical-clone mode: git pull; vendored mode: git subtree pull)
-#   5. Docker compose pull + up -d
+#   5. Compose pull + up -d THROUGH compose.sh so the per-install override
+#      applies (behalfbot#100) - bare compose only when the install has none
 #   6. Healthcheck poll (60s)
-#   7. Run migration script if present for the new version
-#   8. Post success / failure to the alerts channel
+#   7. Verify the merged compose config is actually running (ports published,
+#      scaled-to-0 services down, override in the container's config_files
+#      label) and report a config diff across the update
+#   8. Run migration script if present for the new version
+#   9. Post success / failure to the alerts channel
 #
 # Usage:
 #   chassis-update.sh                # apply non-breaking update
@@ -34,6 +38,14 @@ LOCAL_VERSION_FILE="${SCRIPT_DIR}/../VERSION"
 # healthcheck logic is testable without running a real update.
 # shellcheck source=chassis/scripts/_chassis-update-health.sh
 source "${SCRIPT_DIR}/_chassis-update-health.sh"
+# Merged-config verification helpers (behalfbot#100). Ships alongside this
+# script; a missing copy means a torn tree, and proceeding without it would
+# re-open the silent-override-revert hole, so fail loudly (no `set -e` here).
+# shellcheck source=chassis/scripts/_compose-verify.sh
+source "${SCRIPT_DIR}/_compose-verify.sh" || {
+    echo "[chassis-update] FATAL: ${SCRIPT_DIR}/_compose-verify.sh missing - it ships with this script" >&2
+    exit 1
+}
 UPSTREAM_REMOTE_URL="${CHASSIS_UPDATE_REMOTE:-https://github.com/scrollinondubs/behalfbot.git}"
 UPSTREAM_REMOTE_NAME="chassis"
 UPSTREAM_BRANCH="main"
@@ -87,6 +99,80 @@ dry_or_run_soft() {
     eval "$@" || { log "WARN: command failed (continuing recovery): $*"; return 1; }
 }
 
+# --- Compose invocation strategy (behalfbot#100) ---
+#
+# This script used to bring the stack back with bare `docker compose pull` +
+# `docker compose up -d`. Bare compose knows nothing about the per-install
+# override ($CUSTOMER_HOME/chassis-compose.override.yml - image pins,
+# published ports, env_file, scaled-to-0 services), so every update silently
+# reverted the customer's compose configuration and then reported success.
+# compose.sh is the chassis's one supported way to invoke compose - it layers
+# the override and hard-errors when the file it was told to use is missing.
+#
+# Strategy, decided ONCE up front:
+#   - CHASSIS_COMPOSE_OVERRIDE set (even to "") or the default override file
+#     present  -> every compose call goes through compose.sh. `${VAR-}` (no
+#     colon) mirrors compose.sh: set-but-empty means "deliberately no
+#     override" (chassis dev / smoke-test), unset means "use the default path".
+#   - neither -> a plain default install that never had an override. Keep the
+#     exact legacy bare invocation, with a WARN: forcing compose.sh here would
+#     turn its missing-override guard into a failed update for installs that
+#     were never broken. We do NOT create an override to satisfy the guard.
+#
+# Old-copy-of-this-script note: the process applying an update is the OLD
+# updater; the step-5 pull writes the NEW tree (including compose.sh, which
+# first shipped in v0.2.0) to disk before step 6 runs. So by the time compose
+# is invoked, ${SCRIPT_DIR}/compose.sh exists even when updating FROM a
+# pre-v0.2.0 tree - and if it somehow does not, that is a torn pull and we
+# die rather than fall back to the bare invocation this fix removes.
+# Installs whose OLD updater predates this fix still run one last bare-compose
+# update; chassis-migrations/v0.3.0.sh repairs those at the end of that run.
+COMPOSE_SH="${SCRIPT_DIR}/compose.sh"
+COMPOSE_DIR="$CHASSIS_HOME"
+OVERRIDE_FILE="${CHASSIS_COMPOSE_OVERRIDE-${CUSTOMER_HOME}/chassis-compose.override.yml}"
+if [[ -n "${CHASSIS_COMPOSE_OVERRIDE+x}" || -f "$OVERRIDE_FILE" ]]; then
+    USE_COMPOSE_SH=1
+else
+    USE_COMPOSE_SH=0
+fi
+
+# Print the shell command that runs `docker compose $*` for this install.
+# compose.sh resolves its compose files, project name and --env-file from its
+# own location + CUSTOMER_HOME, independent of the caller's cwd.
+compose_invoke() {
+    if [[ $USE_COMPOSE_SH -eq 1 ]]; then
+        echo "CUSTOMER_HOME='$CUSTOMER_HOME' bash '$COMPOSE_SH' $*"
+    else
+        echo "cd '$COMPOSE_DIR' && docker compose $*"
+    fi
+}
+
+# Best-effort snapshot of the effective (merged) compose config, so a diff
+# exists as evidence when the update changes the stack underneath an operator.
+# Soft on purpose: a broken pre-update tree must not block the update - the
+# step-7 verification after `up -d` is the hard gate. Output can contain
+# interpolated secrets from .env.baked, hence chmod 600 and STATE_DIR only.
+snapshot_config() {
+    local out="$1"
+    if [[ $DRY_RUN -eq 1 ]]; then
+        log "DRY-RUN: snapshot effective compose config -> $out"
+        return 0
+    fi
+    local cmd
+    cmd=$(compose_invoke "config")
+    if eval "$cmd" > "$out" 2>/dev/null && [[ -s "$out" ]]; then
+        chmod 600 "$out"
+        log "Effective compose config snapshot: $out"
+    else
+        rm -f "$out"
+        log "WARN: could not snapshot effective compose config to $out (continuing)"
+    fi
+}
+
+CONFIG_PRE="${STATE_DIR}/compose-config-pre.yaml"
+CONFIG_POST="${STATE_DIR}/compose-config-post.yaml"
+CONFIG_DIFF="${STATE_DIR}/compose-config.diff"
+
 # --- Mode detection ---
 # canonical_clone: CHASSIS_HOME's git origin is scrollinondubs/behalfbot itself.
 #                  Update with `git pull --ff-only`.
@@ -129,14 +215,31 @@ restore_snapshot() {
     if [[ -s "$image_sidecar" ]]; then
         pinned_image=$(tr -d '[:space:]' < "$image_sidecar")
     fi
+    # Same rule as step 5 (behalfbot#100): the recovery `up -d` must not
+    # silently strip the per-install override either. compose.sh may be
+    # missing here when the snapshot restored a pre-v0.2.0 tree over it, so
+    # fall back to bare compose with a warning rather than dying mid-recovery.
+    local up_prefix="cd '$compose_dir' &&"
+    local up_cmd="docker compose"
+    if [[ $USE_COMPOSE_SH -eq 1 ]]; then
+        if [[ -f "$COMPOSE_SH" ]]; then
+            up_prefix="CUSTOMER_HOME='$CUSTOMER_HOME'"
+            up_cmd="bash '$COMPOSE_SH'"
+        else
+            log "WARN: $COMPOSE_SH not present after restore; recovering with bare"
+            log "WARN: docker compose - the per-install override will NOT apply."
+            log "WARN: re-assert it once healthy: bash chassis/scripts/compose.sh up -d"
+        fi
+    fi
+
     if [[ -n "$pinned_image" ]]; then
         log "Pinning container back to pre-update image: $pinned_image"
-        dry_or_run_soft "cd '$compose_dir' && CHASSIS_IMAGE='$pinned_image' docker compose up -d --force-recreate"
+        dry_or_run_soft "$up_prefix CHASSIS_IMAGE='$pinned_image' $up_cmd up -d --force-recreate"
     else
         log "WARN: no pre-update image recorded for this snapshot. The disk tree is"
         log "WARN: restored but the container will come back up on whatever"
         log "WARN: CHASSIS_IMAGE currently resolves to. Verify the running version by hand."
-        dry_or_run_soft "cd '$compose_dir' && docker compose up -d"
+        dry_or_run_soft "$up_prefix $up_cmd up -d"
     fi
 }
 
@@ -177,6 +280,37 @@ Resolve by upstreaming the change or stashing it:
   git -C "$CHASSIS_HOME" stash push -- chassis/
 EOF
     exit 1
+fi
+
+# --- Step 1.5: pre-flight - a missing override is not a default install ---
+#
+# When no override is on disk and none is configured, this is EITHER a plain
+# default install (fine - proceed bare, exactly as before) OR an install whose
+# override has gone missing, where proceeding would silently revert the
+# customer's compose configuration: the exact #100 failure. The two are
+# distinguishable, because the docker engine records the -f files a stack was
+# built with on its containers. If the running chassis container was built
+# WITH an override that no longer exists, refuse - loudly, and BEFORE the
+# pull mutates the tree. We deliberately do not create an override to make
+# the problem disappear. Applies to --dry-run too: it is a truthful prediction
+# that the real run would be refused.
+if [[ $USE_COMPOSE_SH -eq 0 && -f "${COMPOSE_DIR}/docker-compose.yml" ]] && command -v docker >/dev/null 2>&1; then
+    existing_container=$(chassis_find_container "$COMPOSE_DIR")
+    if [[ -n "$existing_container" ]]; then
+        built_with=$(docker inspect "$existing_container" \
+            --format '{{ index .Config.Labels "com.docker.compose.project.config_files" }}' 2>/dev/null)
+        if [[ "$built_with" == *"chassis-compose.override"* ]]; then
+            log "FATAL: the running stack was built with a compose override:"
+            log "FATAL:   $built_with"
+            log "FATAL: but no override exists at $OVERRIDE_FILE now. Proceeding would"
+            log "FATAL: silently revert this install's compose configuration (published"
+            log "FATAL: ports, image pins, scaled-to-0 services) - behalfbot#100."
+            log "FATAL: Restore the override file, or point CHASSIS_COMPOSE_OVERRIDE at its"
+            log "FATAL: location, or set CHASSIS_COMPOSE_OVERRIDE= (empty) if running"
+            log "FATAL: override-less is genuinely intended. Not creating one for you."
+            die "refusing to update: compose override missing but the running stack was built with one"
+        fi
+    fi
 fi
 
 # --- Step 2: BREAKING CHANGES gate ---
@@ -236,6 +370,13 @@ if [[ $DRY_RUN -eq 0 ]]; then
     fi
 fi
 
+# --- Step 4.5: snapshot the effective compose config before the pull ---
+# Evidence for the operator: what the stack's merged config looked like BEFORE
+# this update touched anything. Diffed against the post-up snapshot in step 7.
+if [[ -f "${COMPOSE_DIR}/docker-compose.yml" ]]; then
+    snapshot_config "$CONFIG_PRE"
+fi
+
 # --- Step 5: pull upstream ---
 case "$MODE" in
     canonical_clone)
@@ -253,13 +394,26 @@ case "$MODE" in
         ;;
 esac
 
-# --- Step 6: docker compose pull + up ---
-COMPOSE_DIR="$CHASSIS_HOME"
+# --- Step 6: docker compose pull + up (through compose.sh, behalfbot#100) ---
 if [[ ! -f "${COMPOSE_DIR}/docker-compose.yml" ]]; then
     log "No docker-compose.yml at $COMPOSE_DIR; skipping container refresh"
 else
-    dry_or_run "cd '$COMPOSE_DIR' && docker compose pull"
-    dry_or_run "cd '$COMPOSE_DIR' && docker compose up -d"
+    if [[ $USE_COMPOSE_SH -eq 1 ]]; then
+        # The step-5 pull delivers compose.sh when updating from a pre-v0.2.0
+        # tree, so in a real run it must exist by now. Never fall back to bare
+        # compose - that IS the bug this step replaces. The dry-run path never
+        # pulled, so it only reports the plan.
+        if [[ $DRY_RUN -eq 0 && ! -f "$COMPOSE_SH" ]]; then
+            die "compose.sh not found at $COMPOSE_SH after the upstream pull - refusing to fall back to bare docker compose (behalfbot#100)"
+        fi
+        log "Compose override in effect: ${OVERRIDE_FILE:-<none - explicitly disabled via CHASSIS_COMPOSE_OVERRIDE>}"
+    else
+        log "WARN: no compose override at $OVERRIDE_FILE - bringing the stack up on chassis defaults."
+        log "WARN: real installs carry an override (env_file, image pins, published ports);"
+        log "WARN: see docs/per-customer-repo-pattern.md. Not creating one on your behalf."
+    fi
+    dry_or_run "$(compose_invoke "pull")"
+    dry_or_run "$(compose_invoke "up -d")"
 fi
 
 # --- Step 7: healthcheck ---
@@ -318,16 +472,96 @@ if [[ $DRY_RUN -eq 0 ]]; then
     fi
 fi
 
+# --- Step 7.5: verify the merged compose config is actually running ---
+#
+# behalfbot#100: the version healthcheck above proves the chassis container is
+# up on the new code - over the INTERNAL compose network. It is structurally
+# blind to the things the per-install override changes: published host ports,
+# scaled-to-0 services, image pins. On the install that motivated this, the
+# update dropped the override, postgres stopped publishing 127.0.0.1:5432,
+# every host-side consumer broke, a watchdog bounced the whole VM - and the
+# healthcheck reported green throughout. So: render the merged config the
+# stack SHOULD be running and check the docker engine against it.
+#
+# With an override in play a mismatch is a failed update (rollback + die) -
+# reverting a customer's compose configuration is not a warning-level event.
+# Without one (plain default install) the check still runs but only warns,
+# preserving the no-override contract exactly.
+if [[ $DRY_RUN -eq 0 && "$HEALTHCHECK_MODE" == "container" ]]; then
+    verify_failed=0
+    verify_msgs=""
+    CONFIG_POST_JSON="${STATE_DIR}/compose-config-post.json"
+
+    if eval "$(compose_invoke "config --format json")" > "$CONFIG_POST_JSON" 2>"${CONFIG_POST_JSON}.err" && [[ -s "$CONFIG_POST_JSON" ]]; then
+        chmod 600 "$CONFIG_POST_JSON"
+        rm -f "${CONFIG_POST_JSON}.err"
+        MERGED_PROJECT=$(jq -r '.name // empty' "$CONFIG_POST_JSON")
+
+        verify_msgs=$(compose_verify_running_config "$CONFIG_POST_JSON") || verify_failed=1
+
+        # Direct evidence the engine built the stack WITH the override: the
+        # compose config_files label on the chassis container.
+        if [[ $USE_COMPOSE_SH -eq 1 && -n "$OVERRIDE_FILE" ]]; then
+            compose_override_in_config_files "$MERGED_PROJECT" "$OVERRIDE_FILE"
+            case $? in
+                1)
+                    verify_msgs="${verify_msgs}${verify_msgs:+$'\n'}VERIFY-FAIL: chassis container's compose config_files label does not include $OVERRIDE_FILE - the stack was brought up without the per-install override"
+                    verify_failed=1
+                    ;;
+                2)
+                    verify_msgs="${verify_msgs}${verify_msgs:+$'\n'}VERIFY-FAIL: no running chassis container found in project '$MERGED_PROJECT' to inspect for the override"
+                    verify_failed=1
+                    ;;
+            esac
+        fi
+    else
+        verify_msgs="VERIFY-FAIL: could not render the merged compose config ($(head -c 300 "${CONFIG_POST_JSON}.err" 2>/dev/null | tr '\n' ' '))"
+        verify_failed=1
+    fi
+
+    if [[ $verify_failed -eq 1 ]]; then
+        while IFS= read -r line; do log "$line"; done <<<"$verify_msgs"
+        if [[ $USE_COMPOSE_SH -eq 1 ]]; then
+            log "FAIL: the running stack does not match the merged compose config - the"
+            log "FAIL: per-install override was not (fully) applied. Rolling back."
+            restore_snapshot "$SNAPSHOT" "$COMPOSE_DIR"
+            die "update failed config verification and was rolled back (behalfbot#100)"
+        fi
+        log "WARN: running stack does not match the compose config (no override install;"
+        log "WARN: not failing the update). Review the lines above."
+    else
+        log "Config verification passed: declared ports published, scaled-to-0 services down."
+    fi
+
+    # Operator-facing evidence: did the effective config change across the
+    # update? Snapshot post-up and diff against the pre-pull snapshot. The
+    # diff content can carry interpolated secrets, so it stays in STATE_DIR -
+    # only the fact of drift and the path are logged.
+    snapshot_config "$CONFIG_POST"
+    if [[ -f "$CONFIG_PRE" && -f "$CONFIG_POST" ]]; then
+        if diff -u "$CONFIG_PRE" "$CONFIG_POST" > "$CONFIG_DIFF" 2>/dev/null; then
+            log "Effective compose config unchanged across the update."
+            rm -f "$CONFIG_DIFF"
+        else
+            chmod 600 "$CONFIG_DIFF"
+            log "NOTICE: effective compose config CHANGED across the update ($(grep -c '^[+-]' "$CONFIG_DIFF") diff lines)."
+            log "NOTICE: review: $CONFIG_DIFF"
+        fi
+    fi
+fi
+
 # --- Step 8: run migration script if present ---
 # Migrations are strictly automated shell scripts. Judgment-heavy migrations
 # would have been flagged BREAKING CHANGES and gated behind --force above.
 #
-# chassis/scripts/chassis-migrations/ does not exist in the repo yet - no
-# release has needed a state migration. That is fine and deliberate: the `-f`
-# test below is false for a path under a missing directory just as it is for a
-# missing file, so the step no-ops. The directory gets created by whichever
-# release first ships a migration. Do not pre-create it empty.
-MIGRATION_SCRIPT="${CHASSIS_HOME}/chassis/scripts/chassis-migrations/v${UPSTREAM_VERSION}.sh"
+# The `-f` test below is false for a path under a missing directory just as
+# it is for a missing file, so versions without a migration no-op here. First
+# shipped migration: v0.3.0.sh (behalfbot#100 override repair).
+# Resolved relative to this script (like LOCAL_VERSION_FILE), not
+# ${CHASSIS_HOME}/chassis/scripts/...: that literal path only exists in
+# canonical-clone mode. In vendored-subtree mode the pulled repo root lands
+# UNDER chassis/, so the old path silently skipped every migration there.
+MIGRATION_SCRIPT="${SCRIPT_DIR}/chassis-migrations/v${UPSTREAM_VERSION}.sh"
 if [[ -f "$MIGRATION_SCRIPT" ]]; then
     log "Running migration: $MIGRATION_SCRIPT"
     dry_or_run "bash '$MIGRATION_SCRIPT'"

--- a/chassis/scripts/test-compose-verify.sh
+++ b/chassis/scripts/test-compose-verify.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# test-compose-verify.sh - exercise _compose-verify.sh against a REAL scratch
+# compose project (behalfbot#100).
+#
+# The bug this guards against was a check that could not observe the thing
+# that broke, so this test refuses to be a mock: it stands up actual
+# containers, once WITHOUT the override (the pre-fix updater's failure mode)
+# and once WITH it, and asserts the verifier fails the first and passes the
+# second.
+#
+# Scenario mirrors the real install that motivated #100:
+#   base:     service "chassis" (no published port), service "extra" (publishes
+#             a port, runs by default - the spurious Vaultwarden analogue)
+#   override: chassis publishes 127.0.0.1:$PORT->8080, extra scaled to 0
+#
+# Requires docker + docker compose + jq; SKIPs (exit 0) when unavailable so CI
+# without a docker engine stays green. Uses a throwaway project name and a
+# dynamically picked localhost port; never touches a live install's stack.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=chassis/scripts/_compose-verify.sh
+source "${SCRIPT_DIR}/_compose-verify.sh"
+
+PASS=0
+FAIL=0
+say()  { printf '%s\n' "$*"; }
+ok()   { PASS=$((PASS+1)); say "  PASS: $*"; }
+bad()  { FAIL=$((FAIL+1)); say "  FAIL: $*"; }
+
+if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+    say "SKIP: docker compose and/or jq not available"
+    exit 0
+fi
+if ! docker info >/dev/null 2>&1; then
+    say "SKIP: docker daemon not reachable"
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+PROJECT="bbtest-verify-$$"
+PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1])' 2>/dev/null || echo 15987)"
+
+cleanup() {
+    docker compose -p "$PROJECT" -f "$WORK/base.yml" -f "$WORK/override.yml" down -v --remove-orphans >/dev/null 2>&1
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+cat > "$WORK/base.yml" <<EOF
+name: $PROJECT
+services:
+  chassis:
+    image: alpine:3.20
+    command: ["sleep", "600"]
+  extra:
+    image: alpine:3.20
+    command: ["sleep", "600"]
+    ports:
+      - "127.0.0.1:0:9090"
+EOF
+
+cat > "$WORK/override.yml" <<EOF
+services:
+  chassis:
+    ports:
+      - "127.0.0.1:${PORT}:8080"
+  extra:
+    deploy:
+      replicas: 0
+EOF
+
+MERGED_JSON="$WORK/merged.json"
+docker compose -p "$PROJECT" -f "$WORK/base.yml" -f "$WORK/override.yml" config --format json > "$MERGED_JSON" \
+    || { say "FATAL: could not render merged config"; exit 1; }
+
+say "== unit: expected-ports extraction from the merged config =="
+expected=$(compose_expected_ports "$MERGED_JSON")
+[[ "$expected" == "chassis|8080|${PORT}|127.0.0.1|tcp" ]] \
+    && ok "expected ports = 'chassis|8080|${PORT}|127.0.0.1|tcp'" \
+    || bad "expected-ports extraction got: '$expected'"
+zeros=$(compose_zero_replica_services "$MERGED_JSON")
+[[ "$zeros" == "extra" ]] \
+    && ok "zero-replica services = 'extra'" \
+    || bad "zero-replica extraction got: '$zeros'"
+
+say "== case 1: stack brought up BARE (override dropped - the #100 failure) =="
+docker compose -p "$PROJECT" -f "$WORK/base.yml" up -d >/dev/null 2>&1 \
+    || { say "FATAL: bare up failed"; exit 1; }
+
+if out=$(compose_verify_running_config "$MERGED_JSON"); then
+    bad "verifier PASSED a stack running without the override"
+else
+    ok "verifier failed the bare stack"
+fi
+grep -q "service 'chassis' should publish 127.0.0.1:${PORT}->8080/tcp" <<<"${out:-}" \
+    && ok "unpublished override port detected" \
+    || bad "missing port failure not reported; got: ${out:-<nothing>}"
+grep -q "service 'extra' is scaled to 0 .* but is running" <<<"${out:-}" \
+    && ok "running scaled-to-0 service detected" \
+    || bad "zero-replica violation not reported; got: ${out:-<nothing>}"
+
+compose_override_in_config_files "$PROJECT" "$WORK/override.yml" "chassis"
+rc=$?
+[[ $rc -eq 1 ]] \
+    && ok "config_files label check returns 1 (override absent from the stack)" \
+    || bad "config_files label check returned $rc, expected 1"
+
+say "== case 2: stack brought up WITH the override (the fixed invocation) =="
+docker compose -p "$PROJECT" -f "$WORK/base.yml" -f "$WORK/override.yml" up -d >/dev/null 2>&1 \
+    || { say "FATAL: merged up failed"; exit 1; }
+
+if out=$(compose_verify_running_config "$MERGED_JSON"); then
+    ok "verifier passed the merged stack"
+else
+    bad "verifier failed a correct stack: $out"
+fi
+extra_running=$(compose_service_containers "$PROJECT" "extra")
+[[ -z "$extra_running" ]] \
+    && ok "compose up with the override scaled 'extra' down to 0" \
+    || bad "'extra' still running after merged up: $extra_running"
+
+compose_override_in_config_files "$PROJECT" "$WORK/override.yml" "chassis"
+rc=$?
+[[ $rc -eq 0 ]] \
+    && ok "config_files label check returns 0 (override recorded on the container)" \
+    || bad "config_files label check returned $rc, expected 0"
+
+say ""
+say "RESULT: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Fixes #100.

## What changed

`chassis/scripts/chassis-update.sh` brought the stack back with bare `docker compose pull` + `docker compose up -d`, silently dropping the per-install override and then reporting success - its healthcheck polls the chassis container over the internal network and structurally cannot observe published ports, scaled-to-0 services, or image pins. On the real install that surfaced this (0.1.1 -> 0.2.0), that unpublished postgres's `127.0.0.1:5432`, broke every host-side consumer, escalated `postgres-watchdog` into a `colima restart` mid-update, and created a spurious empty Vaultwarden.

Five changes:

1. **All updater compose calls route through `compose.sh`** - `pull`, `up -d`, and the rollback path's recovery `up`. `compose.sh` is cwd-independent (absolute `-f`, `-p`, `--env-file`), layers the override, and hard-errors when the file it was told to use is missing.
2. **Pre-flight refusal when an override went missing** (step 1.5). A missing override is only a "default install" if the running stack was never built with one. The engine records the `-f` files on every container (`com.docker.compose.project.config_files` label); if the running chassis container was built WITH an override that no longer exists on disk, the update refuses loudly BEFORE the pull mutates the tree. The updater never creates an override to make the problem go away.
3. **Post-update config verification** (step 7.5, new `_compose-verify.sh`). After the version healthcheck passes, the updater renders the merged `docker compose config --format json` and checks the engine against it: every declared published port must actually be bound, every scaled-to-0 service must have no running container, and the chassis container's `config_files` label must include the override. With an override in play, a mismatch rolls back and fails the update. Container-healthy is no longer treated as install-healthy.
4. **Config evidence**: the effective merged config is snapshotted before the pull and after `up -d` (`state/chassis-update/compose-config-{pre,post}.yaml`, chmod 600 - it contains interpolated secrets, so only the fact of drift and the path are logged) and a diff is reported when it changes.
5. **`chassis-migrations/v0.3.0.sh`** - the repair channel for the old-updater window (below). Also: migration scripts now resolve relative to the running script like `VERSION` does; the old `${CHASSIS_HOME}/chassis/scripts/...` literal only exists in canonical-clone layout, so vendored-subtree installs were silently skipping every migration.

## The old-copy-of-the-updater problem

The process applying an update is the OLD updater; the step-5 pull writes the new tree to disk before step 6 runs. Two consequences, both handled:

- **For this new updater**: `compose.sh` (shipped v0.2.0) is guaranteed present at `${SCRIPT_DIR}/compose.sh` by the time compose is invoked, even updating FROM a pre-0.2.0 tree - the pull delivered it. If it is somehow absent in a real run, the updater dies rather than falling back to bare compose (the fallback IS the bug). `--dry-run` never pulls, so it prints the plan without requiring the file.
- **For installs still running a pre-fix updater** (everything <= 0.3.0): their next update TO v0.3.0 performs one last bare-compose `up -d`. Every shipped updater since v0.1.1 runs `chassis-migrations/v${UPSTREAM_VERSION}.sh` from the freshly pulled tree at the end of the run - so this PR ships `v0.3.0.sh`, which re-runs the stack through `compose.sh` (compose recreates drifted services and scales replicas-0 services down, removing the spurious Vaultwarden) and then verifies ports and replicas via the same lib, exiting non-zero if the stack still does not match. Keyed to v0.3.0 deliberately: that is the version those installs are upgrading to. No-override and host-mode installs: explicit no-op. Caveats: installs that already updated to 0.3.0 before this merges will not re-run the migration (manual recovery in #100 applies), and the OLD updater's migration path bug means vendored-subtree installs do not get the repair (Sean's reference install and the known installs are canonical clones).

## No-override installs keep working

Strategy decided once up front: `CHASSIS_COMPOSE_OVERRIDE` set (even empty - compose.sh's deliberate no-override contract) or the default override file present -> compose.sh. Neither -> the EXACT legacy bare invocation plus a WARN, with verification in warn-only mode. Forcing compose.sh there would turn its missing-override guard into a failed update for installs that were never broken. Demonstrated below (canary install).

## Verification (all real runs, scratch compose projects against the local docker engine)

**Unit/lib test** (`bash chassis/scripts/test-compose-verify.sh`, committed; real containers, bare-vs-merged stacks):

```
== unit: expected-ports extraction from the merged config ==
  PASS: expected ports = 'chassis|8080|49625|127.0.0.1|tcp'
  PASS: zero-replica services = 'extra'
== case 1: stack brought up BARE (override dropped - the #100 failure) ==
  PASS: verifier failed the bare stack
  PASS: unpublished override port detected
  PASS: running scaled-to-0 service detected
  PASS: config_files label check returns 1 (override absent from the stack)
== case 2: stack brought up WITH the override (the fixed invocation) ==
  PASS: verifier passed the merged stack
  PASS: compose up with the override scaled 'extra' down to 0
  PASS: config_files label check returns 0 (override recorded on the container)
RESULT: 9 passed, 0 failed
```

**End-to-end rehearsal**: scratch canonical-clone install + fake upstream (local git repo whose path contains `scrollinondubs/behalfbot`, `CHASSIS_UPDATE_RAW_BASE=file://...`), customer dir with `.env.baked` and an override publishing `127.0.0.1:15987:8080` on `chassis` and scaling `extra` to 0.

1. **Happy path** (8.0.0 -> 8.0.1, override present): update routed through compose.sh, healthcheck green, then:
```
[chassis-update] Config verification passed: declared ports published, scaled-to-0 services down.
[chassis-update] Effective compose config unchanged across the update.
[chassis-update] Update complete: v8.0.0 → v8.0.1
bb100e2e-chassis-1  127.0.0.1:15987->8080/tcp     <- override survived
```

2. **Old-updater simulation + migration repair**: bare `docker compose up -d` reproduced the exact field breakage (port unpublished, spurious `extra` container running), then:
```
[migrate-v0.3.0] re-running the stack through compose.sh so .../chassis-compose.override.yml applies
 Container bb100e2e-extra-1 Removed
 Container bb100e2e-chassis-1 Recreated
[migrate-v0.3.0] override re-asserted and verified: declared ports published, scaled-to-0 services down
bb100e2e-chassis-1  127.0.0.1:15987->8080/tcp     <- repaired
```

3. **Override deliberately removed** -> loud refusal, pre-pull (tree still at 8.0.1 after, stack untouched):
```
[chassis-update] FATAL: the running stack was built with a compose override:
[chassis-update] FATAL:   .../docker-compose.yml,.../customer/chassis-compose.override.yml
[chassis-update] FATAL: but no override exists at .../chassis-compose.override.yml now. ...
[chassis-update] FATAL: refusing to update: compose override missing but the running stack was built with one
EXIT=1
```

4. **Verification failure fires and rolls back** (rogue container labeled as the scaled-to-0 service, planted before the update):
```
[chassis-update] Container 'bb100e2e-chassis-1' reports v8.0.2
[chassis-update] VERIFY-FAIL: service 'extra' is scaled to 0 in the merged config but is running: 3c3ed7b0b5f9
[chassis-update] FAIL: per-install override was not (fully) applied. Rolling back.
[chassis-update] + CUSTOMER_HOME='...' CHASSIS_IMAGE='sha256:d9e8...' bash '.../compose.sh' up -d --force-recreate
[chassis-update] FATAL: update failed config verification and was rolled back (behalfbot#100)
EXIT=1
bb100e2e-chassis-1  127.0.0.1:15987->8080/tcp     <- rollback itself kept the override
```

5. **No-override canary install** (never had one, containers built bare): update 8.0.0 -> 8.0.2 proceeds with the legacy bare invocation plus WARN, verification warn-only, `EXIT=0` - no regression.

6. **`--dry-run`**: prints the planned compose.sh commands without executing anything (and without requiring compose.sh to exist yet).

`bash -n` and `shellcheck` clean on all touched scripts (only pre-existing SC2294/SC2012 in the untouched eval helpers).

## Notes for review

- CHANGELOG gets a `## Unreleased` section only; `chassis/VERSION` untouched per instruction. The v0.3.0.sh migration takes effect for 0.x -> 0.3.0 upgrades as soon as this merges to main, since the old updaters fetch upstream main directly.
- The OLD updaters' rollback path (`docker compose up -d --force-recreate`, bare) still drops overrides if a pre-fix update fails healthcheck and rolls back; not fixable retroactively, manual recovery in #100 applies.
- Config snapshots and diffs can contain interpolated secrets, so they live in `state/chassis-update/` at 0600 and are never echoed to the log or Discord.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
