### PR TITLE
fix(loom-vision): resync ClawHub bundle with chassis transcript fix, clean stdout contract

### DIFF
--- a/chassis/CHANGELOG.md
+++ b/chassis/CHANGELOG.md
@@ -16,6 +16,12 @@ Semver:
 - `MINOR` (`0.3.0` → `0.4.0`): new features, optional fields, opt-in behaviors. Backwards-compatible.
 - `PATCH` (`0.3.1` → `0.3.2`): fixes, prompt tweaks, internal refactors. Always backwards-compatible.
 
+## Unreleased
+
+### Fixed
+
+- **ClawHub loom-vision bundle resynced with the chassis script.** The publishable copy under `plugins/loom-vision/clawhub/loom-vision/` missed the 2026-07-15 transcript fix: it still told the agent to read `transcript.vtt`, a file loom-dl never writes (loom-dl 1.1.1 writes `video.transcript.json`), so the transcript half of the published skill silently did nothing. Verified against a real Loom URL before and after. The copy now carries the transcript JSON to VTT/plaintext conversion, and the stray `unknown` line that polluted the script's stdout contract under pipefail is gone (the output directory path must be the only stdout line). Bundle SKILL.md and README now document the real outputs (`transcript.vtt`, `transcript.txt`, `transcript.json`) and the `node` dependency.
+
 ## v0.3.0 - 2026-07-21
 
 The release that makes v0.2.0 real. The plugin fetcher shipped in v0.2.0 downloaded and verified a plugin tree that the chassis then never used; this release makes the fetched tree actually take effect, as an overlay rather than a swap. Also hardens the Notion and Obsidian second-brain adapters to the point where full-length documents survive a round trip, and removes nationality-based screening from the public dating plugin.

--- a/plugins/loom-vision/CLAWHUB_SUBMISSION.md
+++ b/plugins/loom-vision/CLAWHUB_SUBMISSION.md
@@ -19,7 +19,7 @@ Submission is via the `clawhub` CLI (`clawhub skill publish <folder>`), authenti
 
 | File | Purpose |
 |---|---|
-| `clawhub/loom-vision/SKILL.md` | The publishable skill definition. ClawHub parses its YAML frontmatter for registry metadata: `name`, `description` (becomes the search/UI summary), `version`, and `metadata.openclaw` (emoji, homepage, `requires.bins`, install specs for loom-dl + ffmpeg, and optional `envVars`). The env vars the script reads are declared with `required: false` because ClawHub's automated security analysis flags undeclared env var usage as a metadata mismatch. Chassis-only frontmatter (`plugin:`, `enabled_when:`) removed. |
+| `clawhub/loom-vision/SKILL.md` | The publishable skill definition. ClawHub parses its YAML frontmatter for registry metadata: `name`, `description` (becomes the search/UI summary), `version`, and `metadata.openclaw` (emoji, homepage, `requires.bins`, install specs for node, loom-dl and ffmpeg, and optional `envVars`). The env vars the script reads are declared with `required: false` because ClawHub's automated security analysis flags undeclared env var usage as a metadata mismatch. Chassis-only frontmatter (`plugin:`, `enabled_when:`) removed. |
 | `clawhub/loom-vision/process-loom.sh` | Standalone copy of the chassis script. Only differences from the canonical `skills/loom-vision/process-loom.sh`: default `OUTPUT_ROOT` is `${TMPDIR:-/tmp}/loom-vision` instead of `${CHASSIS_HOME}/temp`, and chassis/setup.sh references are gone from comments. Publishing uploads the whole folder, so this ships inside the bundle - `{baseDir}` in SKILL.md resolves to it at runtime. |
 | `clawhub/loom-vision/README.md` | Optional supporting file (allowed; only text files are accepted). Chassis install instructions replaced with `clawhub install`, plus the Behalf.bot pointer. No license section - see the licensing note below. |
 | `CLAWHUB_SUBMISSION.md` | This runbook. Not part of the published bundle (it lives one level above the skill folder, and publish only uploads `clawhub/loom-vision/`). |
@@ -57,5 +57,5 @@ ClawHub publishes **all** skills under **MIT-0** (public domain equivalent: anyo
 
 - Keep `clawhub/loom-vision/` in sync with the canonical chassis script by hand - the two copies intentionally differ only in OUTPUT_ROOT default and comments.
 - Do not add pricing or license text to SKILL.md; ClawHub rejects/ignores both.
-- Only text-based files are accepted in the bundle; the .sh is fine (scripts are scanned after upload). Bundle limit 50MB - ours is ~12KB.
+- Only text-based files are accepted in the bundle; the .sh is fine (scripts are scanned after upload). Bundle limit 50MB - ours is ~20KB.
 - `CLAWHUB_DISABLE_TELEMETRY=1` disables the CLI's install-count telemetry if you care.

--- a/plugins/loom-vision/clawhub/loom-vision/README.md
+++ b/plugins/loom-vision/clawhub/loom-vision/README.md
@@ -25,12 +25,13 @@ The agent then reads the transcript to anchor timing and browses the frames that
 clawhub install @<owner>/loom-vision
 ```
 
-Two CLI dependencies (declared in the skill's install specs, so OpenClaw can install them for you):
+Three CLI dependencies (declared in the skill's install specs, so OpenClaw can install them for you):
 
+- `node` - `brew install node`. Runs the transcript JSON to VTT conversion, and is required by loom-dl anyway.
 - `loom-dl` - `npm install -g loom-dl` (Node-based; not on Homebrew)
-- `ffmpeg` - `brew install ffmpeg` (macOS) or your distro's package manager (Linux)
+- `ffmpeg` - `brew install ffmpeg` (macOS) or your distro's package manager (Linux). Supplies `ffprobe` for duration bounding; installs without `ffprobe` still work, with an estimated end time on the last transcript cue.
 
-Both are idempotent.
+All are idempotent.
 
 ## Usage
 
@@ -43,10 +44,16 @@ bash process-loom.sh "https://www.loom.com/share/<32-hex-id>/..."
 The script prints the output directory path to stdout. The directory contains:
 
 - `video.mp4` - original video (kept for re-sampling at different intervals)
-- `transcript.vtt` - Loom's auto-transcript with timestamps
+- `transcript.vtt` - Loom's auto-transcript as WebVTT with timestamps
+- `transcript.txt` - the same transcript as plaintext
+- `transcript.json` - the raw loom-dl transcript JSON, kept verbatim
 - `frame_NNN.jpg` - sampled frames
 
 Frame N corresponds to timestamp `(N - 1) * FRAME_INTERVAL_SECONDS` from the start.
+
+loom-dl writes its transcript as `<basename>.transcript.json`, not VTT. The script
+converts that into `transcript.vtt` + `transcript.txt` so the agent always has a
+transcript file to read.
 
 ## Configuration
 

--- a/plugins/loom-vision/clawhub/loom-vision/SKILL.md
+++ b/plugins/loom-vision/clawhub/loom-vision/SKILL.md
@@ -9,9 +9,15 @@ metadata:
     homepage: https://behalf.bot
     requires:
       bins:
+        - node
         - loom-dl
         - ffmpeg
     install:
+      - id: brew-node
+        kind: brew
+        formula: node
+        bins: [node]
+        label: Install Node.js (brew)
       - id: node-loom-dl
         kind: node
         package: loom-dl
@@ -35,6 +41,9 @@ metadata:
       - name: FRAME_QUALITY
         required: false
         description: ffmpeg -q:v JPEG quality, 1-31, lower is better. Default 3.
+      - name: TMPDIR
+        required: false
+        description: Standard system temp directory variable. Only used to derive the default OUTPUT_ROOT; never set it for this skill specifically.
 ---
 
 # Loom Vision
@@ -58,8 +67,14 @@ bash {baseDir}/process-loom.sh "<loom-share-url>"
 The script prints the output directory path to stdout. Inside that directory:
 
 - `video.mp4` - the original video (kept in case you want to re-process at a different frame interval)
-- `transcript.vtt` - Loom's auto-transcript with timestamps
+- `transcript.vtt` - Loom's auto-transcript as WebVTT with timestamps (read this one)
+- `transcript.txt` - the same transcript as plaintext, no timestamps
+- `transcript.json` - the raw loom-dl transcript JSON, kept verbatim
 - `frame_001.jpg`, `frame_002.jpg`, ... - sampled frames at 1 frame per N seconds (default 5)
+
+Note: loom-dl writes its transcript as `<basename>.transcript.json`, not VTT. The
+script converts that JSON into `transcript.vtt` + `transcript.txt` for you, so the
+"read the transcript" step below always has a file to read.
 
 ## What to do with the output
 
@@ -86,12 +101,15 @@ All knobs are environment variables, set before invoking the script:
 
 ## Dependencies
 
-Two system CLIs are required (declared in the install specs above so OpenClaw can offer to install them):
+Three system CLIs are required (declared in the install specs above so OpenClaw can offer to install them):
 
+- `node` - runs the transcript JSON to VTT conversion. It is also required by loom-dl, so if loom-dl works, node is already present. Install with `brew install node` if missing.
 - `loom-dl` - install with `npm install -g loom-dl` (Node CLI, not on Homebrew)
-- `ffmpeg` - install with `brew install ffmpeg` (macOS) or your distro's package manager (Linux)
+- `ffmpeg` - install with `brew install ffmpeg` (macOS) or your distro's package manager (Linux). Supplies `ffprobe`, used to bound the final transcript cue.
 
-Both installs are idempotent.
+All installs are idempotent.
+
+If your ffmpeg install lacks `ffprobe` (notably the `ffmpeg-static` npm module), the script degrades gracefully: it estimates the end time of the last transcript cue instead of reading the true video duration. Frames, transcript text, and all earlier cue timings are unaffected.
 
 ## Why this exists
 

--- a/plugins/loom-vision/clawhub/loom-vision/process-loom.sh
+++ b/plugins/loom-vision/clawhub/loom-vision/process-loom.sh
@@ -10,19 +10,22 @@
 # Output:
 #   Creates ${OUTPUT_ROOT}/loom-<video_id>/ containing:
 #     - video.mp4         (full source video, kept for re-sampling)
-#     - transcript.vtt    (Loom auto-transcript with timestamps)
+#     - transcript.json   (raw loom-dl transcript, kept verbatim)
+#     - transcript.vtt    (WebVTT built from the JSON - what the agent reads)
+#     - transcript.txt    (plaintext transcript, no timestamps)
 #     - frame_NNN.jpg     (sampled frames at FRAME_INTERVAL_SECONDS cadence)
 #   Prints the output directory path to stdout. Progress messages go to stderr.
 #
 # Configuration (env vars):
 #   OUTPUT_ROOT               default ${TMPDIR:-/tmp}/loom-vision
-#   FRAME_INTERVAL_SECONDS    default 5
+#   FRAME_INTERVAL_SECONDS    default 5 (try 2-3 for fast bug repros)
 #   FRAME_MAX_WIDTH_PX        default 1280
 #   FRAME_QUALITY             default 3 (ffmpeg -q:v, 1-31, lower = better)
 #
 # Dependencies:
+#   - node    (transcript JSON -> VTT conversion; also required by loom-dl)
 #   - loom-dl (npm install -g loom-dl)
-#   - ffmpeg  (brew install ffmpeg, or your distro's package manager)
+#   - ffmpeg  (brew install ffmpeg; supplies ffprobe for duration bounding)
 
 set -euo pipefail
 
@@ -47,6 +50,10 @@ if ! command -v ffmpeg >/dev/null 2>&1; then
   echo "ERROR: ffmpeg not found in PATH. Install with: brew install ffmpeg" >&2
   exit 2
 fi
+if ! command -v node >/dev/null 2>&1; then
+  echo "ERROR: node not found in PATH. Install with: brew install node" >&2
+  exit 2
+fi
 
 # Extract video ID from URL - Loom share URLs are .../share/<32-hex>/...
 VIDEO_ID=$(echo "$URL" | grep -oE '[a-f0-9]{32}' | head -1)
@@ -59,8 +66,180 @@ fi
 OUTPUT_DIR="$OUTPUT_ROOT/loom-$VIDEO_ID"
 mkdir -p "$OUTPUT_DIR"
 
+# Download the video + transcript. The .mp4 extension on --out is load-bearing:
+# loom-dl treats a path ending in .mp4 as an explicit file. Do NOT change it to
+# a bare directory - loom-dl would then misinterpret the target and break.
 echo "Downloading Loom video $VIDEO_ID..." >&2
-loom-dl --url "$URL" --out "$OUTPUT_DIR/video.mp4" --transcript 2>&2
+# >&2 keeps loom-dl's progress chatter (which it prints on stdout) off OUR
+# stdout - the output directory path must be the only line stdout emits.
+loom-dl --url "$URL" --out "$OUTPUT_DIR/video.mp4" --transcript >&2
+
+# --- transcript JSON -> VTT + plaintext ------------------------------------
+# loom-dl --transcript writes "<out-basename>.transcript.json"
+# (schemaVersion 1.1.x: { "phrases": [ { "ts": <seconds>, "value": <text> } ] }),
+# NOT a transcript.vtt. Older docs told the agent to read transcript.vtt, which
+# never existed, so the transcript half of the skill silently did nothing. The
+# embedded converter is defensive about field names and always emits a valid VTT
+# (even timing-less) so the agent's "read the transcript" step never dead-ends.
+echo "Converting transcript to VTT + plaintext..." >&2
+
+# loom-dl derives the transcript name from the --out basename: video.mp4 -> video.transcript.json
+TRANSCRIPT_JSON="$OUTPUT_DIR/video.transcript.json"
+if [[ ! -f "$TRANSCRIPT_JSON" ]]; then
+  TRANSCRIPT_JSON=$(ls -1 "$OUTPUT_DIR"/*.transcript.json 2>/dev/null | head -1 || true)
+  if [[ -z "${TRANSCRIPT_JSON:-}" ]]; then
+    TRANSCRIPT_JSON=$(ls -1 "$OUTPUT_DIR"/*.json 2>/dev/null | grep -v '/transcript\.json$' | head -1 || true)
+  fi
+fi
+
+VTT="$OUTPUT_DIR/transcript.vtt"
+TXT="$OUTPUT_DIR/transcript.txt"
+
+# Best-effort video duration (seconds) to bound the final cue.
+DURATION_SECONDS=""
+if command -v ffprobe >/dev/null 2>&1; then
+  DURATION_SECONDS=$(ffprobe -v error -show_entries format=duration -of default=nk=1:nw=1 "$OUTPUT_DIR/video.mp4" 2>/dev/null || true)
+fi
+
+if [[ -n "${TRANSCRIPT_JSON:-}" && -f "$TRANSCRIPT_JSON" ]]; then
+  # Keep the raw JSON under a predictable name alongside the converted files.
+  if [[ "$TRANSCRIPT_JSON" != "$OUTPUT_DIR/transcript.json" ]]; then
+    cp -f "$TRANSCRIPT_JSON" "$OUTPUT_DIR/transcript.json"
+  fi
+  node - "$TRANSCRIPT_JSON" "$VTT" "$TXT" "${DURATION_SECONDS:-0}" <<'LOOMVTT'
+const fs = require("fs");
+const args = process.argv.slice(2);
+const jsonPath = args[0], vttPath = args[1], txtPath = args[2];
+const duration = parseFloat(args[3]) || 0;
+
+function writeStub(msg) {
+  fs.writeFileSync(vttPath, "WEBVTT\n\nNOTE " + msg + "\n");
+  fs.writeFileSync(txtPath, "");
+  console.error("WARN: " + msg);
+}
+
+let root;
+try { root = JSON.parse(fs.readFileSync(jsonPath, "utf8")); }
+catch (e) { writeStub("transcript JSON could not be parsed: " + e.message); process.exit(0); }
+
+function firstArray() {
+  for (let i = 0; i < arguments.length; i++) {
+    const c = arguments[i];
+    if (Array.isArray(c) && c.length) return c;
+  }
+  return null;
+}
+let segs = firstArray(
+  root && root.phrases,
+  Array.isArray(root) ? root : null,
+  root && root.transcript,
+  root && root.segments,
+  root && root.cues,
+  root && root.captions,
+  root && root.results
+);
+let wordLevel = false;
+if (!segs) {
+  const words = firstArray(root && root.words, root && root.tokens);
+  if (words) { segs = words; wordLevel = true; }
+}
+if (!segs) {
+  const blob = root && (root.text || root.transcript || root.value);
+  segs = (typeof blob === "string" && blob.trim()) ? [{ value: blob }] : [];
+}
+
+const START_KEYS = ["start_ts", "startTime", "start", "ts", "tsStart", "begin", "offset", "from", "startTimeMs", "startMs"];
+const END_KEYS = ["end_ts", "endTime", "end", "tsEnd", "stop", "to", "endTimeMs", "endMs"];
+const TEXT_KEYS = ["value", "text", "content", "phrase", "caption", "transcript", "word", "token"];
+
+function parseClock(s) {
+  const parts = String(s).trim().split(":").map(Number);
+  if (!parts.length || parts.some(n => !isFinite(n))) return null;
+  let sec = 0;
+  for (const p of parts) sec = sec * 60 + p;
+  return sec;
+}
+function num(v) {
+  if (typeof v === "number" && isFinite(v)) return v;
+  if (typeof v === "string" && v.trim() !== "") {
+    if (isFinite(+v)) return +v;
+    return parseClock(v);
+  }
+  return null;
+}
+function pickKV(o, keys) {
+  for (const k of keys) if (o && o[k] !== undefined && o[k] !== null && o[k] !== "") return [k, o[k]];
+  return [null, undefined];
+}
+function toSec(k, raw) { let v = num(raw); if (v === null) return null; if (/ms$/i.test(k || "")) v /= 1000; return v; }
+function pick(o, keys) { return pickKV(o, keys)[1]; }
+function startOf(o) { const kv = pickKV(o, START_KEYS); return toSec(kv[0], kv[1]); }
+function endOf(o) { const kv = pickKV(o, END_KEYS); return toSec(kv[0], kv[1]); }
+function textOf(o) { if (typeof o === "string") return o; const t = pick(o, TEXT_KEYS); return t == null ? "" : String(t); }
+
+let cues;
+if (wordLevel) {
+  cues = [];
+  const CHUNK = 12;
+  for (let i = 0; i < segs.length; i += CHUNK) {
+    const grp = segs.slice(i, i + CHUNK);
+    const text = grp.map(textOf).join(" ").replace(/\s+/g, " ").trim();
+    const starts = grp.map(startOf).filter(v => v != null);
+    const ends = grp.map(endOf).filter(v => v != null);
+    cues.push({ start: starts.length ? starts[0] : null, end: ends.length ? ends[ends.length - 1] : null, text });
+  }
+} else {
+  cues = segs.map(s => ({ start: startOf(s), end: endOf(s), text: textOf(s).replace(/\s+/g, " ").trim() }))
+             .filter(c => c.text.length || c.start != null);
+}
+
+const anyStart = cues.some(c => c.start != null);
+
+for (let i = 0; i < cues.length; i++) {
+  if (cues[i].start == null) continue;
+  if (cues[i].end == null) {
+    let ns = null;
+    for (let j = i + 1; j < cues.length; j++) if (cues[j].start != null) { ns = cues[j].start; break; }
+    cues[i].end = ns != null ? ns : (duration > cues[i].start ? duration : cues[i].start + 4);
+  }
+  if (cues[i].end <= cues[i].start) cues[i].end = cues[i].start + 0.5;
+}
+
+function fmt(t) {
+  if (!(t > 0)) t = 0;
+  const h = Math.floor(t / 3600), m = Math.floor((t % 3600) / 60), s = Math.floor(t % 60);
+  const ms = Math.round((t - Math.floor(t)) * 1000);
+  const p = (n, w) => String(n).padStart(w, "0");
+  return p(h, 2) + ":" + p(m, 2) + ":" + p(s, 2) + "." + p(ms, 3);
+}
+
+let out = "WEBVTT\n\n";
+if (anyStart) {
+  let n = 0;
+  for (const c of cues) {
+    if (!c.text || c.start == null) continue;
+    n++;
+    out += n + "\n" + fmt(c.start) + " --> " + fmt(c.end) + "\n" + c.text + "\n\n";
+  }
+} else {
+  const whole = cues.map(c => c.text).filter(Boolean).join(" ").replace(/\s+/g, " ").trim();
+  const end = duration > 0 ? duration : Math.max(1, whole.split(/\s+/).length * 0.4);
+  out += "NOTE No per-cue timings were present in the source transcript JSON; emitting an untimed transcript.\n\n";
+  out += "1\n" + fmt(0) + " --> " + fmt(end) + "\n" + (whole || "(empty transcript)") + "\n\n";
+}
+fs.writeFileSync(vttPath, out);
+
+let txt = cues.map(c => c.text).filter(Boolean).join("\n").trim();
+if (!txt && root && typeof root.text === "string") txt = root.text.trim();
+fs.writeFileSync(txtPath, txt + (txt ? "\n" : ""));
+
+console.error("Transcript converted: " + cues.filter(c => c.text).length + " segments -> " + vttPath + (anyStart ? " (timed)" : " (untimed fallback)"));
+LOOMVTT
+else
+  echo "WARN: no transcript JSON found - loom-dl may not have a transcript for this video." >&2
+  printf 'WEBVTT\n\nNOTE No transcript was produced by loom-dl for this video.\n' > "$VTT"
+  : > "$TXT"
+fi
 
 echo "Sampling frames (1 per ${FRAME_INTERVAL_SECONDS}s, max width ${FRAME_MAX_WIDTH_PX}px)..." >&2
 ffmpeg -y -i "$OUTPUT_DIR/video.mp4" \
@@ -69,7 +248,10 @@ ffmpeg -y -i "$OUTPUT_DIR/video.mp4" \
   "$OUTPUT_DIR/frame_%03d.jpg" 2>/dev/null
 
 FRAME_COUNT=$(ls "$OUTPUT_DIR"/frame_*.jpg 2>/dev/null | wc -l | tr -d ' ')
-DURATION=$(ffmpeg -i "$OUTPUT_DIR/video.mp4" 2>&1 | grep Duration | awk '{print $2}' | tr -d ',' || echo "unknown")
+# `|| true` keeps ffmpeg's nonzero exit (it has no output file) from tripping
+# pipefail; the empty-check supplies the fallback without a stray extra line.
+DURATION=$(ffmpeg -i "$OUTPUT_DIR/video.mp4" 2>&1 | grep -m1 Duration | awk '{print $2}' | tr -d ',' || true)
+[[ -z "$DURATION" ]] && DURATION="unknown"
 
 echo "Processed: $FRAME_COUNT frames, duration $DURATION" >&2
 echo "$OUTPUT_DIR"

--- a/plugins/loom-vision/skills/loom-vision/process-loom.sh
+++ b/plugins/loom-vision/skills/loom-vision/process-loom.sh
@@ -68,7 +68,9 @@ mkdir -p "$OUTPUT_DIR"
 # loom-dl treats a path ending in .mp4 as an explicit file. Do NOT change it to
 # a bare directory - loom-dl would then misinterpret the target and break.
 echo "Downloading Loom video $VIDEO_ID..." >&2
-loom-dl --url "$URL" --out "$OUTPUT_DIR/video.mp4" --transcript 2>&2
+# >&2 keeps loom-dl's progress chatter (which it prints on stdout) off OUR
+# stdout - the output directory path must be the only line stdout emits.
+loom-dl --url "$URL" --out "$OUTPUT_DIR/video.mp4" --transcript >&2
 
 # --- transcript JSON -> VTT + plaintext ------------------------------------
 # transcript JSON->VTT conversion added per beta feedback from Bart Boughton,


### PR DESCRIPTION
## What changed

The ClawHub-publishable loom-vision bundle (`plugins/loom-vision/clawhub/loom-vision/`) was stale relative to the canonical chassis script. It was staged 2026-07-07, but the chassis copy got the transcript fix (1636a68) on 2026-07-15, and PR #54 merged the pre-fix bundle on 2026-07-16. Publishing it as-is would have shipped a skill whose transcript half silently does nothing - the exact defect class the chassis fix was written for.

- **`clawhub/loom-vision/process-loom.sh` resynced from the canonical chassis script.** The stale copy told the agent to read `transcript.vtt`, a file loom-dl 1.1.1 never writes (it writes `video.transcript.json`). The synced copy carries the transcript JSON to VTT/plaintext converter. Only intentional deltas remain: `OUTPUT_ROOT` defaults to `${TMPDIR:-/tmp}/loom-vision`, and chassis-only comment references are gone.
- **Stdout contract fixed in BOTH copies.** `loom-dl ... 2>&2` was a no-op redirect, so loom-dl's progress chatter landed on stdout; the stale copy additionally leaked a stray `unknown` line from the duration fallback under pipefail. The documented contract is that the output directory path is the only stdout line - it now is.
- **Bundle `SKILL.md` / `README.md`** document the real outputs (`transcript.vtt`, `transcript.txt`, `transcript.json` plus the conversion note) and the `node` dependency (`requires.bins` + brew install spec). `TMPDIR` declared in `envVars` with `required: false` since ClawHub's security analysis flags undeclared env var reads.
- **`CLAWHUB_SUBMISSION.md`**: dependency list and bundle size corrected. No other runbook changes - the publish flow verified on 2026-07-07 is untouched.
- **`chassis/CHANGELOG.md`**: entry under `## Unreleased`. `chassis/VERSION` untouched.

## How it was verified

- [x] Ran the SHIPPED bundle script against a real Loom URL (`loom.com/share/0d2d3ecc...`, 14m56s): produced `video.mp4` + 179 frames + `video.transcript.json` only - **no `transcript.vtt`**, and a stray `unknown` line on stdout. Defect confirmed live.
- [x] Ran the FIXED bundle script against the same URL: stdout carried exactly one line (the output dir); directory contains `video.mp4`, `transcript.json`, `transcript.vtt` (84 timed cues), `transcript.txt`, 179 x 1280x720 JPEG frames.
- [x] `bash -n` on both scripts; mode 755 preserved on both (the inert-non-executable-artifact class from v0.3.0 notes).
- [x] SKILL.md frontmatter parses as valid YAML (ruby psych); `requires.bins` = [node, loom-dl, ffmpeg] and `envVars` match exactly what the script reads.
- [x] Code-body diff of bundle script vs chassis script: only the OUTPUT_ROOT default and two comment lines differ, as the runbook promises.
- [x] Hygiene grep on the published folder for `Sean`, `/Users/jax`, `CHASSIS_HOME`, iCloud references, personal names: clean.

## Notes

Nothing has been published to ClawHub yet, so this lands before first publish. The submit runbook (`CLAWHUB_SUBMISSION.md`) and its MIT-0 licensing warning are unchanged and remain Sean's manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
