### PR TITLE
docs(changelog): six plugins published to behalfbot-plugins - pin bump staged for post-tag

### DIFF
--- a/chassis/CHANGELOG.md
+++ b/chassis/CHANGELOG.md
@@ -18,6 +18,10 @@ Semver:
 
 ## Unreleased
 
+### Changed
+
+- **All seven plugins are now published in `behalfbot-plugins`.** `angel-protocol`, `bfl`, `dating`, `remarkable`, `restaurant-booking`, and `whatsapp` join `loom-vision` in the central plugins repo (behalfbot-plugins#3), genericized for public installs (no principal names, no reference-install repo slugs, and restaurant-booking no longer ships a real Discord channel id as its soft-confirm default - it now requires per-install configuration and fails loudly when unset). Registry floors: `dating` requires chassis >= 0.3.0 (the sanitized post-#99/#101 content and the overlay resolver it shadows through are both 0.3.0); the rest require >= 0.2.0, the first chassis that fetches at all. `PLUGINS_PIN` still points at `v0.1.0` in this entry: the pin can only move to a tag+SHA that exists AFTER the plugins-repo merge is tagged, so the bump lands as its own reviewed change once the tag is cut. Until the pin moves, every install keeps running the baked copies; after it moves, the fetched copies win by name under the 0.3.0 overlay and the baked tree remains the fallback.
+
 ### Fixed
 
 - **`chassis-update.sh` no longer silently reverts customer compose overrides (#100).** The updater brought the stack back with bare `docker compose pull` + `docker compose up -d`, dropping the per-install override (published ports, image pins, env_file, scaled-to-0 services) and then reporting success - its healthcheck polls the chassis container over the internal network and cannot see published ports. On the install that surfaced this, the update unpublished postgres's `127.0.0.1:5432` (breaking every host-side consumer and triggering a watchdog VM bounce mid-update) and created a fresh empty Vaultwarden the override scales to 0. Now:


### PR DESCRIPTION
## What

Companion PR to scrollinondubs/behalfbot-plugins#3, which ports the six remaining baked plugins (`angel-protocol`, `bfl`, `dating`, `remarkable`, `restaurant-booking`, `whatsapp`) into the central plugins repo. This PR adds the `## Unreleased` CHANGELOG entry documenting the publication and the pending pin bump.

**`chassis/PLUGINS_PIN` is deliberately unchanged** (still `v0.1.0 7f82667...`). It cannot move yet: the fetcher hard-fails (exit 3, treated as a supply-chain signal) unless the pinned tag resolves to exactly the pinned SHA, and the SHA the new tag will point at does not exist until the plugins PR merges. Guessing a SHA here would brick the fetch on every install. `chassis/VERSION` is also untouched per repo policy (version bumps are Sean's call).

No baked plugin files are touched, so this does not conflict with the in-flight dating-plugin work on `plugins/dating/scheduled-tasks/recovery-hooks.d/dating-emulator-recovery.sh`.

## Exact post-merge steps (the pin bump)

Run only after behalfbot-plugins#3 is merged, in this order:

1. In `behalfbot-plugins`: re-diff `dating/` against this repo's `plugins/dating/` and sync if the concurrent dating fix merged after the port snapshot (taken at `b742d08`). The overlay makes a fetched plugin win by name, so tagging a stale dating tree would shadow a newer baked copy on every >= 0.3.0 install.
2. In `behalfbot-plugins`: tag the merge commit on main and push the tag:
   `git tag v0.2.0 <merge-commit-sha> && git push origin v0.2.0`
   (next repo-level tag; adjust if numbering has advanced).
3. Get the commit SHA the tag resolves to: `git rev-parse v0.2.0^{}` (40 hex chars). This is the merge commit SHA on behalfbot-plugins main. Never a guess, never a branch SHA.
4. On THIS branch (or a follow-up PR), set `chassis/PLUGINS_PIN` to the single line:
   `v0.2.0 <that-40-hex-sha>`
5. Sanity check before merging the pin: `bash chassis/scripts/fetch-plugins.sh --tag v0.2.0 --sha <that-sha>` against a scratch `CUSTOMER_HOME` should fetch, pass the registry sanity check, and write a lockfile listing 7 plugins (6 on a 0.2.x chassis, with `dating` in `skipped[]`).
6. Merge. On the next boot after installs pull the chassis update, `fetch-plugins.sh` fetches the tree and `resolve-plugin-root.sh` overlays it: all seven fetched copies win by name, baked stays as fallback.

## Behavior until then

Nothing changes at runtime from this PR: the pin still resolves to `v0.1.0` (loom-vision only), so installs keep running baked copies of the six.

## Verification

- CHANGELOG is the only file changed (`git diff --stat` confirms).
- The published tree in behalfbot-plugins#3 was validated against this repo's machinery: the real `resolve-plugin-root.sh` composed an overlay with all 7 plugins winning as fetched (rc=0), and the fetcher's verbatim sanity-check and min-version-gate logic pass (0.2.0 chassis installs 6 and skips `dating 0.3.0`; 0.3.0 installs 7). Full transcript in the plugins PR body.
- The tag+SHA network path of the fetcher was NOT exercised (no tag exists yet); step 5 above covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
