### PR TITLE
fix(mcp): memory MEMORY_FILE_PATH broken inside the chassis container (mount-path mismatch)

### DIFF
--- a/chassis/.mcp.json.template
+++ b/chassis/.mcp.json.template
@@ -4,12 +4,10 @@
   "mcpServers": {
 
     "memory": {
-      "_role": "default-on, no auth — knowledge graph",
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-memory"],
-      "env": {
-        "MEMORY_FILE_PATH": "${CHASSIS_HOME}/memory/memory.jsonl"
-      }
+      "_role": "default-on, no auth - knowledge graph",
+      "_note": "MEMORY_FILE_PATH resolves from the launch cwd (the customer root) at spawn time - it is NOT baked as an absolute path. .mcp.json is bind-mount-shared between the host and the chassis container, which see the same directory at different absolute paths (the host customer path vs /app/customer). A single baked absolute path is therefore valid in only one of the two namespaces. Claude Code spawns this stdio server with cwd = the customer root in both, so $(pwd)/memory/memory.jsonl points at the one shared file either way. The previous ${CHASSIS_HOME} token was never substituted by hydrate-mcp-json.py (it only handles <ANGLE_BRACKET> placeholders), so a fresh render emitted the literal string and any legacy render baked a host-only absolute path.",
+      "command": "sh",
+      "args": ["-c", "export MEMORY_FILE_PATH=\"$(pwd)/memory/memory.jsonl\"; exec npx -y @modelcontextprotocol/server-memory"]
     },
 
     "playwright": {


### PR DESCRIPTION
## Summary

The `memory` MCP server silently reads an empty graph and writes nowhere when it runs **inside the chassis container** (heartbeats, briefings, any `claude -p`). On a live install this froze the knowledge graph for ~2 weeks before anyone noticed, because host-side interactive sessions kept working.

## Root cause

`chassis/.mcp.json.template:11` set:

```
"MEMORY_FILE_PATH": "${CHASSIS_HOME}/memory/memory.jsonl"
```

Two independent problems:

1. **`${CHASSIS_HOME}` is never substituted.** `hydrate-mcp-json.py` only substitutes `<ANGLE_BRACKET>` placeholders (`_PLACEHOLDER_PAT = re.compile(r'<([A-Z_][A-Z0-9_]*)>')`). The `${VAR}` shell form is left untouched. It was the ONLY `${...}` token in the whole template - every other entry uses `<...>`. On a fresh hydrate the literal string `${CHASSIS_HOME}/memory/memory.jsonl` survives into `.mcp.json`, so the server writes to a bogus relative directory. (Older installs carry an absolute host path baked by the retired sed/jq/envsubst renderer.)

2. **A single baked absolute path cannot be correct in both mount namespaces.** `.mcp.json` lives at the customer root and is bind-mount-shared: the host sees it at the host customer path, the container sees the same directory at `/app/customer`. A host-absolute value (`/Users/.../memory/memory.jsonl`) does not exist inside the container; a container-absolute value (`/app/customer/...`) does not exist on the host. Whichever you bake, one namespace breaks.

### Confirmed on a live install

- Container view: `/app/customer/memory/memory.jsonl` = the real file (34 entities, 0 relations), frozen since 2026-07-09.
- The container's memory MCP was configured with the host absolute path, which does not exist in-container, so `read_graph` returned an empty graph and every write was discarded. Two weeks of container-side writes lost.
- Host sessions read the same 34 entities fine, which is why the bug looked intermittent.

## Fix

Launch the server through `sh` so `MEMORY_FILE_PATH` resolves from the **launch cwd** at spawn time instead of being baked. Claude Code spawns this stdio server with cwd = the customer root in both contexts (host repo root, and `/app/customer` for the in-container dispatcher), so `$(pwd)/memory/memory.jsonl` points at the one shared file in either namespace. No hydrator change, no per-context config, no symlink, no absolute path.

```json
"command": "sh",
"args": ["-c", "export MEMORY_FILE_PATH=\"$(pwd)/memory/memory.jsonl\"; exec npx -y @modelcontextprotocol/server-memory"]
```

### Alternatives considered and rejected

- **Bake a container-absolute path** - breaks host sessions (same class of bug, mirrored).
- **Teach the hydrator to substitute `${CHASSIS_HOME}`** - still bakes one absolute path, so still breaks the other namespace. Does not address the shared-file constraint.
- **Entrypoint symlink `host_customer_path -> /app/customer`** (the interim mitigation, see below) - works but is customer-specific, requires the container to learn the host path via compose, needs `mkdir -p` of host-shaped parents as root, and adds a symlink lifecycle to maintain. The cwd-relative launch needs none of that. Worth keeping in mind only if a consumer ever launches `claude` from a subdirectory of the customer root (then cwd != root); no current consumer does - the heartbeat dispatcher runs from `/app/customer` and host sessions run from the repo root.

## Interim mitigation currently live on the affected install

A non-durable root symlink was added so the stale baked host path resolves in-container:

```
docker exec -u root behalfbot ln -sfn /app/customer <host_customer_path>
```

This dies on container restart. This PR is the durable replacement; once it ships and the install re-hydrates `.mcp.json`, the symlink can be removed.

## Test plan

- [x] Template still parses as JSON.
- [x] `hydrate-mcp-json.py` dry-run emits a clean memory block with no leftover tokens and no absolute path.
- [x] Launch command resolves to the correct shared file in both cwd contexts: host root -> host customer memory file; `/app/customer` -> `/app/customer/memory/memory.jsonl` (same physical file via the mount, 34 lines).
- [ ] After deploy + re-hydrate: in-container `read_graph` returns 34 entities (not 0); a write via the container's memory MCP lands in the shared file and is visible from a host session.
- [ ] Remove the interim symlink on the affected install and confirm memory still works across a container restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)