### PR TITLE
fix(bake-env): guard no-match PATH_KEYS grep so pipefail doesn't abort the bake

### DIFF
--- a/chassis/scripts/bake-env.sh
+++ b/chassis/scripts/bake-env.sh
@@ -189,7 +189,14 @@ fi
 # new-jaxity#49 for context. The strip step still does that work; only the
 # re-append for the three container-overridden keys is removed.
 PATH_KEYS_REGEX='^(CUSTOMER_HOME|CHASSIS_HOME|REPO|MANIFEST|CUSTOMER_CLAUDE_DIR)='
-PATH_ORIGINALS=$(echo "$APP_VARS" | grep -E "$PATH_KEYS_REGEX" | sort -u)
+# `|| true` guards the no-match case: when none of the new vars are host-path
+# keys, grep exits 1, and under `set -o pipefail` (see `set -euo pipefail` at
+# the top) that non-zero propagates through the pipeline and `set -e` aborts
+# the whole bake. This bit whenever bake ran from a shell that had already
+# sourced `.env` (so the path keys were pre-env and got subtracted out). Every
+# sibling grep in this script (TOXIC_PRESENT, APP_VARS) already carries the
+# same guard.
+PATH_ORIGINALS=$(echo "$APP_VARS" | grep -E "$PATH_KEYS_REGEX" | sort -u || true)
 if [[ -n "$PATH_ORIGINALS" ]]; then
     while IFS= read -r line; do
         key="${line%%=*}"


### PR DESCRIPTION
## What

One-line guard on the `PATH_ORIGINALS` pipeline in `chassis/scripts/bake-env.sh`:

```diff
-PATH_ORIGINALS=$(echo "$APP_VARS" | grep -E "$PATH_KEYS_REGEX" | sort -u)
+PATH_ORIGINALS=$(echo "$APP_VARS" | grep -E "$PATH_KEYS_REGEX" | sort -u || true)
```

(plus a comment explaining why the guard is there).

## Why

The script runs under `set -euo pipefail`. When none of the newly-sourced vars are host-path keys (`CUSTOMER_HOME` / `CHASSIS_HOME` / `REPO` / `MANIFEST` / `CUSTOMER_CLAUDE_DIR`), `grep` exits 1. `pipefail` propagates that non-zero out of the command substitution and `set -e` aborts the entire bake before `.env.baked` is ever written.

It bites specifically when `bake-env.sh` is invoked from a shell that has already sourced `.env`. Those path keys are then present in the pre-source snapshot and get subtracted out by the `comm -13` diff, so the only new vars are non-path ones and the grep matches nothing.

Every sibling grep in the script (`TOXIC_PRESENT`, `APP_VARS`) already carries the `|| true` guard - this line was the one that missed it.

## Context

Surfaced on Sean's install on 2026-07-24 during Gmail-monitor go-live: a re-bake that added only `GMAIL_MONITOR_*` vars aborted at this line. This is the durable upstream version of a guard applied on-disk that day.

## How verified

- `bash -n chassis/scripts/bake-env.sh` - parses clean.
- Isolated repro under `set -euo pipefail` with a no-match grep: the pre-fix pipeline exits 1 and never reaches the line after it; the `|| true` variant reaches it with an empty `PATH_ORIGINALS` and exit 0.
- Ran the real `bake-env.sh --dry-run` from a shell that had pre-sourced a `.env` defining only non-path vars: completes past the `PATH_ORIGINALS` line and exits 0 (pre-fix, this aborted there).

## Version

Does not touch `chassis/VERSION`. Flagging rather than bumping: `VERSION` is `0.3.0` and the sibling memory-MCP fix (#112) also shipped without a bump this round. Say the word if you want a patch bump on either of these.

## Test plan

- [x] Script parses.
- [x] No-match grep no longer aborts (isolated repro + real dry-run).
- [ ] Ratify + merge (Sean).