### PR TITLE
feat(chassis): reconcile-mcp-config - detect + fix .mcp.json vs chassis.config drift

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'chassis/second_brain/**'
       - 'chassis/scripts/hydrate-mcp-json.py'
+      - 'chassis/scripts/reconcile-mcp-config.py'
       - 'chassis/scripts/gmail-attachment.py'
       - 'chassis/scripts/tests/**'
       - 'chassis/.mcp.json.template'
@@ -21,6 +22,7 @@ on:
     paths:
       - 'chassis/second_brain/**'
       - 'chassis/scripts/hydrate-mcp-json.py'
+      - 'chassis/scripts/reconcile-mcp-config.py'
       - 'chassis/scripts/gmail-attachment.py'
       - 'chassis/scripts/tests/**'
       - 'chassis/.mcp.json.template'

--- a/chassis/scripts/bootstrap-mcp-config.sh
+++ b/chassis/scripts/bootstrap-mcp-config.sh
@@ -42,6 +42,10 @@
 #   --force. The use case is install-time bootstrap, NOT routine refresh.
 #   If you need to rotate a token, edit `.mcp.json` directly or rotate in
 #   Vaultwarden + re-run with --force.
+# - Even with --force, refuses if a re-hydrate would DROP a server that is live
+#   in the existing `.mcp.json` but not enabled in chassis.config.yaml (checked
+#   via reconcile-mcp-config.py). Run `reconcile-mcp-config.py --fix` to add the
+#   preserving flags, or pass --allow-drop to overwrite and accept the loss.
 # - Never logs token values. The hydrator names only the placeholders it could
 #   NOT resolve, and the env keys it dropped for that reason.
 # - File written with `umask 077` to land at 0600.
@@ -49,7 +53,8 @@
 # Usage
 # =====
 #   bash chassis/scripts/bootstrap-mcp-config.sh              # idempotent - skips if file exists
-#   bash chassis/scripts/bootstrap-mcp-config.sh --force      # rewrite even if file exists
+#   bash chassis/scripts/bootstrap-mcp-config.sh --force      # rewrite even if file exists (guarded)
+#   bash chassis/scripts/bootstrap-mcp-config.sh --force --allow-drop  # rewrite even if it drops live servers
 #   bash chassis/scripts/bootstrap-mcp-config.sh --dry-run    # print result to stdout, don't write
 #
 # Related
@@ -81,10 +86,12 @@ ENV_FILE="$CUSTOMER_HOME/.env"
 
 FORCE=0
 DRY_RUN=0
+ALLOW_DROP=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --force) FORCE=1; shift ;;
         --dry-run) DRY_RUN=1; shift ;;
+        --allow-drop) ALLOW_DROP=1; shift ;;
         -h|--help)
             grep -E "^# (Usage|  bash)" "$0" | sed 's/^# //'
             exit 0
@@ -146,6 +153,39 @@ fi
 if [[ -f "$TARGET" && $FORCE -eq 0 ]]; then
     echo "skip: $TARGET already exists; pass --force to overwrite" >&2
     exit 0
+fi
+
+# --force destructive-drift guard.
+# A --force re-hydrate rebuilds .mcp.json from config + template, which SILENTLY
+# drops any server present in the live file but not enabled in config. Before
+# overwriting an existing file, ask reconcile-mcp-config.py whether that would
+# drop anything. If it would, refuse and point at the fix. Legit token-rotation
+# --force runs are unaffected: a consistent install has an empty drop set and
+# the guard passes silently. Bypass with --allow-drop when the drop is intended.
+RECONCILER="$SCRIPT_DIR/reconcile-mcp-config.py"
+if [[ -f "$TARGET" && $FORCE -eq 1 && $ALLOW_DROP -eq 0 && -f "$RECONCILER" ]]; then
+    reconciler_args=(--config "$CONFIG" --template "$TEMPLATE" --mcp "$TARGET" --json)
+    [[ -f "$ENV_FILE" ]] && reconciler_args+=(--env "$ENV_FILE")
+    # The reconciler exits 1 when it finds drift, which under `set -e` would
+    # abort this script. Swallow its exit code here - the drop set is read from
+    # the JSON body, not the exit code.
+    reconciler_json=$(python3 "$RECONCILER" "${reconciler_args[@]}" 2>/dev/null || true)
+    would_drop=$(printf '%s' "$reconciler_json" | python3 -c '
+import json, sys
+try:
+    r = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print(",".join(i["server"] for i in r.get("present_but_would_drop", [])))
+' 2>/dev/null || true)
+    if [[ -n "$would_drop" ]]; then
+        echo "REFUSING --force: a re-hydrate would DROP live MCP servers: $would_drop" >&2
+        echo "  They are present in $TARGET but chassis.config.yaml does not enable them." >&2
+        echo "  Preserve them: python3 $RECONCILER --fix" >&2
+        echo "  (writes the enabling flags into chassis.config.yaml, then re-run this with --force)" >&2
+        echo "  To overwrite and accept the drop anyway, pass --allow-drop." >&2
+        exit 3
+    fi
 fi
 
 rc=0

--- a/chassis/scripts/reconcile-mcp-config.py
+++ b/chassis/scripts/reconcile-mcp-config.py
@@ -1,0 +1,676 @@
+#!/usr/bin/env python3
+"""reconcile-mcp-config.py - detect + fix drift between a live .mcp.json and
+what chassis.config.yaml + .mcp.json.template would hydrate.
+
+Why this exists
+===============
+An install's live .mcp.json can drift from what the hydrator would emit today.
+When it does, a full re-hydrate (bootstrap-mcp-config.sh --force, or any regen)
+silently DROPS every server that is present in the live file but not enabled in
+config. No error, no warning - working MCP integrations just vanish.
+
+Concrete case (2026-07-24): a live .mcp.json running 15 servers, a config that
+enables only 6. The 9-server gap are all in the template but gated behind module
+flags the config never declared. A --force re-hydrate there would be destructive.
+
+This tool makes that gap visible before it bites, and can write the missing
+flags back into chassis.config.yaml so a later hydrate keeps every live server.
+
+What it does
+============
+Reads the live .mcp.json, the .mcp.json.template, chassis.config.yaml, and .env.
+It REUSES hydrate-mcp-json.py's gating logic (the `_enable_when` evaluator, the
+placeholder substitution, the obsidian mode normalization) rather than
+reimplementing it - there is one predicate evaluator in the chassis, and it
+lives in the hydrator. See load_hydrator() for how it is imported.
+
+It computes three sets by comparing the live server keys against the set the
+hydrator WOULD emit for the given config + template:
+
+  PRESENT_BUT_WOULD_DROP  in live, hydrate would NOT emit. The dangerous set.
+                          For each, the exact `_enable_when` flag from the
+                          template that would preserve it is resolved and
+                          printed - the fix is to add that flag to config.
+  WOULD_EMIT_BUT_MISSING  config/template says on, live lacks it. A re-hydrate
+                          would ADD it. Under-provisioned; surfaced as info.
+  CONSISTENT              present in both. Fine.
+
+It also:
+  - verifies, for every server that WOULD emit, that .env holds the
+    <PLACEHOLDER> tokens it needs, so a later hydrate does not silently produce
+    placeholder-broken entries (mirrors the hydrator's exit-2 condition).
+  - flags host-vs-container path-model mismatches where detectable (a live entry
+    carrying a host absolute path where the template renders a container path
+    like ${CHASSIS_ROOT:-/app/chassis}/...).
+
+Modes
+=====
+  --check (default)  report only. Human summary, or --json. Exit nonzero on any
+                     drift. CI / smoke-test friendly. Read-only on everything.
+  --fix              write the suggested flags into chassis.config.yaml
+                     (idempotent, backup first, comments preserved). NEVER
+                     writes .mcp.json - that stays the hydrator's job. --fix
+                     only ever edits chassis.config.yaml.
+
+Guardrails
+==========
+  - Read-only on .mcp.json. Always.
+  - --fix only ever edits chassis.config.yaml, with a .bak backup written first.
+  - Idempotent. Re-running against a reconciled install is a no-op.
+  - No secrets in output - server names, config flag paths, and placeholder
+    token NAMES only. Never a token value.
+
+Exit codes
+==========
+  0 - consistent (check), or fix applied / nothing to fix
+  1 - drift detected (check mode)
+  2 - bad input (a required file is missing or malformed)
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import shutil
+import sys
+
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+HYDRATOR_PATH = os.path.join(SCRIPT_DIR, 'hydrate-mcp-json.py')
+
+
+def load_hydrator():
+    """Import hydrate-mcp-json.py as a module and return it.
+
+    The hydrator's filename has a hyphen, so a plain `import` cannot name it.
+    It IS cleanly importable by path, though: every function is module-level and
+    main() is guarded by `if __name__ == '__main__'`, so importing runs no side
+    effects. This is the exact mechanism chassis/second_brain/tests already use
+    to drive the real hydrator. Importing rather than refactoring keeps
+    hydrate-mcp-json.py byte-identical, so its existing test suite is untouched.
+    """
+    spec = importlib.util.spec_from_file_location('hydrate_mcp_json', HYDRATOR_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def normalize_render_config(hydrator, config):
+    """Return the config the hydrator would actually render against.
+
+    hydrate-mcp-json.py's main() does one config normalization before it calls
+    hydrate(): an obsidian backend with a non-adapter mode is forced to adapter,
+    because obsidian has no native MCP server and direct mode would render no
+    second-brain surface at all. To predict the emitted set faithfully, the
+    reconciler applies the same normalization. It is replicated here (rather
+    than imported) because it lives inside main() in the hydrator; kept small
+    and adjacent to a pointer at the original so the coupling is visible.
+    """
+    if not isinstance(config, dict):
+        return config
+    render = json.loads(json.dumps(config))  # never mutate the caller's config
+    sb = render.get('second_brain')
+    if isinstance(sb, dict) and sb.get('backend') == 'obsidian':
+        if sb.get('mode') != 'adapter':
+            sb['mode'] = 'adapter'
+    return render
+
+
+# --------------------------------------------------------------------------
+# Predicate parsing - which flag preserves a would-drop server
+# --------------------------------------------------------------------------
+
+def parse_clauses(hydrator, predicate):
+    """Split an `_enable_when` predicate into structured clauses.
+
+    Returns a list of dicts: {path, op, kind, value, raw_literal}. The RHS is
+    parsed with the hydrator's OWN parse_literal so a literal means the same
+    thing here as it does at hydrate time. Clauses whose RHS the hydrator cannot
+    parse are dropped from the structured view (the hydrator treats the whole
+    predicate as False in that case; we only use this view to SUGGEST a fix, and
+    an unparsable literal has no safe suggestion).
+    """
+    out = []
+    for raw in predicate.split('&&'):
+        clause = raw.strip()
+        if '!=' in clause and '==' not in clause:
+            lhs, _, rhs = clause.partition('!=')
+            op = '!='
+        elif '==' in clause:
+            lhs, _, rhs = clause.partition('==')
+            op = '=='
+        else:
+            continue
+        path = lhs.strip()
+        if path.startswith('chassis.config.yaml.'):
+            path = path[len('chassis.config.yaml.'):]
+        parsed = hydrator.parse_literal(rhs)
+        if parsed is None:
+            continue
+        kind, value = parsed
+        out.append({
+            'path': path,
+            'op': op,
+            'kind': kind,
+            'value': value,
+            'raw_literal': rhs.strip(),
+        })
+    return out
+
+
+def yaml_value_literal(kind, value):
+    """Render a parsed literal back into the text form written into YAML."""
+    if kind == 'bool':
+        return 'true' if value else 'false'
+    if kind == 'str':
+        return "'{}'".format(value)
+    return str(value)
+
+
+def resolve_fix(hydrator, entry, config):
+    """Work out what config edits would make `entry` emit.
+
+    Returns (assignments, notes, auto_fixable).
+      assignments : list of {path, value_literal, raw_literal, op} for `==`
+                    clauses that are NOT currently satisfied - the flags to add.
+      notes       : human strings for clauses that cannot be auto-fixed safely.
+      auto_fixable: True only when every unsatisfied clause is an `==` clause.
+
+    `!=` clauses are deliberately NOT auto-applied. The only servers that gate on
+    `!=` are the second-brain pair (siyuan/notion require
+    second_brain.mode != 'adapter'); "fixing" one by flipping mode would silently
+    drop the adapter server, trading one dropped server for another. Those get a
+    note and are left to a human.
+    """
+    predicate = entry.get('_enable_when')
+    if not predicate:
+        return [], [], False
+    assignments = []
+    notes = []
+    auto_fixable = True
+    for clause in parse_clauses(hydrator, predicate):
+        current = hydrator.resolve_path(config, clause['path'])
+        if clause['op'] == '==':
+            if current == clause['value']:
+                continue  # already satisfied
+            assignments.append({
+                'path': clause['path'],
+                'value_literal': yaml_value_literal(clause['kind'], clause['value']),
+                'raw_literal': clause['raw_literal'],
+                'op': '==',
+            })
+        else:  # !=
+            if current != clause['value']:
+                continue  # already satisfied
+            auto_fixable = False
+            notes.append(
+                "requires {} != {} (currently {}) - resolve by hand; flipping it "
+                "would drop the server it excludes".format(
+                    clause['path'], clause['raw_literal'], repr(current))
+            )
+    return assignments, notes, auto_fixable
+
+
+# --------------------------------------------------------------------------
+# Placeholder check - would an emitted server hydrate broken
+# --------------------------------------------------------------------------
+
+def unresolved_placeholders_for(hydrator, entry, config, env):
+    """Return the sorted set of <PLACEHOLDER> token names that would NOT resolve
+    for this entry, mirroring what hydrate() would leave unresolved.
+
+    Runs the hydrator's own apply_overrides -> strip_meta_keys ->
+    substitute_placeholders pipeline against the entry, so the answer matches
+    what the real hydrate would produce. Only token NAMES are returned, never
+    values, so this is safe to print.
+    """
+    overridden = hydrator.apply_overrides(entry, config)
+    stripped = hydrator.strip_meta_keys(overridden)
+    unresolved = set()
+    hydrator.substitute_placeholders(stripped, env, unresolved)
+    return sorted(unresolved)
+
+
+# --------------------------------------------------------------------------
+# Host-vs-container path-model detection
+# --------------------------------------------------------------------------
+
+def _flatten_strings(obj, prefix=''):
+    """Flatten a JSON-ish structure to {json_path: string_value} for leaves."""
+    out = {}
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            child = '{}.{}'.format(prefix, k) if prefix else k
+            out.update(_flatten_strings(v, child))
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            out.update(_flatten_strings(v, '{}[{}]'.format(prefix, i)))
+    elif isinstance(obj, str):
+        out[prefix] = obj
+    return out
+
+
+_CONTAINER_MARKERS = ('${CHASSIS_ROOT', '/app/chassis', '/app/')
+
+
+def _is_container_path(value):
+    return any(marker in value for marker in _CONTAINER_MARKERS)
+
+
+def _is_host_abs_path(value):
+    """A leading-slash absolute path that is NOT the container root and carries
+    no ${CHASSIS_ROOT} marker - i.e. a path baked for one host's namespace."""
+    if not value.startswith('/'):
+        return False
+    if value.startswith('/app/'):
+        return False
+    if '${CHASSIS_ROOT' in value:
+        return False
+    return True
+
+
+def detect_path_model_mismatches(name, rendered_entry, live_entry):
+    """Compare a server present in both the render and live for host-vs-container
+    path drift. Returns a list of mismatch dicts (possibly empty).
+
+    The signal: the template renders a value carrying a container-root marker
+    (the hydrator does NOT expand ${CHASSIS_ROOT}, so it survives verbatim into
+    the emitted file), while the live file at the same field holds a host
+    absolute path. That is a file written for the wrong namespace.
+    """
+    rendered = _flatten_strings(rendered_entry)
+    live = _flatten_strings(live_entry)
+    mismatches = []
+    for field, tval in rendered.items():
+        lval = live.get(field)
+        if lval is None:
+            continue
+        if _is_container_path(tval) and _is_host_abs_path(lval):
+            mismatches.append({
+                'server': name,
+                'field': field,
+                'template': tval,
+                'live': lval,
+            })
+    return mismatches
+
+
+# --------------------------------------------------------------------------
+# Core drift computation
+# --------------------------------------------------------------------------
+
+def compute_report(hydrator, live, config, template, env):
+    """Build the full drift report. Pure - no I/O, no exit."""
+    render_config = normalize_render_config(hydrator, config)
+    dropped_env = {}
+    hydrated, _unresolved = hydrator.hydrate(render_config, template, env, dropped_env)
+    would_emit = set(hydrated['mcpServers'])
+
+    live_servers = live.get('mcpServers', {}) if isinstance(live, dict) else {}
+    live_keys = {k for k in live_servers if not k.startswith('_')}
+
+    template_servers = template.get('mcpServers', {})
+
+    present_but_would_drop = []
+    for name in sorted(live_keys - would_emit):
+        entry = template_servers.get(name)
+        if not isinstance(entry, dict):
+            present_but_would_drop.append({
+                'server': name,
+                'enable_when': None,
+                'assignments': [],
+                'notes': ['not present in .mcp.json.template - cannot resolve a '
+                          'preserving flag; carried by hand or from an old template'],
+                'auto_fixable': False,
+            })
+            continue
+        assignments, notes, auto_fixable = resolve_fix(hydrator, entry, render_config)
+        present_but_would_drop.append({
+            'server': name,
+            'enable_when': entry.get('_enable_when'),
+            'assignments': assignments,
+            'notes': notes,
+            'auto_fixable': auto_fixable and bool(assignments),
+        })
+
+    would_emit_but_missing = sorted(would_emit - live_keys)
+    consistent = sorted(live_keys & would_emit)
+
+    broken_placeholders = {}
+    for name in sorted(would_emit):
+        entry = template_servers.get(name)
+        if not isinstance(entry, dict):
+            continue
+        missing = unresolved_placeholders_for(hydrator, entry, render_config, env)
+        if missing:
+            broken_placeholders[name] = missing
+
+    path_mismatches = []
+    for name in consistent:
+        entry = template_servers.get(name)
+        if not isinstance(entry, dict):
+            continue
+        rendered_entry = hydrated['mcpServers'].get(name, {})
+        path_mismatches.extend(
+            detect_path_model_mismatches(name, rendered_entry, live_servers.get(name, {}))
+        )
+
+    drift = bool(present_but_would_drop or would_emit_but_missing
+                 or broken_placeholders or path_mismatches)
+
+    return {
+        'present_but_would_drop': present_but_would_drop,
+        'would_emit_but_missing': would_emit_but_missing,
+        'consistent': consistent,
+        'broken_placeholders': broken_placeholders,
+        'path_model_mismatches': path_mismatches,
+        'drift': drift,
+    }
+
+
+# --------------------------------------------------------------------------
+# chassis.config.yaml surgical editing (--fix)
+# --------------------------------------------------------------------------
+
+_ADDED_MARKER = '  # added by reconcile-mcp-config'
+
+
+def _indent_len(line):
+    return len(line) - len(line.lstrip(' '))
+
+
+def _key_of(line):
+    """Return the mapping key on this line, or None for blanks, comments, and
+    list items. Keys in chassis.config.yaml are simple identifiers."""
+    content = line.strip()
+    if not content or content.startswith('#') or content.startswith('- '):
+        return None
+    if ':' not in content:
+        return None
+    key = content.split(':', 1)[0].strip()
+    if not key or key.startswith('#'):
+        return None
+    return key
+
+
+def _block_end(lines, parent_idx, parent_indent):
+    """Index one past the last line belonging to the block whose header is at
+    parent_idx. Stops at the next real key indented at or above parent_indent."""
+    j = parent_idx + 1
+    while j < len(lines):
+        content = lines[j].strip()
+        if content == '' or content.startswith('#'):
+            j += 1
+            continue
+        if _indent_len(lines[j]) <= parent_indent:
+            break
+        j += 1
+    return j
+
+
+def _find_child(lines, key, region_start, region_end, indent):
+    for i in range(region_start, region_end):
+        if _indent_len(lines[i]) == indent and _key_of(lines[i]) == key:
+            return i
+    return -1
+
+
+def _replace_value(line, value_literal):
+    """Replace the value on a `key: value` line, preserving indentation and any
+    trailing inline comment at its original column."""
+    indent = _indent_len(line)
+    indent_str = line[:indent]
+    body = line[indent:]
+    key = body.split(':', 1)[0]
+    after = body[len(key) + 1:]
+    hashpos = after.find('#')
+    new_body = '{}{}: {}'.format(indent_str, key, value_literal)
+    if hashpos >= 0:
+        comment = after[hashpos:]
+        comment_col = indent + len(key) + 1 + hashpos
+        pad = comment_col - len(new_body)
+        if pad < 1:
+            pad = 1
+        return '{}{}{}'.format(new_body, ' ' * pad, comment)
+    return new_body
+
+
+def set_yaml_path(lines, segments, value_literal):
+    """Set (or insert) segments -> value_literal in `lines`, mutating in place.
+
+    Returns 'modified', 'inserted', or 'noop'. Existing leaves are rewritten in
+    place; missing leaves and missing intermediate mappings are inserted as the
+    first child of their parent, tagged with a trailing marker comment.
+    """
+    parent_idx = -1
+    parent_indent = -2
+    region_start, region_end = 0, len(lines)
+    for depth, seg in enumerate(segments):
+        child_indent = parent_indent + 2
+        is_leaf = depth == len(segments) - 1
+        idx = _find_child(lines, seg, region_start, region_end, child_indent)
+        if is_leaf:
+            if idx >= 0:
+                new_line = _replace_value(lines[idx], value_literal)
+                if new_line == lines[idx]:
+                    return 'noop'
+                lines[idx] = new_line
+                return 'modified'
+            insert_at = parent_idx + 1 if parent_idx >= 0 else 0
+            indent_str = ' ' * child_indent
+            lines.insert(insert_at,
+                         '{}{}: {}{}'.format(indent_str, seg, value_literal, _ADDED_MARKER))
+            return 'inserted'
+        if idx >= 0:
+            parent_idx = idx
+            parent_indent = child_indent
+            region_start = idx + 1
+            region_end = _block_end(lines, idx, child_indent)
+        else:
+            insert_at = parent_idx + 1 if parent_idx >= 0 else 0
+            indent_str = ' ' * child_indent
+            lines.insert(insert_at, '{}{}:'.format(indent_str, seg))
+            parent_idx = insert_at
+            parent_indent = child_indent
+            region_start = insert_at + 1
+            region_end = insert_at + 1
+    return 'noop'
+
+
+def gather_fix_assignments(report):
+    """Collect the unique (path, value_literal) assignments to apply, in a
+    stable order, from the auto-fixable would-drop servers only."""
+    seen = {}
+    ordered = []
+    for item in report['present_but_would_drop']:
+        if not item['auto_fixable']:
+            continue
+        for assignment in item['assignments']:
+            key = assignment['path']
+            if key in seen:
+                continue
+            seen[key] = assignment['value_literal']
+            ordered.append((assignment['path'], assignment['value_literal']))
+    return ordered
+
+
+def apply_fix(config_path, report):
+    """Write the suggested flags into chassis.config.yaml. Backs the file up to
+    <path>.bak first, only when there is something to change. Returns a dict
+    describing what happened."""
+    assignments = gather_fix_assignments(report)
+    with open(config_path) as f:
+        text = f.read()
+    lines = text.split('\n')
+
+    applied = []
+    for path, value_literal in assignments:
+        action = set_yaml_path(lines, path.split('.'), value_literal)
+        if action != 'noop':
+            applied.append({'path': path, 'value': value_literal, 'action': action})
+
+    skipped = [item['server'] for item in report['present_but_would_drop']
+               if not item['auto_fixable']]
+
+    if not applied:
+        return {'changed': False, 'applied': [], 'skipped': skipped, 'backup': None}
+
+    backup_path = config_path + '.bak'
+    shutil.copy2(config_path, backup_path)
+    with open(config_path, 'w') as f:
+        f.write('\n'.join(lines))
+    return {'changed': True, 'applied': applied, 'skipped': skipped, 'backup': backup_path}
+
+
+# --------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------
+
+def render_human(report):
+    lines = []
+    pd = report['present_but_would_drop']
+    lines.append('=== MCP config drift report ===')
+    lines.append('')
+    if pd:
+        lines.append('PRESENT_BUT_WOULD_DROP ({}) - live now, a re-hydrate would DROP these:'.format(len(pd)))
+        for item in pd:
+            lines.append('  - {}'.format(item['server']))
+            if item['enable_when']:
+                lines.append('      gate: {}'.format(item['enable_when']))
+            for assignment in item['assignments']:
+                lines.append('      add to config: {}: {}'.format(
+                    assignment['path'], assignment['value_literal']))
+            for note in item['notes']:
+                lines.append('      note: {}'.format(note))
+        lines.append('')
+    else:
+        lines.append('PRESENT_BUT_WOULD_DROP (0) - nothing live would be dropped.')
+        lines.append('')
+
+    wm = report['would_emit_but_missing']
+    if wm:
+        lines.append('WOULD_EMIT_BUT_MISSING ({}) - config says on, live lacks them (info; a re-hydrate adds them):'.format(len(wm)))
+        for name in wm:
+            lines.append('  - {}'.format(name))
+        lines.append('')
+
+    lines.append('CONSISTENT ({}): {}'.format(
+        len(report['consistent']), ', '.join(report['consistent']) or '(none)'))
+    lines.append('')
+
+    bp = report['broken_placeholders']
+    if bp:
+        lines.append('PLACEHOLDER-BROKEN ({}) - would emit but .env is missing tokens:'.format(len(bp)))
+        for name, tokens in bp.items():
+            lines.append('  - {}: {}'.format(name, ', '.join(tokens)))
+        lines.append('')
+
+    pm = report['path_model_mismatches']
+    if pm:
+        lines.append('PATH_MODEL_MISMATCH ({}) - live host path where template renders a container path:'.format(len(pm)))
+        for item in pm:
+            lines.append('  - {} [{}]'.format(item['server'], item['field']))
+            lines.append('      template: {}'.format(item['template']))
+            lines.append('      live:     {}'.format(item['live']))
+        lines.append('')
+
+    if report['drift']:
+        lines.append('DRIFT DETECTED. Run with --fix to write the preserving flags into chassis.config.yaml.')
+    else:
+        lines.append('No drift. Live .mcp.json matches what the hydrator would emit.')
+    return '\n'.join(lines)
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+def resolve_default(*candidates):
+    for c in candidates:
+        if c:
+            return c
+    return None
+
+
+def main(argv=None):
+    customer_home = os.environ.get('CUSTOMER_HOME') or os.environ.get('CHASSIS_HOME') or '.'
+    default_template = os.path.join(os.path.dirname(SCRIPT_DIR), '.mcp.json.template')
+
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument('--config', default=os.path.join(customer_home, 'chassis.config.yaml'),
+                   help='chassis.config.yaml path')
+    p.add_argument('--template', default=default_template, help='.mcp.json.template path')
+    p.add_argument('--env', default=os.path.join(customer_home, '.env'),
+                   help='.env path (for the placeholder check)')
+    p.add_argument('--mcp', default=os.path.join(customer_home, '.mcp.json'),
+                   help='live .mcp.json path (read-only)')
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument('--check', action='store_true', help='report only (default)')
+    mode.add_argument('--fix', action='store_true',
+                      help='write preserving flags into chassis.config.yaml')
+    p.add_argument('--json', action='store_true', help='machine-readable output')
+    args = p.parse_args(argv)
+
+    hydrator = load_hydrator()
+
+    for label, path in (('template', args.template), ('live .mcp.json', args.mcp)):
+        if not os.path.exists(path):
+            print('ERROR: {} not found: {}'.format(label, path), file=sys.stderr)
+            return 2
+
+    try:
+        template = hydrator.load_json(args.template)
+    except (ValueError, OSError) as exc:
+        print('ERROR: cannot parse template {}: {}'.format(args.template, exc), file=sys.stderr)
+        return 2
+    try:
+        live = hydrator.load_json(args.mcp)
+    except (ValueError, OSError) as exc:
+        print('ERROR: cannot parse live .mcp.json {}: {}'.format(args.mcp, exc), file=sys.stderr)
+        return 2
+
+    if os.path.exists(args.config):
+        config = hydrator.load_yaml(args.config)
+    else:
+        print('WARN: config not found: {} - treating as empty. Feature-gated '
+              'servers count as would-drop.'.format(args.config), file=sys.stderr)
+        config = {}
+
+    env = hydrator.load_env(args.env)
+
+    report = compute_report(hydrator, live, config, template, env)
+
+    if args.fix:
+        if not os.path.exists(args.config):
+            print('ERROR: --fix needs an existing chassis.config.yaml to edit: {}'.format(
+                args.config), file=sys.stderr)
+            return 2
+        result = apply_fix(args.config, report)
+        if args.json:
+            print(json.dumps({'report': report, 'fix': result}, indent=2))
+        elif result['changed']:
+            print('Wrote {} flag(s) into {} (backup: {}):'.format(
+                len(result['applied']), args.config, result['backup']))
+            for item in result['applied']:
+                print('  {} {}: {}'.format(item['action'], item['path'], item['value']))
+            if result['skipped']:
+                print('Not auto-fixed (resolve by hand): {}'.format(', '.join(result['skipped'])))
+            print('Re-run bootstrap-mcp-config.sh --dry-run to confirm every live server now emits.')
+        else:
+            print('No changes needed - chassis.config.yaml already preserves every live server.')
+            if result['skipped']:
+                print('Still needs a manual decision: {}'.format(', '.join(result['skipped'])))
+        return 0
+
+    # --check (default)
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(render_human(report))
+    return 1 if report['drift'] else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/chassis/scripts/smoke-test.sh
+++ b/chassis/scripts/smoke-test.sh
@@ -185,6 +185,58 @@ check_mcp_json_present() {
     fi
 }
 
+check_mcp_config_drift() {
+    # Destructive-drift guard. reconcile-mcp-config.py compares the live
+    # .mcp.json against the set the hydrator WOULD emit from chassis.config.yaml
+    # + the template. The failure worth catching here is PRESENT_BUT_WOULD_DROP:
+    # servers running live that a --force re-hydrate would silently drop because
+    # config never enabled them. That is a landmine, not a cosmetic diff, so it
+    # FAILs. WOULD_EMIT_BUT_MISSING and placeholder gaps are benign here and do
+    # not fail the check.
+    local reconciler="$CHASSIS_ROOT/scripts/reconcile-mcp-config.py"
+    local config="$CHASSIS_HOME/chassis.config.yaml"
+    local template="$CHASSIS_ROOT/.mcp.json.template"
+    local mcp="$CHASSIS_HOME/.mcp.json"
+    local envf="$CHASSIS_HOME/.env"
+    if [[ ! -f "$reconciler" ]]; then
+        record SKIP mcp_config_drift "reconcile-mcp-config.py not found"
+        return
+    fi
+    if [[ ! -f "$mcp" || ! -f "$template" ]]; then
+        record SKIP mcp_config_drift ".mcp.json or template missing - nothing to compare"
+        return
+    fi
+    local args=(--config "$config" --template "$template" --mcp "$mcp" --json)
+    [[ -f "$envf" ]] && args+=(--env "$envf")
+    local out
+    out=$(python3 "$reconciler" "${args[@]}" 2>/dev/null)
+    if [[ -z "$out" ]]; then
+        record FAIL mcp_config_drift "reconcile-mcp-config.py produced no output"
+        return
+    fi
+    local summary
+    summary=$(printf '%s' "$out" | python3 -c '
+import json, sys
+try:
+    r = json.load(sys.stdin)
+except Exception:
+    print("")
+    sys.exit()
+drop = [i["server"] for i in r.get("present_but_would_drop", [])]
+if drop:
+    print("FAIL|a re-hydrate would DROP: %s - run reconcile-mcp-config.py --fix"
+          % ", ".join(drop))
+else:
+    print("PASS|no destructive drift; live .mcp.json survives a re-hydrate")
+' 2>/dev/null)
+    if [[ -z "$summary" ]]; then
+        record FAIL mcp_config_drift "could not parse reconciler output"
+        return
+    fi
+    local status="${summary%%|*}" msg="${summary#*|}"
+    record "$status" mcp_config_drift "$msg"
+}
+
 check_briefings_dispatch_helper() {
     if [[ ! -x "$CHASSIS_ROOT/scripts/post-to-channel.sh" ]]; then
         record FAIL briefings_dispatch "$CHASSIS_ROOT/scripts/post-to-channel.sh not executable"
@@ -295,6 +347,7 @@ run_core_checks() {
     check_heartbeat_dispatcher_script
     check_heartbeats_md_present
     check_mcp_json_present
+    check_mcp_config_drift
     check_briefings_dispatch_helper
     check_telegram_intake_helper
     check_slack_intake_helper

--- a/chassis/scripts/tests/test_reconcile_mcp_config.py
+++ b/chassis/scripts/tests/test_reconcile_mcp_config.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""test_reconcile_mcp_config.py - drift detection + config reconciliation.
+
+Drives chassis/scripts/reconcile-mcp-config.py, which reuses the REAL hydrator
+(chassis/scripts/hydrate-mcp-json.py) for all gating. Fixtures here are fully
+SYNTHETIC (svc_* server names, made-up flag paths) so nothing depends on the
+shipped template or any real install's server set.
+
+Coverage:
+  - the three sets: PRESENT_BUT_WOULD_DROP, WOULD_EMIT_BUT_MISSING, CONSISTENT
+  - the exact preserving flag resolved for each would-drop server
+  - the placeholder check (would-emit server whose .env lacks a token)
+  - the host-vs-container path-model flag
+  - the real-case shape with synthetic names: 15 live, 6 enabled, 9 gated ->
+    exactly those 9 in PRESENT_BUT_WOULD_DROP with the correct flags
+  - --fix: surgical YAML edit (modify existing leaf, insert new leaf, create a
+    missing intermediate mapping), comment preservation, backup, idempotency
+  - !=-gated servers are surfaced but never auto-fixed
+
+Run:
+    python3 -m pytest chassis/scripts/tests/test_reconcile_mcp_config.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RECONCILER_PATH = REPO_ROOT / "chassis" / "scripts" / "reconcile-mcp-config.py"
+
+_spec = importlib.util.spec_from_file_location("reconcile_mcp_config", RECONCILER_PATH)
+reconcile = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(reconcile)
+
+HYDRATOR = reconcile.load_hydrator()
+
+
+def _core(role="core"):
+    return {"_role": role, "command": "npx", "args": ["-y", "pkg"]}
+
+
+def _gated(predicate, env=None):
+    entry = {"_enable_when": predicate, "command": "npx", "args": ["-y", "pkg"]}
+    if env is not None:
+        entry["env"] = env
+    return entry
+
+
+def _report(template, config, live, env=None):
+    return reconcile.compute_report(HYDRATOR, live, config, template, env or {})
+
+
+def _live(*names):
+    return {"mcpServers": {n: {"command": "npx", "args": ["-y", "pkg"]} for n in names}}
+
+
+class ThreeSetsTest(unittest.TestCase):
+    TEMPLATE = {
+        "mcpServers": {
+            "svc_core": _core(),
+            "svc_on": _gated("chassis.config.yaml.modules.on == true"),
+            "svc_off": _gated("chassis.config.yaml.modules.off == true"),
+            "svc_wants": _gated("chassis.config.yaml.modules.wants == true"),
+        }
+    }
+    CONFIG = {"modules": {"on": True, "off": False, "wants": True}}
+
+    def test_present_but_would_drop(self):
+        # svc_off is live but config never enables it -> the dangerous set.
+        live = _live("svc_core", "svc_on", "svc_off")
+        report = _report(self.TEMPLATE, self.CONFIG, live)
+        names = [i["server"] for i in report["present_but_would_drop"]]
+        self.assertEqual(names, ["svc_off"])
+        item = report["present_but_would_drop"][0]
+        self.assertEqual(item["enable_when"], "chassis.config.yaml.modules.off == true")
+        self.assertTrue(item["auto_fixable"])
+        self.assertEqual(item["assignments"][0]["path"], "modules.off")
+        self.assertEqual(item["assignments"][0]["value_literal"], "true")
+
+    def test_would_emit_but_missing(self):
+        # svc_wants is enabled in config but not present live -> info set.
+        live = _live("svc_core", "svc_on")
+        report = _report(self.TEMPLATE, self.CONFIG, live)
+        self.assertIn("svc_wants", report["would_emit_but_missing"])
+        self.assertEqual(report["present_but_would_drop"], [])
+
+    def test_consistent(self):
+        live = _live("svc_core", "svc_on", "svc_wants")
+        report = _report(self.TEMPLATE, self.CONFIG, live)
+        self.assertEqual(report["consistent"], ["svc_core", "svc_on", "svc_wants"])
+        self.assertFalse(report["drift"])
+
+    def test_underscore_keys_in_live_are_ignored(self):
+        live = _live("svc_core", "svc_on", "svc_wants")
+        live["mcpServers"]["_divider"] = {"_role": "doc"}
+        report = _report(self.TEMPLATE, self.CONFIG, live)
+        self.assertNotIn("_divider", report["consistent"])
+        self.assertEqual(report["present_but_would_drop"], [])
+
+
+class PlaceholderCheckTest(unittest.TestCase):
+    TEMPLATE = {
+        "mcpServers": {
+            "svc_keyed": _gated(
+                "chassis.config.yaml.modules.keyed == true",
+                env={"API_KEY": "<SVC_TOKEN>"},
+            ),
+        }
+    }
+    CONFIG = {"modules": {"keyed": True}}
+
+    def setUp(self):
+        # substitute_placeholders falls back to os.environ, so isolate it or a
+        # real SVC_TOKEN on the dev box would mask the missing-token case.
+        patcher = mock.patch.dict("os.environ", {}, clear=True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_missing_token_is_flagged(self):
+        live = _live("svc_keyed")
+        report = _report(self.TEMPLATE, self.CONFIG, live, env={})
+        self.assertEqual(report["broken_placeholders"], {"svc_keyed": ["SVC_TOKEN"]})
+        self.assertTrue(report["drift"])
+
+    def test_present_token_is_not_flagged(self):
+        live = _live("svc_keyed")
+        report = _report(self.TEMPLATE, self.CONFIG, live, env={"SVC_TOKEN": "x"})
+        self.assertEqual(report["broken_placeholders"], {})
+
+
+class PathModelTest(unittest.TestCase):
+    TEMPLATE = {
+        "mcpServers": {
+            "svc_adapter": {
+                "_enable_when": "chassis.config.yaml.modules.adapter == true",
+                "command": "python3",
+                "args": ["${CHASSIS_ROOT:-/app/chassis}/second_brain/mcp_server.py"],
+            }
+        }
+    }
+    CONFIG = {"modules": {"adapter": True}}
+
+    def test_host_path_where_template_renders_container_path(self):
+        live = {
+            "mcpServers": {
+                "svc_adapter": {
+                    "command": "python3",
+                    "args": ["/Users/someone/.behalfbot/chassis/chassis/second_brain/mcp_server.py"],
+                }
+            }
+        }
+        report = _report(self.TEMPLATE, self.CONFIG, live)
+        self.assertEqual(len(report["path_model_mismatches"]), 1)
+        m = report["path_model_mismatches"][0]
+        self.assertEqual(m["server"], "svc_adapter")
+        self.assertEqual(m["field"], "args[0]")
+        self.assertIn("/app/chassis", m["template"])
+        self.assertTrue(m["live"].startswith("/Users/"))
+
+    def test_matching_container_path_is_not_flagged(self):
+        live = {
+            "mcpServers": {
+                "svc_adapter": {
+                    "command": "python3",
+                    "args": ["${CHASSIS_ROOT:-/app/chassis}/second_brain/mcp_server.py"],
+                }
+            }
+        }
+        report = _report(self.TEMPLATE, self.CONFIG, live)
+        self.assertEqual(report["path_model_mismatches"], [])
+
+
+class NotEqualGateIsNotAutoFixedTest(unittest.TestCase):
+    # second-brain shape: a server gated on mode != 'adapter'. When config is in
+    # adapter mode the server drops, but flipping mode would drop the adapter
+    # server instead - so it is surfaced with a note and never auto-fixed.
+    TEMPLATE = {
+        "mcpServers": {
+            "svc_native": _gated(
+                "chassis.config.yaml.second_brain.backend == 'siyuan' "
+                "&& chassis.config.yaml.second_brain.mode != 'adapter'"
+            ),
+        }
+    }
+    CONFIG = {"second_brain": {"backend": "siyuan", "mode": "adapter"}}
+
+    def test_not_equal_clause_blocks_auto_fix(self):
+        live = _live("svc_native")
+        report = _report(self.TEMPLATE, self.CONFIG, live)
+        item = report["present_but_would_drop"][0]
+        self.assertEqual(item["server"], "svc_native")
+        self.assertFalse(item["auto_fixable"])
+        self.assertTrue(any("!=" in n for n in item["notes"]))
+
+
+# ---------------------------------------------------------------------------
+# Real-case shape, synthetic names: 15 live, 6 enabled, 9 gated-and-dropped.
+# ---------------------------------------------------------------------------
+
+REAL_SHAPE_TEMPLATE = {
+    "mcpServers": {
+        # 4 ungated core servers - always emit.
+        "svc_alpha": _core(),
+        "svc_bravo": _core(),
+        "svc_charlie": _core(),
+        "svc_delta": _core(),
+        # 2 gated servers the config DOES enable -> also emit (6 total).
+        "svc_echo": _gated("chassis.config.yaml.modules.echo == true"),
+        "svc_foxtrot": _gated("chassis.config.yaml.second_brain.backend == 'siyuan'"),
+        # 9 gated servers the config never enables -> the drop set.
+        "svc_turso": _gated("chassis.config.yaml.modules.turso == true"),
+        "svc_amp": _gated("chassis.config.yaml.modules.amplitude == true"),
+        "svc_tavily": _gated("chassis.config.yaml.modules.research.tavily == true"),
+        "svc_brave": _gated("chassis.config.yaml.modules.research.brave == true"),
+        "svc_frame0": _gated("chassis.config.yaml.modules.frame0 == true"),
+        "svc_loom": _gated("chassis.config.yaml.modules.loom_mcp == true"),
+        "svc_n8n": _gated("chassis.config.yaml.modules.n8n == true"),
+        "svc_remarkable": _gated("chassis.config.yaml.modules.remarkable == true"),
+        "svc_oura": _gated("chassis.config.yaml.modules.bfl.strava_oura_reconcile == true"),
+    }
+}
+
+REAL_SHAPE_LIVE = _live(
+    "svc_alpha", "svc_bravo", "svc_charlie", "svc_delta", "svc_echo", "svc_foxtrot",
+    "svc_turso", "svc_amp", "svc_tavily", "svc_brave", "svc_frame0", "svc_loom",
+    "svc_n8n", "svc_remarkable", "svc_oura",
+)
+
+# A synthetic chassis.config.yaml with comments and nesting, enabling only 6.
+# modules.research is absent entirely (svc_tavily/svc_brave need a new mapping);
+# modules.bfl exists with strava_oura_reconcile: false (svc_oura is a modify).
+REAL_SHAPE_CONFIG_YAML = """\
+# Synthetic chassis.config.yaml for the reconcile test.
+version: 1
+
+second_brain:
+  backend: siyuan                           # enables svc_foxtrot
+  mode: direct
+
+modules:
+  echo: true                                # enables svc_echo
+  admin: true                               # unrelated, must survive untouched
+  bfl:
+    enabled: false
+    strava_oura_reconcile: false            # svc_oura gate - flips to true
+    fdc_enrich: false
+  google:
+    gmail: false
+
+trust_line:
+  calendar: read_only
+"""
+
+DROPPED_9 = {
+    "svc_turso", "svc_amp", "svc_tavily", "svc_brave", "svc_frame0",
+    "svc_loom", "svc_n8n", "svc_remarkable", "svc_oura",
+}
+
+EXPECTED_FLAGS = {
+    "svc_turso": ("modules.turso", "true"),
+    "svc_amp": ("modules.amplitude", "true"),
+    "svc_tavily": ("modules.research.tavily", "true"),
+    "svc_brave": ("modules.research.brave", "true"),
+    "svc_frame0": ("modules.frame0", "true"),
+    "svc_loom": ("modules.loom_mcp", "true"),
+    "svc_n8n": ("modules.n8n", "true"),
+    "svc_remarkable": ("modules.remarkable", "true"),
+    "svc_oura": ("modules.bfl.strava_oura_reconcile", "true"),
+}
+
+
+class RealCaseShapeTest(unittest.TestCase):
+    def _config(self):
+        import io
+        # Reuse the hydrator's YAML loader against the synthetic text.
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write(REAL_SHAPE_CONFIG_YAML)
+            path = f.name
+        self.addCleanup(os.unlink, path)
+        return HYDRATOR.load_yaml(path)
+
+    def test_exactly_nine_would_drop_with_correct_flags(self):
+        report = _report(REAL_SHAPE_TEMPLATE, self._config(), REAL_SHAPE_LIVE)
+        dropped = {i["server"] for i in report["present_but_would_drop"]}
+        self.assertEqual(dropped, DROPPED_9)
+        for item in report["present_but_would_drop"]:
+            self.assertTrue(item["auto_fixable"], item["server"])
+            path, value = EXPECTED_FLAGS[item["server"]]
+            self.assertEqual(item["assignments"][0]["path"], path)
+            self.assertEqual(item["assignments"][0]["value_literal"], value)
+
+    def test_six_consistent_and_drift_true(self):
+        report = _report(REAL_SHAPE_TEMPLATE, self._config(), REAL_SHAPE_LIVE)
+        self.assertEqual(len(report["consistent"]), 6)
+        self.assertTrue(report["drift"])
+
+
+class FixEndToEndTest(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.config_path = os.path.join(self.dir, "chassis.config.yaml")
+        with open(self.config_path, "w") as f:
+            f.write(REAL_SHAPE_CONFIG_YAML)
+
+    def _run_fix(self):
+        config = HYDRATOR.load_yaml(self.config_path)
+        report = _report(REAL_SHAPE_TEMPLATE, config, REAL_SHAPE_LIVE)
+        return reconcile.apply_fix(self.config_path, report)
+
+    def test_fix_enables_all_nine_then_render_drops_nothing(self):
+        result = self._run_fix()
+        self.assertTrue(result["changed"])
+        self.assertTrue(os.path.exists(result["backup"]))
+
+        # After the fix, a fresh report must show zero would-drop and every live
+        # server consistent.
+        config = HYDRATOR.load_yaml(self.config_path)
+        report = _report(REAL_SHAPE_TEMPLATE, config, REAL_SHAPE_LIVE)
+        self.assertEqual(report["present_but_would_drop"], [])
+        self.assertEqual(len(report["consistent"]), 15)
+
+    def test_fix_preserves_unrelated_keys_and_comments(self):
+        self._run_fix()
+        text = Path(self.config_path).read_text()
+        self.assertIn("admin: true", text)
+        self.assertIn("# unrelated, must survive untouched", text)
+        self.assertIn("backend: siyuan", text)
+        # The oura flag was flipped in place, keeping its trailing comment.
+        self.assertIn("strava_oura_reconcile: true", text)
+        self.assertIn("# svc_oura gate", text)
+
+    def test_fix_creates_missing_research_mapping(self):
+        self._run_fix()
+        config = HYDRATOR.load_yaml(self.config_path)
+        self.assertIs(config["modules"]["research"]["tavily"], True)
+        self.assertIs(config["modules"]["research"]["brave"], True)
+
+    def test_fix_is_idempotent(self):
+        self._run_fix()
+        second = self._run_fix()
+        self.assertFalse(second["changed"])
+        self.assertIsNone(second["backup"])
+
+
+class SetYamlPathUnitTest(unittest.TestCase):
+    def _apply(self, text, dotted, value):
+        lines = text.split("\n")
+        action = reconcile.set_yaml_path(lines, dotted.split("."), value)
+        return "\n".join(lines), action
+
+    def test_modify_existing_leaf_preserves_comment_column(self):
+        text = "modules:\n  flag: false            # keep me\n"
+        out, action = self._apply(text, "modules.flag", "true")
+        self.assertEqual(action, "modified")
+        self.assertIn("flag: true", out)
+        self.assertIn("# keep me", out)
+
+    def test_insert_new_leaf_under_existing_parent(self):
+        text = "modules:\n  existing: true\n"
+        out, action = self._apply(text, "modules.turso", "true")
+        self.assertEqual(action, "inserted")
+        self.assertIn("  turso: true", out)
+        self.assertIn("added by reconcile-mcp-config", out)
+
+    def test_insert_creates_missing_intermediate_mapping(self):
+        text = "modules:\n  existing: true\n"
+        out, action = self._apply(text, "modules.research.brave", "true")
+        self.assertEqual(action, "inserted")
+        self.assertIn("  research:", out)
+        self.assertIn("    brave: true", out)
+
+    def test_noop_when_value_already_set(self):
+        text = "modules:\n  flag: true\n"
+        _out, action = self._apply(text, "modules.flag", "true")
+        self.assertEqual(action, "noop")
+
+    def test_does_not_confuse_sibling_blocks(self):
+        text = "modules:\n  bfl:\n    a: false\n  other:\n    a: false\n"
+        out, _action = self._apply(text, "modules.bfl.a", "true")
+        # Only the bfl.a leaf flips; other.a stays false.
+        self.assertIn("  bfl:\n    a: true", out)
+        self.assertIn("  other:\n    a: false", out)
+
+
+class CliTest(unittest.TestCase):
+    """Exercise main() through argv, asserting exit codes and read-only-on-mcp."""
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.template = os.path.join(self.dir, ".mcp.json.template")
+        self.config = os.path.join(self.dir, "chassis.config.yaml")
+        self.mcp = os.path.join(self.dir, ".mcp.json")
+        self.env = os.path.join(self.dir, ".env")
+        import json as _json
+        with open(self.template, "w") as f:
+            _json.dump(REAL_SHAPE_TEMPLATE, f)
+        with open(self.config, "w") as f:
+            f.write(REAL_SHAPE_CONFIG_YAML)
+        with open(self.mcp, "w") as f:
+            _json.dump(REAL_SHAPE_LIVE, f)
+        with open(self.env, "w") as f:
+            f.write("")
+
+    def _argv(self, *extra):
+        return ["--config", self.config, "--template", self.template,
+                "--mcp", self.mcp, "--env", self.env, *extra]
+
+    def test_check_exits_1_on_drift(self):
+        rc = reconcile.main(self._argv())
+        self.assertEqual(rc, 1)
+
+    def test_fix_does_not_touch_mcp_json(self):
+        before = Path(self.mcp).read_bytes()
+        reconcile.main(self._argv("--fix"))
+        self.assertEqual(Path(self.mcp).read_bytes(), before)
+
+    def test_fix_then_check_exits_0(self):
+        reconcile.main(self._argv("--fix"))
+        rc = reconcile.main(self._argv())
+        self.assertEqual(rc, 0)
+
+    def test_missing_live_file_exits_2(self):
+        os.unlink(self.mcp)
+        rc = reconcile.main(self._argv())
+        self.assertEqual(rc, 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -194,6 +194,44 @@ Wireframe / mockup generation. No auth required for stdio mode.
 
 ---
 
+## Drift detection + reconcile (`reconcile-mcp-config.py`)
+
+A live `.mcp.json` can drift from what `chassis.config.yaml` + the template would hydrate today. When it does, a `--force` re-hydrate (or any regen) **silently drops** every server that is present in the live file but not enabled in config - no error, no warning, working MCP integrations just vanish. Real case: a live file running 15 servers where the config only enables 6; a `--force` there would drop the other 9.
+
+[`chassis/scripts/reconcile-mcp-config.py`](../chassis/scripts/reconcile-mcp-config.py) detects that gap before it bites, and can write the missing flags back into `chassis.config.yaml`. It reuses the hydrator's own gating logic, so its answer matches what a real hydrate would produce. It is **read-only on `.mcp.json`** - `--fix` only ever edits `chassis.config.yaml`, after backing it up.
+
+```bash
+# Report drift (default). Exit 0 = clean, exit 1 = drift, exit 2 = bad input.
+python3 chassis/scripts/reconcile-mcp-config.py --check
+
+# Same, machine-readable (used by smoke-test.sh + the bootstrap --force guard):
+python3 chassis/scripts/reconcile-mcp-config.py --json
+
+# Write the preserving flags into chassis.config.yaml (idempotent, backs up first):
+python3 chassis/scripts/reconcile-mcp-config.py --fix
+```
+
+Paths default from `$CUSTOMER_HOME` / `$CHASSIS_HOME`; override with `--config`, `--template`, `--mcp`, `--env`.
+
+### The three sets
+
+| Set | Meaning | Action |
+|---|---|---|
+| **PRESENT_BUT_WOULD_DROP** | Live now, but a re-hydrate would NOT emit it (config never enabled it). The dangerous set. | `--fix` adds the exact `_enable_when` flag that preserves each one. |
+| **WOULD_EMIT_BUT_MISSING** | Config enables it but the live file lacks it. Under-provisioned; a re-hydrate would ADD it. | Info only. Re-hydrate when convenient. |
+| **CONSISTENT** | Present in both. | None. |
+
+Two extra checks ride along: every server that WOULD emit is verified against `.env` for the `<PLACEHOLDER>` tokens it needs (so a later hydrate does not produce placeholder-broken entries - same condition the hydrator exits 2 on), and host-vs-container **path-model mismatches** are flagged where detectable (a live entry carrying a host absolute path where the template renders a container path like `${CHASSIS_ROOT:-/app/chassis}/...`).
+
+`--fix` only auto-applies `==`-gated flags. The second-brain servers gate on `mode != 'adapter'`; "fixing" one by flipping mode would drop the adapter server instead, so those are surfaced with a note and left to a human.
+
+### Integration points
+
+- **`smoke-test.sh`** runs the check as `mcp_config_drift`. It FAILs only on PRESENT_BUT_WOULD_DROP (the destructive set); the info sets do not fail the smoke run.
+- **`bootstrap-mcp-config.sh --force`** runs the check before overwriting an existing `.mcp.json`. If PRESENT_BUT_WOULD_DROP is non-empty it **refuses** (exit 3) and points at `reconcile-mcp-config.py --fix`. Legit token-rotation `--force` runs are unaffected - a consistent install has an empty drop set and the guard passes silently. Pass `--allow-drop` to overwrite and accept the loss on purpose.
+
+---
+
 ## Lessons baked in
 
 - **#6** — agent-side accounts for every credential. Don't reuse personal identity.


### PR DESCRIPTION
Closes #115

## What this adds

`chassis/scripts/reconcile-mcp-config.py` - a drift detector + config reconciler. A live `.mcp.json` can drift from what `chassis.config.yaml` + the template would hydrate. When it does, a `--force` re-hydrate (or any regen) silently DROPS every server present in the live file but not enabled in config - no error, no warning, working MCP integrations just vanish. This tool surfaces that gap before it bites and can write the preserving flags back into config.

It **reuses the hydrator's gating logic** (imported by path via importlib - the same mechanism `second_brain/tests` already use), so `hydrate-mcp-json.py` is left **byte-identical** and its existing test suite is untouched. Decision recorded below.

### The three sets
- **PRESENT_BUT_WOULD_DROP** - live now, a re-hydrate would NOT emit it. The dangerous set. For each, the exact `_enable_when` flag that would preserve it is resolved and printed.
- **WOULD_EMIT_BUT_MISSING** - config enables it, live lacks it. Info (a re-hydrate would ADD it).
- **CONSISTENT** - present in both.

Two extra checks: every would-emit server is verified against `.env` for the `<PLACEHOLDER>` tokens it needs (mirrors the hydrator's exit-2 condition), and host-vs-container path-model mismatches are flagged.

### Modes
- `--check` (default): human summary or `--json`. Exit nonzero on drift. CI/smoke friendly. Read-only on everything.
- `--fix`: writes preserving flags into `chassis.config.yaml` (backup first, comments preserved, idempotent). **Never writes `.mcp.json`** - reconciler is read-only on it. Only `==`-gated flags are auto-applied; the second-brain `!=` gate is surfaced with a note and left to a human (flipping it would drop the adapter server).

## Files
- **add** `chassis/scripts/reconcile-mcp-config.py`
- **add** `chassis/scripts/tests/test_reconcile_mcp_config.py` (24 tests, synthetic fixtures)
- **mod** `chassis/scripts/smoke-test.sh` - new `mcp_config_drift` check (FAILs only on the destructive set)
- **mod** `chassis/scripts/bootstrap-mcp-config.sh` - `--force` refuses (exit 3) when a re-hydrate would drop live servers, points at `--fix`; `--allow-drop` bypasses
- **mod** `docs/mcp-setup.md` - usage + meaning of the three sets
- **mod** `.github/workflows/python-tests.yml` - add the reconciler to the trigger paths

## How it was verified
All run locally against a python 3.12 venv (pytest + pyyaml + mcp==1.28.1, matching the CI job):

- **Full python suite** (`pytest chassis/second_brain/tests/ chassis/scripts/tests/`): **323 passed, 4 skipped** - includes hydrate-mcp-json's existing tests (unaffected) and the 24 new reconciler tests.
- **`git diff origin/main -- chassis/scripts/hydrate-mcp-json.py`**: empty (byte-identical).
- **End-to-end against the REAL template** with a synthetic install reproducing the real-case shape (live file with the 9 gated servers + 5 core/enabled, config enabling only those):
  - `--check` reported the 9 PRESENT_BUT_WOULD_DROP with the exact preserving flag for each, exit 1.
  - `--fix` wrote 9 flags into `chassis.config.yaml` (8 inserts incl. a created `modules.research` mapping, 1 in-place modify with comment column preserved), backed up to `.bak`, `.mcp.json` untouched.
  - `hydrate-mcp-json.py --dry-run` then emitted all servers with zero unresolved-placeholder warnings; nothing dropped.
  - re-running `--check` exited 0 (no drift); re-running `--fix` was a no-op (idempotent).
- **Bootstrap guard**: `--force` against the drifted install REFUSED (exit 3), live file unchanged; `--force --allow-drop` proceeded; `--force` against a consistent install re-hydrated silently (guard passes, no false positive on legit token rotation).
- **shellcheck --severity=error** on both edited shell scripts: clean.

## Decisions surfaced
- **Import vs refactor**: the hydrator is cleanly importable by path (module-level functions, guarded `main()`), so I imported it rather than extracting a shared lib. This keeps `hydrate-mcp-json.py` byte-identical and its tests untouched, which the issue prioritized. The one piece of `main()` not covered by `hydrate()` (the obsidian `mode -> adapter` normalization) is replicated in a small, commented helper that points back at the original, so the emitted-set prediction stays faithful for obsidian installs.
- **Host-vs-container path model**: surfaced, not silently resolved. The reconciler only edits config flags via `--fix`; it never rewrites paths in either `.mcp.json` or config. Path-model mismatches (a live host-absolute path where the template renders `${CHASSIS_ROOT:-/app/chassis}/...`) are reported in `--check` output for a human to resolve, because the correct fix depends on whether the install is host-side or container-side - not something the tool should pick.
- **Smoke severity**: the smoke check FAILs only on PRESENT_BUT_WOULD_DROP (the destructive set). WOULD_EMIT_BUT_MISSING and placeholder gaps are benign there (a fresh post-bootstrap install is consistent) so they do not fail the smoke run, even though `--check`'s own exit code treats any drift as nonzero.

## Not done
- **VERSION intentionally unchanged (0.3.0)** - recent chassis PRs #112/#113/#114 stayed at 0.3.0; a bump needs Sean's sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)