### PR TITLE
fix(ci): diff-against-canonical is a required check, so it must run on every PR

### DIFF
--- a/.github/workflows/fetcher-seed-matches-canonical.yml
+++ b/.github/workflows/fetcher-seed-matches-canonical.yml
@@ -9,11 +9,25 @@ name: fetcher-seed-matches-canonical
 # That is precisely the drift class behalfbot#53 was written to kill, one layer
 # down - so enforce it rather than document it.
 
+# NO `paths:` filter on pull_request, and that is deliberate.
+#
+# `diff-against-canonical` is a REQUIRED status check on main as of
+# 2026-07-29. A required check that is path-filtered never reports on a PR
+# outside those paths, and GitHub then blocks that PR forever on
+# "Expected — Waiting for status to be reported". Not a failure - a deadlock
+# with no red X, no log, and nothing for a contributor to click on.
+#
+# The filter here was two specific files, so any PR that did not touch
+# chassis/scripts/fetch-plugins.sh would hang. That includes a README fix,
+# which is the likeliest shape for a first contribution from outside.
+#
+# The job takes about 9 seconds. That is a cheap price for a check that
+# always reports.
+#
+# The `push` trigger is unchanged - it was never filtered and nothing is
+# gated on it.
 on:
   pull_request:
-    paths:
-      - 'chassis/scripts/fetch-plugins.sh'
-      - '.github/workflows/fetcher-seed-matches-canonical.yml'
   push:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
Branch protection went live on `main` a few minutes ago. It surfaced a trap that affects all three public repos.

## The deadlock

A **required** status check that is **path-filtered** never reports on a PR outside those paths. GitHub does not treat that as a pass or a fail - it blocks the PR indefinitely on:

```
Expected — Waiting for status to be reported
```

No red X. No log. Nothing for a contributor to click on, and no way to work out why their PR is stuck. It simply never merges.

## Why it bites tonight

The likeliest shape for a first contribution from a talk audience is a README or docs fix. That PR touches none of the filtered paths, so every path-filtered required check hangs on it. Someone's first contribution to the project would sit unmergeable with no explanation.

## The change

Drops the `paths:` filter on `pull_request` only. The `push` trigger keeps its filter where it had one - nothing is gated on `push`, so there is no reason to burn minutes re-running on a docs commit.

Cost is a few seconds of CI on PRs that have nothing for the job to do. That is a cheap price for a check that always reports.

## Audit across all three repos

```
behalfbot          build                    PATH-FILTERED  -> de-require (Docker build, 2-13 min)
                   diff-against-canonical   PATH-FILTERED  -> fixed here
                   check-no-customer-state  always runs
BehalfBot-open     shellcheck               PATH-FILTERED  -> fixed (its ONLY required check)
behalfbot-plugins  shellcheck               PATH-FILTERED  -> fixed
                   validate                 always runs
                   scanner-self-test        always runs
                   credential-scan          always runs
```

`build` is deliberately not changed. It is also required and also path-filtered, but it is the Docker image build at 2 to 13 minutes per run, so firing it on every docs typo is the wrong trade. It is being removed from the required-contexts list instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)