### PR TITLE
feat(governance): CONTRIBUTING, SECURITY, PR template, CODEOWNERS, DCO check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# Every path in this repo is owned by the maintainer.
+#
+# CODEOWNERS here is a review-routing convenience, NOT an access control. It
+# requests a review on a PR touching a path; it does not block a merge. Branch
+# protection on main is what actually gates merges - see the ruleset, which
+# requires status checks, restricts deletions and blocks force pushes.
+#
+# Deliberately not paired with "Require review from Code Owners" in the ruleset:
+# this is a single-maintainer project, so requiring an approval would mean
+# nobody can ever merge, including the owner.
+
+*                           @scrollinondubs
+
+# Paths where a wrong change is expensive, listed so the routing is explicit
+# even though the owner is the same. Anything under these should get a slower
+# read than a docs typo.
+
+/chassis/.claude/hooks/      @scrollinondubs
+/.github/                    @scrollinondubs
+/bootstrap.sh                @scrollinondubs
+/docker/                     @scrollinondubs
+/cloudflare/                 @scrollinondubs
+/LICENSE                     @scrollinondubs
+/SECURITY.md                 @scrollinondubs

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<!--
+Thanks for contributing. CONTRIBUTING.md has the full detail; this template is
+just the shape a reviewer needs. Delete any section that does not apply rather
+than writing "n/a" in it.
+-->
+
+## What this changes
+
+<!-- One or two sentences. What is different after this merges? -->
+
+## Why
+
+<!-- The problem, not the patch. Link an issue if there is one - anything
+non-trivial should have started as one. -->
+
+## How it was verified
+
+<!-- What you actually ran or observed, not what you expect to happen. "CI is
+green" is fine for a docs change; anything behavioural needs more. -->
+
+## Checklist
+
+- [ ] Every commit is signed off (`git commit -s`) - CI enforces this, see CONTRIBUTING.md
+- [ ] No credentials, tokens, or install-specific values (names, channel IDs, home paths, timezones)
+- [ ] Safety rules stay at the hook layer, not moved into a prompt or a CLAUDE.md
+- [ ] Any new heartbeat gathers cheaply first and invokes the model only when there is real work
+- [ ] I read CONTRIBUTING.md's "what gets a PR declined" list
+
+## Anything you are unsure about
+
+<!-- Genuinely useful. Naming the part you are least confident in gets you a
+better review than presenting it as finished. -->

--- a/.github/scripts/check-dco.sh
+++ b/.github/scripts/check-dco.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# check-dco.sh — every non-merge commit in a PR must carry a Signed-off-by line.
+#
+# This is a DCO check, not a CLA. Nobody signs a document and nobody assigns
+# copyright. `git commit -s` appends one line asserting the contributor wrote
+# the change (or has the right to submit it) and is submitting it under this
+# project's licence. See CONTRIBUTING.md for the reasoning.
+#
+# Merge commits are skipped. GitHub generates them and they carry no author
+# assertion, so requiring a sign-off on them would fail every PR that has been
+# updated from main.
+#
+# Usage:
+#   BASE=<sha> HEAD=<sha> bash .github/scripts/check-dco.sh
+# Exit 0 if every commit is signed off, 1 otherwise.
+
+set -uo pipefail
+
+BASE="${BASE:-}"
+HEAD="${HEAD:-}"
+
+if [[ -z "$BASE" || -z "$HEAD" ]]; then
+    echo "check-dco: BASE and HEAD must be set" >&2
+    exit 2
+fi
+
+# `git log BASE..HEAD` needs both objects present. A shallow clone silently
+# yields an empty range instead of an error, which would pass this check on
+# every PR - the exact "a check that cannot fail" shape this repo has been
+# bitten by before. Verify the range resolves before trusting an empty result.
+if ! git rev-parse --verify --quiet "$BASE^{commit}" >/dev/null; then
+    echo "check-dco: BASE $BASE is not present in this clone — fetch depth too shallow" >&2
+    exit 2
+fi
+if ! git rev-parse --verify --quiet "$HEAD^{commit}" >/dev/null; then
+    echo "check-dco: HEAD $HEAD is not present in this clone — fetch depth too shallow" >&2
+    exit 2
+fi
+
+commits=$(git rev-list --no-merges "$BASE..$HEAD")
+
+if [[ -z "$commits" ]]; then
+    echo "check-dco: no non-merge commits in range — nothing to verify"
+    exit 0
+fi
+
+missing=0
+checked=0
+
+while IFS= read -r sha; do
+    [[ -z "$sha" ]] && continue
+    checked=$((checked + 1))
+    subject=$(git log -1 --format=%s "$sha")
+    if git log -1 --format=%B "$sha" | grep -qiE '^ *Signed-off-by: .+ <[^@]+@[^>]+>'; then
+        echo "  ok    ${sha:0:8}  $subject"
+    else
+        echo "  MISS  ${sha:0:8}  $subject"
+        missing=$((missing + 1))
+    fi
+done <<< "$commits"
+
+echo
+if [[ "$missing" -gt 0 ]]; then
+    cat <<'EOF'
+FAIL: some commits have no Signed-off-by line.
+
+This project uses the Developer Certificate of Origin (https://developercertificate.org/).
+It is one line in the commit message. No form to sign, no copyright assignment -
+you keep your copyright. It records that you wrote the change, or have the right
+to submit it, and are submitting it under this project's licence.
+
+To fix the most recent commit:
+
+    git commit --amend -s --no-edit
+    git push --force-with-lease
+
+To fix every commit on your branch:
+
+    git rebase --signoff origin/main
+    git push --force-with-lease
+
+To avoid it next time, commit with -s:
+
+    git commit -s -m "your message"
+
+EOF
+    echo "$missing of $checked commit(s) unsigned"
+    exit 1
+fi
+
+echo "OK: all $checked commit(s) signed off"

--- a/.github/scripts/test-check-dco.sh
+++ b/.github/scripts/test-check-dco.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# test-check-dco.sh — prove the DCO check passes signed commits, fails unsigned
+# ones, skips merge commits, and refuses to pass on a range it cannot resolve.
+#
+# The last case is the one that matters most. `git log BASE..HEAD` on a shallow
+# clone returns an EMPTY range rather than an error, so a naive implementation
+# reports "all commits signed" for every PR forever. That is the same shape as
+# the dead monitors found on 2026-07-29: a check that cannot fail is worse than
+# no check, because it manufactures confidence.
+#
+# Builds throwaway git repos under mktemp. Touches nothing in this repo.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECKER="$HERE/check-dco.sh"
+pass=0
+fail=0
+
+WORK=$(mktemp -d)
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+git_quiet() { git -c user.name=Test -c user.email=test@example.com -c commit.gpgsign=false "$@" >/dev/null 2>&1; }
+
+expect() {
+    local want="$1" name="$2" dir="$3" base="$4" head="$5"
+    local got
+    ( cd "$dir" && BASE="$base" HEAD="$head" bash "$CHECKER" >/dev/null 2>&1 )
+    got=$?
+    if [[ "$got" == "$want" ]]; then
+        echo "  ok    $name"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL  $name (wanted exit $want, got $got)"
+        fail=$((fail + 1))
+    fi
+}
+
+# --- repo 1: signed and unsigned commits on a branch -----------------------
+R="$WORK/basic"
+mkdir -p "$R" && cd "$R" || exit 1
+git_quiet init -b main
+echo base > f.txt && git_quiet add . && git_quiet commit -m "base" -s
+BASE=$(git rev-parse HEAD)
+
+echo one >> f.txt && git_quiet add . && git_quiet commit -m "signed change" -s
+SIGNED=$(git rev-parse HEAD)
+
+echo two >> f.txt && git_quiet add . && git_quiet commit -m "unsigned change"
+UNSIGNED=$(git rev-parse HEAD)
+
+echo "Sign-off detection:"
+expect 0 "all commits signed"                "$R" "$BASE"   "$SIGNED"
+expect 1 "one unsigned commit in range"      "$R" "$BASE"   "$UNSIGNED"
+expect 0 "empty range (nothing to verify)"   "$R" "$SIGNED" "$SIGNED"
+
+# --- repo 2: a merge commit must be skipped, not demanded ------------------
+M="$WORK/merge"
+mkdir -p "$M" && cd "$M" || exit 1
+git_quiet init -b main
+echo base > f.txt && git_quiet add . && git_quiet commit -m "base" -s
+MBASE=$(git rev-parse HEAD)
+
+git_quiet checkout -b feature
+echo feat > g.txt && git_quiet add . && git_quiet commit -m "feature work" -s
+
+git_quiet checkout main
+echo other > h.txt && git_quiet add . && git_quiet commit -m "main moves" -s
+
+git_quiet checkout feature
+# --no-ff forces a merge commit, which git creates WITHOUT a sign-off. GitHub
+# does the same when a PR is updated from main. Demanding one would fail every
+# such PR.
+git_quiet merge --no-ff main -m "Merge main into feature"
+MHEAD=$(git rev-parse HEAD)
+
+echo
+echo "Merge commits:"
+expect 0 "unsigned merge commit is skipped" "$M" "$MBASE" "$MHEAD"
+
+# --- repo 3: unresolvable range must NOT pass ------------------------------
+echo
+echo "Unresolvable range - must refuse, never silently pass:"
+expect 2 "BASE not in this clone"  "$R" "0000000000000000000000000000000000000000" "$SIGNED"
+expect 2 "HEAD not in this clone"  "$R" "$BASE" "0000000000000000000000000000000000000000"
+expect 2 "BASE/HEAD unset"         "$R" "" ""
+
+cd "$HERE" || exit 1
+echo
+if [[ "$fail" -gt 0 ]]; then
+    echo "FAIL: $fail of $((pass + fail)) checks failed"
+    exit 1
+fi
+echo "OK: $pass/$pass checks passed"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,47 @@
+name: DCO
+
+# NO `paths:` filter, deliberately. Every commit needs a sign-off regardless of
+# what it touches, and a path-filtered check that might one day be made
+# required would deadlock any PR outside its paths - see the 2026-07-29 fix
+# where three required checks were filtered and blocked docs-only PRs forever
+# on "Expected — Waiting for status to be reported".
+#
+# `pull_request`, never `pull_request_target`: read-only token, no repo
+# secrets, so a fork cannot exfiltrate anything by editing this file.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dco-self-test:
+    # Runs before the real check. A DCO checker that silently passes everything
+    # is worse than no checker - it manufactures confidence. These tests build
+    # throwaway git repos and prove it fails on an unsigned commit, skips merge
+    # commits, and refuses rather than passes when the commit range cannot be
+    # resolved (a shallow clone returns an EMPTY range, not an error).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prove the DCO check can still fail
+        run: bash .github/scripts/test-check-dco.sh
+
+  dco:
+    needs: dco-self-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history: the check needs both BASE and HEAD present to resolve
+          # the commit range. A shallow clone yields an empty range, which would
+          # pass silently on every PR.
+          fetch-depth: 0
+      - name: Every non-merge commit must carry a Signed-off-by line
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: bash .github/scripts/check-dco.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing to the Behalf.bot chassis
+
+Thanks for looking. This document exists so you know the bar before you spend a
+weekend on something, and so a "no" from us is a link rather than an argument.
+
+## Read this first: what this project is, and what it is not
+
+The chassis is **opinionated infrastructure for one person's always-on agent**.
+It is not a framework trying to serve every use case. A change that makes it
+more general at the cost of making it harder to reason about will usually be
+declined, and that is not a judgement on the code.
+
+The line that matters most: **safety lives at the hook layer, not in prompts.**
+`chassis/.claude/hooks/guardrails.sh` is deterministic and survives a context
+reset; a rule written into a CLAUDE.md does not. Changes that move enforcement
+from the first place to the second will be declined regardless of how well they
+are written. See [`docs/security.md`](docs/security.md).
+
+## Licence and the sign-off
+
+This repo is under the **O'Saasy Licence** (see [`LICENSE`](LICENSE)), which is
+source-available rather than OSI-approved open source. That matters for
+contributions: with MIT or Apache there is a well-understood convention that a
+contribution arrives under the project's licence. There is no such convention
+for a custom licence, so we ask for it explicitly.
+
+We use the [Developer Certificate of Origin](https://developercertificate.org/).
+**This is not a CLA.** There is no form, no signing ceremony, and no copyright
+assignment - you keep your copyright. It is one line in your commit message:
+
+```
+Signed-off-by: Your Name <your@email.com>
+```
+
+`git commit -s` adds it for you. It records that you wrote the change, or have
+the right to submit it, and are submitting it under this project's licence.
+
+CI checks it. If you forget:
+
+```bash
+git commit --amend -s --no-edit        # most recent commit
+git rebase --signoff origin/main       # every commit on your branch
+git push --force-with-lease
+```
+
+## Before you open a PR
+
+**Open an issue first for anything non-trivial.** A typo fix or a clearly-scoped
+bug fix can go straight to a PR. Anything that adds a dependency, changes an
+interface, adds a heartbeat, or touches the hook layer should start as an issue,
+because the most common reason a well-written PR gets declined is that it
+rebuilds something deliberately rejected earlier.
+
+**Check the closed issues and merged PRs.** Same reason.
+
+## What CI will check
+
+Every PR runs, on every change regardless of paths:
+
+| Check | What it wants |
+|---|---|
+| `check-no-customer-state` | No customer-specific state committed into the chassis tree |
+| `diff-against-canonical` | The plugin fetcher seed still matches the canonical list |
+| `dco` | Every non-merge commit has a `Signed-off-by` line |
+
+Shell changes additionally run `shellcheck` at `severity: error`. The bar is
+"contains no real bug", not "matches our style" - do not spend time on lint
+preferences.
+
+Some workflows are path-filtered and will not run on your PR. That is expected
+and is not something being skipped: only checks that can run on every PR are
+required to pass.
+
+## What gets a PR declined
+
+Stated plainly so you can avoid all of it:
+
+- Moving a safety rule from the hook layer into a prompt or a CLAUDE.md
+- Committing credentials, tokens, or anything customer-specific
+- Adding a dependency to do something the standard library or an existing
+  dependency already does
+- Broad reformatting or style-only churn mixed into a functional change
+- A new heartbeat with no gather-first condition. The dispatcher's whole design
+  is "check cheaply, invoke the model rarely" - roughly 96 ticks a day for about
+  4 model calls. A heartbeat that fires the model on a schedule regardless of
+  whether there is work breaks the economics for every install.
+- Anything that makes the chassis assume a specific person's setup. If it
+  hardcodes a name, a channel ID, a path under someone's home directory, or a
+  timezone, it belongs in an install overlay rather than here.
+
+## Security
+
+**Do not open a public issue for a vulnerability.** See
+[`SECURITY.md`](SECURITY.md) for the private disclosure channel.
+
+## Review, and what to expect
+
+This is a small project with one maintainer. Reviews are best-effort, not
+same-day. A PR that sits for a few days has not been ignored.
+
+An assistant does a first pass on inbound PRs - size, paths touched, CI state,
+whether it duplicates earlier work - and surfaces a summary. **Every merge
+decision is a human one.** Nothing is merged by a bot.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,69 @@
+# Security policy
+
+## Reporting a vulnerability
+
+**Do not open a public issue.** A public issue discloses the problem to everyone
+at the same moment, including anyone who would use it.
+
+Use GitHub's private vulnerability reporting instead:
+
+**[Report a vulnerability](https://github.com/scrollinondubs/behalfbot/security/advisories/new)**
+
+It is enabled on this repo. The report is visible only to the maintainer until a
+fix is ready, and it gives us a private thread to ask questions in.
+
+Expect a first response within a few days. This is a small project with one
+maintainer, so please do not read silence as dismissal - if a week passes with
+nothing, feel free to nudge by opening a public issue that says only "I filed a
+private report, please look", with no detail in it.
+
+## What is in scope
+
+This project is an always-on agent that runs with broad access on someone's own
+machine, so the interesting failures are usually about **the boundary between
+untrusted input and privileged action** rather than memory safety.
+
+Particularly wanted:
+
+- **A way around the hook layer.** `chassis/.claude/hooks/guardrails.sh` is
+  deterministic enforcement that is supposed to hold even when the model is
+  confused or adversarially prompted. A command shape that reaches a blocked
+  action anyway is the highest-value report here.
+- **Prompt injection that reaches a privileged action.** The agent reads email,
+  web pages, chat messages and documents, all of which are attacker-controlled.
+  Getting it to *say* something silly is a curiosity. Getting it to send, delete,
+  push, spend, or exfiltrate is a vulnerability.
+- **Credential exposure.** Anything that puts a token, key or secret somewhere it
+  can be read - a log, an error message, a committed file, a prompt sent to a
+  model provider.
+- **Privilege escalation across the install boundary.** A plugin or an installed
+  component reaching data or credentials outside its declared scope.
+- **Anything that lets a third party reach an installed agent** without the
+  operator's involvement.
+
+## What is out of scope
+
+- The use of `--dangerously-skip-permissions`. That is a deliberate, documented
+  design decision with the hook layer as its compensating control - see
+  [`docs/security.md`](docs/security.md). Reports that it is dangerous in the
+  abstract, without a concrete bypass, will be closed.
+- Findings that require an attacker to already have shell access on the machine
+  running the agent. At that point they have everything.
+- Missing hardening with no exploit path attached, particularly automated scanner
+  output pasted verbatim.
+- Vulnerabilities in third-party services or dependencies. Report those upstream;
+  we will happily take a PR bumping a version.
+- Social engineering of the maintainer.
+
+## Disclosure
+
+We would rather fix it and credit you than argue about a timeline. Tell us what
+disclosure schedule you are working to and we will try to meet it. If you would
+like credit, say so and how you want to be named.
+
+## For operators running an install
+
+If you believe **your own** install is compromised rather than finding a flaw in
+the software, that is an incident, not a vulnerability report. Rotate your
+credentials first, then get in touch. `docs/disaster-recovery.md` covers the
+restore path.


### PR DESCRIPTION
Step 3 of the OSS plan Sean greenlit this morning, and the last of it. Steps 1 and 2 (CI, branch protection, the `oss-inbound` alerting heartbeat) are already in.

## Why now

This repo is public, has 11 stars, and is about to get attention from a 140-person talk. It had:

- no statement anywhere of what a contribution should look like
- no private channel for a vulnerability report
- no record of what terms an inbound contribution arrives under

## What lands

**`CONTRIBUTING.md`** leads with what the project is *not*, because the most common reason a well-written PR gets declined is that it makes the chassis more general at the cost of being harder to reason about. It states the hook-layer rule explicitly - safety is deterministic enforcement in `guardrails.sh`, never a prompt instruction - and lists what gets a PR declined so contributors can avoid all of it before writing code rather than after.

**`SECURITY.md`** points at GitHub private vulnerability reporting, enabled today. Before this, a researcher who found something in a public agent framework had exactly one channel: a public issue disclosing it to everyone at once. Scope is written for what this project actually is - the interesting failures are at the boundary between untrusted input and privileged action, so hook-layer bypasses and injections that reach a real action are named as the highest-value reports. Out-of-scope names the predictable noise, including `"--dangerously-skip-permissions` is dangerous" with no concrete bypass attached.

**DCO rather than a CLA**, per Sean's call. This repo is under a custom source-available licence, so the inbound=outbound convention that MIT and Apache get for free does not apply and the terms have to be stated. A CLA would mean a signing flow and would visibly deter contributors; DCO is one line and `git commit -s`.

**`CODEOWNERS`** is review routing, not access control, and the comment says so. Deliberately not paired with "Require review from Code Owners" - single maintainer, so requiring an approval would mean nobody can ever merge, including you.

## The DCO check is proven to fail before it is trusted

`.github/scripts/test-check-dco.sh` builds throwaway git repos and asserts seven behaviours. CI runs it **before** the real check, so a regression that blinds the checker breaks the build instead of silently passing every PR.

```
Sign-off detection:
  ok    all commits signed
  ok    one unsigned commit in range
  ok    empty range (nothing to verify)

Merge commits:
  ok    unsigned merge commit is skipped

Unresolvable range - must refuse, never silently pass:
  ok    BASE not in this clone
  ok    HEAD not in this clone
  ok    BASE/HEAD unset

OK: 7/7 checks passed
```

The load-bearing case is the last group. **`git log BASE..HEAD` on a shallow clone returns an EMPTY range rather than an error**, so a naive implementation reports "all commits signed" on every PR forever - the same "check that cannot fail" shape as this morning's two dead monitors. The checker exits 2 instead of passing.

Merge commits are skipped because GitHub creates them without a sign-off; demanding one would fail every PR that has been updated from main.

## Not required, on purpose

`dco` is **not** added to the required-status-checks list. That is your call to make, and it needs the ruleset edited. It runs on every PR either way, with no `paths:` filter - three required checks were path-filtered this morning and blocked docs-only PRs indefinitely on "Expected — Waiting for status to be reported".

🤖 Generated with [Claude Code](https://claude.com/claude-code)