### PR TITLE
Fix merge-plugin-triggers.sh to resolve plugins via CHASSIS_PLUGINS_ROOT

### DIFF
--- a/chassis/scripts/merge-plugin-triggers.sh
+++ b/chassis/scripts/merge-plugin-triggers.sh
@@ -8,18 +8,29 @@
 # Behavior:
 #   - Reads chassis.config.yaml to determine which plugins are enabled
 #     (modules.<plugin>.enabled = true)
-#   - For each enabled plugin, reads plugins/<plugin>/openclaw.plugin.json,
-#     pulls the contracts.triggers array
+#   - For each enabled plugin, resolves its openclaw.plugin.json the same way
+#     every other plugin-tree consumer does: via CHASSIS_PLUGINS_ROOT (the
+#     resolved baked+fetched overlay from resolve-plugin-root.sh / _env.sh —
+#     behalfbot#95), falling back to $CUSTOMER_HOME/plugins/<plugin> for
+#     customer-local-only plugins (e.g. midnight-oil) that are never baked or
+#     fetched — see chassis/scripts/fetch-plugins.sh's note on that directory.
+#     Pulls the contracts.triggers array.
 #   - Replaces the `triggers:` block in chassis/triggers.yaml with the merged
 #     set, preserving order: chassis-shipped triggers first (from the template's
 #     marker block), then plugin-declared triggers in plugin-id alphabetical order
-#   - Validates the resulting file parses cleanly via dispatch-trigger.sh's
-#     awk parser (running it in dry-run mode)
+#   - Asserts that every enabled plugin resolves to a manifest somewhere in
+#     that search (resolved root, then customer-local), and fails loudly
+#     (nonzero exit) instead of silently merging zero triggers when the
+#     lookup points at the wrong directory — see behalfbot#98.
 #
 # Required env:
 #   CHASSIS_HOME — absolute path to the chassis directory
 #
 # Optional env:
+#   CHASSIS_PLUGINS_ROOT — resolved plugin root; resolved via _env.sh /
+#       resolve-plugin-root.sh when unset
+#   CUSTOMER_HOME — customer state root (holds the local-only plugins/ dir);
+#       defaults to CHASSIS_HOME when unset, same as _env.sh
 #   DRY_RUN — if "true", emit the merged YAML to stdout instead of writing to disk
 #
 # Idempotent: running twice with no plugin changes produces an identical file.
@@ -27,6 +38,10 @@
 set -euo pipefail
 
 : "${CHASSIS_HOME:?CHASSIS_HOME must be set}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_env.sh"
 
 CONFIG="$CHASSIS_HOME/chassis.config.yaml"
 TARGET="$CHASSIS_HOME/chassis/triggers.yaml"
@@ -77,25 +92,41 @@ print("\n".join(sorted(plugins)))
 PY
 )
 
-# Build merged triggers section
-merged=$(python3 - <<PY
+# Build merged triggers section. Resolve each plugin's manifest via
+# CHASSIS_PLUGINS_ROOT first (the same resolved baked+fetched overlay every
+# other plugin-tree consumer uses), then fall back to $CUSTOMER_HOME/plugins
+# for customer-local-only plugins that are never baked or fetched.
+merged=$(CHASSIS_PLUGINS_ROOT="$CHASSIS_PLUGINS_ROOT" CUSTOMER_HOME="$CUSTOMER_HOME" python3 - <<PY
 import json
 import os
 import sys
 from pathlib import Path
 
-chassis_home = Path(os.environ["CHASSIS_HOME"])
+plugins_root = Path(os.environ["CHASSIS_PLUGINS_ROOT"])
+customer_plugins = Path(os.environ["CUSTOMER_HOME"]) / "plugins"
 plugin_names = """$enabled_plugins""".strip().splitlines()
 
 entries = []
+not_found = []
 for name in plugin_names:
-    manifest = chassis_home / "plugins" / name / "openclaw.plugin.json"
+    manifest = plugins_root / name / "openclaw.plugin.json"
+    source = "plugins_root"
     if not manifest.exists():
+        manifest = customer_plugins / name / "openclaw.plugin.json"
+        source = "customer_local"
+    if not manifest.exists():
+        # Assertion (behalfbot#98): an enabled plugin with no manifest in
+        # EITHER the resolved plugin root or the customer-local tree is
+        # unresolvable — the exact silent-drop shape this issue exists to
+        # catch (every enabled plugin used to resolve to nothing whenever
+        # the lookup pointed at the wrong directory, and this script kept
+        # printing a success line anyway). Fail loudly instead.
+        not_found.append(name)
         continue
     try:
         data = json.loads(manifest.read_text())
     except Exception as e:
-        print(f"WARN: skipping {name}: {e}", file=sys.stderr)
+        print(f"WARN: skipping {name} ({source}): {e}", file=sys.stderr)
         continue
     triggers = data.get("contracts", {}).get("triggers", []) or []
     plugin_id = data.get("id", name)
@@ -105,6 +136,14 @@ for name in plugin_names:
         t = dict(t)
         t["plugin"] = plugin_id
         entries.append(t)
+
+if not_found:
+    print(
+        f"ERROR: enabled plugin(s) have no manifest under {plugins_root} or {customer_plugins}: "
+        + ", ".join(not_found),
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 # Output in YAML
 def yaml_str(v):

--- a/chassis/scripts/test-merge-plugin-triggers.sh
+++ b/chassis/scripts/test-merge-plugin-triggers.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# test-merge-plugin-triggers.sh - Unit tests for merge-plugin-triggers.sh
+# plugin-manifest resolution (behalfbot#98).
+#
+# The bug these lock down
+# ========================
+# merge-plugin-triggers.sh read manifests from $CHASSIS_HOME/plugins/<name>,
+# never consulting CHASSIS_PLUGINS_ROOT. Every other plugin-tree consumer
+# (cmd_install_plugin, smoke-test.sh, bootstrap.sh) resolves plugins through
+# CHASSIS_PLUGINS_ROOT (the baked+fetched overlay from resolve-plugin-root.sh,
+# behalfbot#95). This script alone picked up only the customer-side
+# plugins/ directory (local-only plugins like midnight-oil) and silently
+# merged zero triggers for everything else - with no error, no warning, and
+# a "✓ merged" success line printed regardless.
+#
+# No docker daemon, no network. Everything runs against temp directories.
+#
+# Exit codes:
+#   0 - all scenarios passed
+#   1 - one or more scenarios failed
+#   2 - test harness itself broke
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MERGE="${SCRIPT_DIR}/merge-plugin-triggers.sh"
+
+if [[ ! -f "$MERGE" ]]; then
+    echo "test-merge-plugin-triggers: missing $MERGE" >&2
+    exit 2
+fi
+
+fail=0
+pass=0
+
+check() {
+    local name="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        pass=$((pass + 1))
+    else
+        echo "FAIL [$name] expected '$expected', got '$actual'"
+        fail=$((fail + 1))
+    fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+manifest() {
+    # manifest <dir> <plugin-id> <trigger-name>
+    mkdir -p "$1"
+    cat > "$1/openclaw.plugin.json" <<JSON
+{
+  "id": "$2",
+  "contracts": {
+    "triggers": [
+      {"name": "$3", "keyword_regex": "^${3}:", "handler": "/bin/true"}
+    ]
+  }
+}
+JSON
+}
+
+fresh_env() {
+    # fresh_env <label> -> sets CUSTOMER, ROOT globals, writes config + template
+    CUSTOMER="$TMP/$1/customer"
+    ROOT="$TMP/$1/plugins-root"
+    mkdir -p "$CUSTOMER/chassis" "$ROOT"
+    cat > "$CUSTOMER/chassis.config.yaml" <<YAML
+modules:
+  alpha:
+    enabled: true
+  beta:
+    enabled: true
+  gamma:
+    enabled: false
+YAML
+    printf '# template header\ntriggers:\n' > "$CUSTOMER/chassis/triggers.yaml.template"
+}
+
+run_merge() {
+    # -> MERGED_OUT, MERGE_RC
+    MERGED_OUT="$(DRY_RUN=true \
+        CHASSIS_HOME="$CUSTOMER" CUSTOMER_HOME="$CUSTOMER" \
+        CHASSIS_PLUGINS_ROOT="$ROOT" \
+        bash "$MERGE" 2>"$TMP/merge.log")"
+    MERGE_RC=$?
+}
+
+# --- scenario 1: plugin lives only in the resolved plugin root --------------
+# THE regression test: pre-fix, this plugin would never be found because the
+# script looked under $CHASSIS_HOME/plugins, not $CHASSIS_PLUGINS_ROOT.
+fresh_env s1
+manifest "$ROOT/alpha" "alpha" "alpha-trigger"
+manifest "$ROOT/beta" "beta" "beta-trigger"
+run_merge
+check "s1 exit" "0" "$MERGE_RC"
+check "s1 alpha trigger merged" "1" "$(grep -c 'name: alpha-trigger' <<<"$MERGED_OUT")"
+check "s1 beta trigger merged" "1" "$(grep -c 'name: beta-trigger' <<<"$MERGED_OUT")"
+
+# --- scenario 2: one plugin only in customer-local plugins/ -----------------
+# The behaviour that DID work pre-fix (e.g. Sean's midnight-oil) must keep
+# working: a plugin with no manifest in the resolved root but a manifest
+# under $CUSTOMER_HOME/plugins/<name>.
+fresh_env s2
+manifest "$ROOT/alpha" "alpha" "alpha-trigger"
+manifest "$CUSTOMER/plugins/beta" "beta" "beta-trigger"
+run_merge
+check "s2 exit" "0" "$MERGE_RC"
+check "s2 alpha (root) trigger merged" "1" "$(grep -c 'name: alpha-trigger' <<<"$MERGED_OUT")"
+check "s2 beta (customer-local) trigger merged" "1" "$(grep -c 'name: beta-trigger' <<<"$MERGED_OUT")"
+
+# --- scenario 3: resolved root wins when a plugin exists in both ------------
+fresh_env s3
+manifest "$ROOT/alpha" "alpha" "root-wins-trigger"
+manifest "$CUSTOMER/plugins/alpha" "alpha" "customer-shadow-trigger"
+manifest "$ROOT/beta" "beta" "beta-trigger"
+run_merge
+check "s3 exit" "0" "$MERGE_RC"
+check "s3 root manifest wins" "1" "$(grep -c 'name: root-wins-trigger' <<<"$MERGED_OUT")"
+check "s3 customer manifest shadowed" "0" "$(grep -c 'name: customer-shadow-trigger' <<<"$MERGED_OUT")"
+
+# --- scenario 4: an enabled plugin with no manifest anywhere fails loudly ---
+# This is the check that can fail (issue acceptance criterion): removing/
+# breaking the resolution must not merge silently.
+fresh_env s4
+manifest "$ROOT/alpha" "alpha" "alpha-trigger"
+# beta enabled in config but no manifest under $ROOT or $CUSTOMER/plugins.
+run_merge
+check "s4 exit is nonzero" "1" "$([[ "$MERGE_RC" -ne 0 ]] && echo 1 || echo 0)"
+check "s4 error mentions beta" "1" "$(grep -c 'beta' "$TMP/merge.log")"
+
+# ---------------------------------------------------------------------------
+echo
+echo "test-merge-plugin-triggers: $pass passed, $fail failed"
+[[ "$fail" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary
- `merge-plugin-triggers.sh` read plugin manifests from `$CHASSIS_HOME/plugins/<name>` only, never consulting `CHASSIS_PLUGINS_ROOT` - the resolved baked+fetched overlay every other plugin-tree consumer uses (behalfbot#95).
- In-container, `$CHASSIS_HOME/plugins` resolves to the customer-side `plugins/` dir, so a plugin fetched from `behalfbot-plugins` or baked into the image would install and validate cleanly but never get its Discord trigger registered - with nothing erroring.
- Now resolves each enabled plugin's manifest via `CHASSIS_PLUGINS_ROOT` first (sourcing `_env.sh` so resolution matches the rest of the system), falling back to `$CUSTOMER_HOME/plugins` for customer-local-only plugins (e.g. midnight-oil) that are never baked or fetched - per `fetch-plugins.sh`'s note that this directory must never be clobbered.
- Added an assertion: an enabled plugin with no manifest in either location now fails the script loudly instead of silently merging zero triggers and printing a "✓ merged" success line anyway.
- Added `chassis/scripts/test-merge-plugin-triggers.sh` - 4 scenarios against temp dirs (root-only plugin, customer-local-only plugin, root-wins-over-customer precedence, and the loud-failure case), no docker/network required.

## Test plan
- [x] `bash chassis/scripts/test-merge-plugin-triggers.sh` - 11/11 passed
- [x] `bash chassis/scripts/test-plugin-root-resolution.sh` - 32/32 passed (unaffected, sanity check)
- [x] `bash -n chassis/scripts/merge-plugin-triggers.sh`

Closes #98