### PR TITLE
fix(daily-log-gather): make merged/opened/closed_unmerged day filters exclusive on the upper bound

### DIFF
--- a/chassis/scripts/daily-log-gather.py
+++ b/chassis/scripts/daily-log-gather.py
@@ -177,6 +177,23 @@ def run_text(argv: list[str], *, verbose: bool, timeout: int = 60) -> str | None
 # --- GitHub surface -------------------------------------------------------
 
 
+def classify_pr_for_day(pr: dict, day_str: str) -> str | None:
+    """Bucket a PR dict into "merged" / "opened" / "closed_unmerged" for the
+    single calendar day `day_str` (YYYY-MM-DD), or None if it belongs to a
+    different day. Each PR maps to at most one bucket for a given day."""
+    state = (pr.get("state") or "").upper()
+    merged_at = pr.get("mergedAt")
+    closed_at = pr.get("closedAt")
+    created_at = pr.get("createdAt")
+    if merged_at and merged_at[:10] == day_str:
+        return "merged"
+    if state == "OPEN" and created_at and created_at[:10] == day_str:
+        return "opened"
+    if state == "CLOSED" and closed_at and not merged_at and closed_at[:10] == day_str:
+        return "closed_unmerged"
+    return None
+
+
 def gather_github(gh_user: str, since: datetime, until: datetime, *, verbose: bool
                   ) -> tuple[dict[str, dict], list[dict], list[str]]:
     """Return (prs_by_repo, open_issues_awaiting_input, warnings)."""
@@ -246,17 +263,13 @@ def gather_github(gh_user: str, since: datetime, until: datetime, *, verbose: bo
                 "url": pr.get("url"),
                 "body_excerpt": body[:300].strip(),
             }
-            state = (pr.get("state") or "").upper()
-            merged_at = pr.get("mergedAt")
-            closed_at = pr.get("closedAt")
-            created_at = pr.get("createdAt")
-            if merged_at and since_str <= merged_at[:10] <= until_str:
+            bucket = classify_pr_for_day(pr, since_str)
+            if bucket == "merged":
                 merged.append(item)
-            elif state == "OPEN" and created_at and since_str <= created_at[:10] <= until_str:
+            elif bucket == "opened":
                 opened.append(item)
-            elif state == "CLOSED" and closed_at and not merged_at:
-                if since_str <= closed_at[:10] <= until_str:
-                    closed_unmerged.append(item)
+            elif bucket == "closed_unmerged":
+                closed_unmerged.append(item)
         if merged or opened or closed_unmerged:
             prs_by_repo[repo] = {
                 "merged": merged,

--- a/chassis/scripts/test-daily-log-gather.sh
+++ b/chassis/scripts/test-daily-log-gather.sh
@@ -228,6 +228,58 @@ else
 fi
 
 # ------------------------------------------------------------------------
+# Scenario 7: classify_pr_for_day window is one calendar day wide.
+#
+# Regression for the bug where the merged/opened/closed_unmerged filters
+# used an inclusive since..until range (both ends), so a PR merged "today"
+# (until_str) leaked into the report labelled "yesterday" (since_str).
+# ------------------------------------------------------------------------
+classify_out=$(python3 - "$GATHER" <<'PYEOF'
+import importlib.util
+import sys
+
+gather_path = sys.argv[1]
+spec = importlib.util.spec_from_file_location("daily_log_gather", gather_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+classify = mod.classify_pr_for_day
+since_str = "2026-07-18"
+until_str = "2026-07-19"
+
+cases = [
+    # (pr, expected_bucket)
+    ({"state": "MERGED", "mergedAt": "2026-07-18T23:00:00Z"}, "merged"),
+    ({"state": "MERGED", "mergedAt": "2026-07-19T00:30:00Z"}, None),
+    ({"state": "OPEN", "createdAt": "2026-07-18T10:00:00Z"}, "opened"),
+    ({"state": "OPEN", "createdAt": "2026-07-19T00:05:00Z"}, None),
+    ({"state": "CLOSED", "closedAt": "2026-07-18T12:00:00Z"}, "closed_unmerged"),
+    ({"state": "CLOSED", "closedAt": "2026-07-19T00:05:00Z"}, None),
+]
+
+failures = []
+for pr, expected in cases:
+    got = classify(pr, since_str)
+    if got != expected:
+        failures.append(f"{pr} -> got {got!r}, expected {expected!r}")
+
+if failures:
+    print("FAIL")
+    for f in failures:
+        print(f)
+else:
+    print("PASS")
+PYEOF
+)
+if [[ "$classify_out" == PASS* ]]; then
+    pass=$((pass + 1))
+else
+    echo "FAIL [classify_pr_for_day] window is not one calendar day wide"
+    echo "$classify_out"
+    fail=$((fail + 1))
+fi
+
+# ------------------------------------------------------------------------
 # Summary
 # ------------------------------------------------------------------------
 echo


### PR DESCRIPTION
## Summary
- `since_str <= x <= until_str` treated PRs/issues from *today* as belonging to *yesterday*'s report, since the payload's `date` field is `since_str` (yesterday). A PR merged at 00:30 UTC landed in both the previous day's log and the current one.
- Extracted the per-PR classification into `classify_pr_for_day()` and compared only against `since_str`, matching the single-day semantics the report actually claims.
- Applied identically to `merged`, `opened` (OPEN + createdAt), and `closed_unmerged` (CLOSED + closedAt, not merged).

## Test plan
- [x] `chassis/scripts/test-daily-log-gather.sh` - added scenario 7, a direct unit test of `classify_pr_for_day` against fixtures spanning the since/until boundary (mirrors the bug report's 2026-07-18/19 evidence). All 7 scenarios pass locally.
- [x] `python3 -m py_compile chassis/scripts/daily-log-gather.py`

Closes #126

---

Replaces #130, which is identical except that its commit carried no `Signed-off-by` trailer and failed the DCO check. The fix could not be amended in place: `.claude/hooks/guardrails.sh:34` blocks force-push unconditionally, so the corrected commit had to arrive on a new branch.