### PR TITLE
fix(dispatcher): lock the state-file read-modify-write cycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ scripts/watchdog-*.sh
 # Customer-side scheduled-task state. The template files (e.g. *.template,
 # *-prompt.md.template) live in chassis/ and remain tracked.
 scheduled-tasks/heartbeat-state.json
+# Per-writer staging files set_state/increment_fire_count create before the
+# atomic mv (new-jaxity#412/#409) - "${STATE_FILE}.$$.<key>.tmp".
+scheduled-tasks/heartbeat-state.json.*.tmp
 scheduled-tasks/conservation-mode.json
 scheduled-tasks/quota-last-block-start.txt
 

--- a/chassis/scheduled-tasks/heartbeat-dispatcher.sh
+++ b/chassis/scheduled-tasks/heartbeat-dispatcher.sh
@@ -204,21 +204,95 @@ get_state() {
     jq -r --arg n "$name" --arg f "$field" '.[$n][$f] // ""' "$STATE_FILE"
 }
 
+# Mutex around the read-modify-write cycle below (new-jaxity#412/#409).
+# `mkdir` is atomic on every filesystem this script runs on (the container,
+# macOS, Linux) with no external dependency (flock is not on macOS by
+# default) - exactly one caller can ever create "${STATE_FILE}.lock" at a
+# time, so it doubles as a zero-dependency mutex.
+#
+# This is NOT the same bug a unique-per-writer temp path fixes. A unique tmp
+# path only stops two writers' STAGING files from colliding - it does nothing
+# about two writers both reading $STATE_FILE before either has written it
+# back, computing their update from that same stale snapshot, and the second
+# mv silently discarding the first writer's change. That is a lost-update
+# race, not a filename collision, and it reproduces reliably under concurrent
+# distinct-key writers even with unique tmp paths - see
+# tests/test_state_write_race.sh, which failed against a unique-tmp-path-only
+# version of this fix before the locking below was added. Observed live as
+# the dispatcher firing pulse-triage twice 4s apart on 2026-07-30 - the
+# signature of a lost state write, most likely from two dispatcher runs
+# overlapping (acquire_lock's PID-file check is itself non-atomic).
+_state_lock_acquire() {
+    local lock_dir="${STATE_FILE}.lock"
+    local waited_ms=0
+    # Declared once, outside the loop - zsh prints "holder=<value>" to stdout
+    # (like a bare `typeset holder` would) if `local holder` re-runs on a
+    # variable that already holds a value from the previous iteration.
+    # Verified directly: `f(){ local i=0; while ...; do local x; x=$i; done }`
+    # prints "x=<value>" on every iteration after the first.
+    local holder
+    while ! mkdir "$lock_dir" 2>/dev/null; do
+        # Stale-lock recovery: a dispatcher run that died mid-write (kill -9,
+        # OOM) leaves the lock dir behind forever otherwise.
+        holder=$(cat "$lock_dir/pid" 2>/dev/null || echo "")
+        if [[ -n "$holder" ]] && ! kill -0 "$holder" 2>/dev/null; then
+            rmdir "$lock_dir" 2>/dev/null || true
+            continue
+        fi
+        sleep 0.1 2>/dev/null || sleep 1
+        waited_ms=$((waited_ms + 100))
+        if [[ $waited_ms -ge 10000 ]]; then
+            log "WARNING state lock held >10s by pid ${holder:-unknown} - proceeding unlocked, a write may be lost"
+            return 1
+        fi
+    done
+    echo $$ > "$lock_dir/pid"
+    return 0
+}
+
+_state_lock_release() {
+    rm -rf "${STATE_FILE}.lock"
+}
+
 set_state() {
     local name="$1" field="$2" value="$3"
-    local tmp="${STATE_FILE}.tmp"
-    jq --arg n "$name" --arg f "$field" --arg v "$value" \
-        '.[$n] = (.[$n] // {}) | .[$n][$f] = $v' "$STATE_FILE" > "$tmp" \
-        && mv "$tmp" "$STATE_FILE"
+    local tmp="${STATE_FILE}.$$.${name}.tmp"
+    # `if` rather than a bare call so the timeout ("held >10s, proceeding
+    # unlocked") path can't trip `set -e` (new-jaxity#394's process_heartbeat
+    # lesson: a nonzero return from a bare statement under set -e kills the
+    # whole run, not just this write) - and so _state_lock_release only runs
+    # when THIS call actually holds the lock. Releasing unconditionally on
+    # the timeout path would rm -rf a lock dir some other writer still owns,
+    # letting a second writer in underneath it and recreating the exact race
+    # this is here to close.
+    if _state_lock_acquire; then
+        jq --arg n "$name" --arg f "$field" --arg v "$value" \
+            '.[$n] = (.[$n] // {}) | .[$n][$f] = $v' "$STATE_FILE" > "$tmp" \
+            && mv "$tmp" "$STATE_FILE"
+        _state_lock_release
+    else
+        jq --arg n "$name" --arg f "$field" --arg v "$value" \
+            '.[$n] = (.[$n] // {}) | .[$n][$f] = $v' "$STATE_FILE" > "$tmp" \
+            && mv "$tmp" "$STATE_FILE"
+    fi
 }
 
 increment_fire_count() {
     local name="$1"
-    local tmp="${STATE_FILE}.tmp"
-    jq --arg n "$name" \
-        '.[$n] = (.[$n] // {}) | .[$n].fire_count = ((.[$n].fire_count // "0") | tonumber + 1 | tostring)' \
-        "$STATE_FILE" > "$tmp" \
-        && mv "$tmp" "$STATE_FILE"
+    local tmp="${STATE_FILE}.$$.${name}.tmp"
+    # Same reasoning as set_state above.
+    if _state_lock_acquire; then
+        jq --arg n "$name" \
+            '.[$n] = (.[$n] // {}) | .[$n].fire_count = ((.[$n].fire_count // "0") | tonumber + 1 | tostring)' \
+            "$STATE_FILE" > "$tmp" \
+            && mv "$tmp" "$STATE_FILE"
+        _state_lock_release
+    else
+        jq --arg n "$name" \
+            '.[$n] = (.[$n] // {}) | .[$n].fire_count = ((.[$n].fire_count // "0") | tonumber + 1 | tostring)' \
+            "$STATE_FILE" > "$tmp" \
+            && mv "$tmp" "$STATE_FILE"
+    fi
 }
 
 # --- Ollama ---
@@ -1099,4 +1173,11 @@ ${gathered_data}
 }
 
 # Redirect all output to log; Claude output goes to its own file via >
-main "$@" >> "$LOG_FILE" 2>&1
+#
+# Guarded so tests/test_state_write_race.sh can `source` this file to reach
+# set_state/increment_fire_count in isolation without kicking off a full
+# dispatcher run. Unset in every real invocation (launchd/systemd), so
+# production behaviour is unchanged.
+if [[ "${DISPATCHER_TEST_SOURCE:-0}" != "1" ]]; then
+    main "$@" >> "$LOG_FILE" 2>&1
+fi

--- a/chassis/scheduled-tasks/tests/test_state_write_race.sh
+++ b/chassis/scheduled-tasks/tests/test_state_write_race.sh
@@ -1,0 +1,88 @@
+#!/bin/zsh
+# Regression test for new-jaxity#412 / #409: set_state and increment_fire_count
+# used to share a single "${STATE_FILE}.tmp" staging path across every
+# concurrent writer. Two heartbeats writing at once could race on that one
+# temp file - the second jq to finish clobbers the first's still-being-staged
+# output before its mv runs, and the loser's write vanishes with no error.
+# Observed live on 2026-07-30: the dispatcher fired pulse-triage twice 4s
+# apart, the signature of a lost state write.
+#
+# This sources heartbeat-dispatcher.sh with DISPATCHER_TEST_SOURCE=1 (see the
+# guard at the bottom of that file) to reach set_state/increment_fire_count in
+# isolation, points CUSTOMER_HOME at a scratch temp dir, then fires N
+# concurrent writers at DISTINCT keys and asserts every single one survived.
+# Against the pre-fix shared-tmp-path code this fails intermittently but
+# reliably across repeated runs; against the per-writer-tmp-path fix it
+# passes every time.
+#
+# Run from repo root:
+#   zsh chassis/scheduled-tasks/tests/test_state_write_race.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="${0:A:h}"
+DISPATCHER="${SCRIPT_DIR}/../heartbeat-dispatcher.sh"
+
+TMP_HOME=$(mktemp -d)
+cleanup() { rm -rf "$TMP_HOME"; }
+trap cleanup EXIT
+
+export CUSTOMER_HOME="$TMP_HOME"
+export CHASSIS_HOME="$TMP_HOME"
+mkdir -p "$TMP_HOME/scheduled-tasks" "$TMP_HOME/logs/scheduled"
+
+export DISPATCHER_TEST_SOURCE=1
+source "$DISPATCHER"
+
+init_state
+
+WRITER_COUNT=20
+FAIL=0
+
+# Fire WRITER_COUNT concurrent set_state calls, each at its own key, from
+# separate background jobs (separate PIDs) - the shape that raced on the old
+# shared "${STATE_FILE}.tmp" path. Distinct keys, same instant, is exactly
+# the scenario the issue calls for: two heartbeats never touch each other's
+# state entry, so any loss here is purely the temp-file collision, not a
+# legitimate same-key conflict.
+for i in $(seq 1 $WRITER_COUNT); do
+    set_state "writer-$i" "marker" "value-$i" &
+done
+wait
+
+for i in $(seq 1 $WRITER_COUNT); do
+    got=$(get_state "writer-$i" "marker")
+    if [[ "$got" != "value-$i" ]]; then
+        echo "FAIL: writer-$i lost its write - expected 'value-$i', got '${got:-<empty>}'"
+        FAIL=1
+    fi
+done
+
+# Same race, same assertion, for increment_fire_count.
+for i in $(seq 1 $WRITER_COUNT); do
+    increment_fire_count "counter-$i" &
+done
+wait
+
+for i in $(seq 1 $WRITER_COUNT); do
+    got=$(jq -r --arg n "counter-$i" '.[$n].fire_count // ""' "$STATE_FILE")
+    if [[ "$got" != "1" ]]; then
+        echo "FAIL: counter-$i lost its increment - expected fire_count '1', got '${got:-<empty>}'"
+        FAIL=1
+    fi
+done
+
+# No leftover staging files - every "${STATE_FILE}.$$.<key>.tmp" must have
+# been mv'd away.
+leftover=("$TMP_HOME"/scheduled-tasks/*.tmp(N))
+if [[ ${#leftover[@]} -gt 0 ]]; then
+    echo "FAIL: leftover tmp files after all writers completed: ${leftover[*]}"
+    FAIL=1
+fi
+
+if [[ $FAIL -eq 0 ]]; then
+    echo "PASS: $((WRITER_COUNT * 2)) concurrent distinct-key writers all survived, no leftover tmp files"
+    exit 0
+else
+    exit 1
+fi


### PR DESCRIPTION
## Summary

First slice of new-jaxity#412's dispatcher-state-hardening triage (behalfbot side of the fix for new-jaxity#394's lost-state-write bug, observed live as the dispatcher firing pulse-triage twice 4s apart on 2026-07-30).

The issue's own scoping asked for a narrower fix (unique temp path per writer). Built that first, wrote the concurrent-writer regression test it asked for, and it still failed reliably: a unique temp path only stops two writers' *staging* files colliding, it does nothing about two writers both reading `STATE_FILE` before either writes back, computing an update from the same stale snapshot, and the second `mv` silently discarding the first writer's change. That's a lost-update race, not a filename collision.

**Fix:** a zero-dependency `mkdir`-based mutex around the whole read + jq + write + mv cycle in `set_state`/`increment_fire_count` (mkdir is atomic on every filesystem this runs on; `flock` isn't on macOS by default), with stale-lock recovery for a dead PID and a 10s fail-open timeout. Kept the unique-per-writer temp path too, as defense in depth.

Also found and fixed via the regression test: a real zsh quirk where re-declaring `local holder` inside the retry loop caused zsh to print `holder=<value>` to stdout on every iteration after the first.

**Not in scope here** (separate slices of #412): #403 briefing clobber, #408 ccusage pattern, #410 postgres watchdog template, #404 `OLLAMA_URL` carve-out.

## Test plan

- [x] New regression test `chassis/scheduled-tasks/tests/test_state_write_race.sh`: sources the dispatcher in isolation, fires 40 concurrent distinct-key writes across both functions, asserts every write survived and no tmp files are left. Confirmed it fails against the pre-fix code AND against a unique-temp-path-only fix; passes against this one.
- [x] `zsh -n` syntax check passes.