### PR TITLE
fix(bake-env): refuse a bake that collapses the key count

### DIFF
--- a/chassis/scripts/bake-env.sh
+++ b/chassis/scripts/bake-env.sh
@@ -273,6 +273,56 @@ if [[ "$DRY_RUN" == "true" ]]; then
     exit 0
 fi
 
+# --- Regression guard -------------------------------------------------------
+#
+# This script derives its key set by diffing the environment before and after
+# sourcing .env, so ANY variable already present in the calling shell is
+# subtracted out. Run it from a shell that has already sourced .env - which is
+# easy to do by accident, since bw-unlock.sh and several gather scripts do it -
+# and the bake quietly produces an almost-empty file while reporting success.
+#
+# Measured 2026-08-01 23:09 on the reference install: a bake from such a shell
+# rewrote .env.baked from 132 keys to 4, dropping every hydrated secret
+# including all six AWS_BACKUP_* credentials. The container came back healthy,
+# nothing errored, and offsite backups failed silently at the next 03:20 run.
+# Nobody noticed for a day.
+#
+# A bake that removes most of the existing keys is never intentional. Refuse it
+# and say why, rather than write a file that looks fine and is not.
+if [[ -f "$DST_BAKED" && "${ALLOW_KEY_SHRINK:-0}" != "1" ]]; then
+    prev_keys=$(grep -cE '^[A-Z][A-Z0-9_]*=' "$DST_BAKED" || true)
+    prev_keys=${prev_keys:-0}
+    if (( prev_keys > 0 )); then
+        # Threshold rather than "any decrease": removing a secret from .env is a
+        # legitimate thing to do, and a guard that fires on a one-key change is
+        # a guard people learn to bypass. Half is well clear of routine churn
+        # and well below the 132 -> 4 collapse this exists to catch.
+        min_keys=$(( (prev_keys + 1) / 2 ))
+        if (( n_keys < min_keys )); then
+            rm -f "$TMP_BAKED"
+            cat >&2 <<EOF
+ERROR: refusing to write $DST_BAKED - key count would collapse.
+
+  existing: $prev_keys keys
+  new bake: $n_keys keys  (below the $min_keys floor)
+
+This almost always means the bake ran from a shell that had already sourced
+.env. This script computes its key set by diffing the environment before and
+after sourcing, so pre-existing variables are subtracted out and vanish from
+the output.
+
+Re-run from a clean environment:
+
+  env -i HOME="\$HOME" PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin \\
+    CHASSIS_HOME="$CUSTOMER_HOME" bash $0
+
+If the reduction is genuinely intended, pass ALLOW_KEY_SHRINK=1.
+EOF
+            exit 1
+        fi
+    fi
+fi
+
 mv "$TMP_BAKED" "$DST_BAKED"
 chmod 600 "$DST_BAKED"
 


### PR DESCRIPTION
`bake-env.sh` derives its key set by **diffing the environment before and after sourcing `.env`**, so any variable already present in the calling shell is subtracted out. Run it from a shell that has already sourced `.env` - easy to do by accident, since `bw-unlock.sh` and several gather scripts do exactly that - and the bake quietly writes an almost-empty file **while reporting success**.

## What it cost on the reference install

2026-08-01 23:09, a bake from such a shell rewrote `.env.baked` from **132 keys to 4**:

```
BW_SESSION  CUSTOMER_CLAUDE_DIR  DOCKER_SOCKET  MANIFEST
```

Every hydrated secret gone, including all six `AWS_BACKUP_*` credentials. The container came back **healthy**. Nothing errored. Offsite backups failed silently at the next 03:20 run and went unnoticed for a day.

The resulting alert then misdiagnosed it as *"missing AWS credentials... regenerate via AWS CloudShell"* - which would have sent the operator off to rotate keys that were never invalid. They were in Vaultwarden and working the whole time.

That is the shape worth fixing: not a crash, a plausible-looking success.

## The guard

Compare against the current `.env.baked` and refuse below half:

```
ERROR: refusing to write /Users/jax/.behalfbot/.env.baked - key count would collapse.

  existing: 132 keys
  new bake: 4 keys  (below the 66 floor)

This almost always means the bake ran from a shell that had already sourced
.env. [...]

Re-run from a clean environment:

  env -i HOME="$HOME" PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin \
    CHASSIS_HOME="..." bash .../bake-env.sh

If the reduction is genuinely intended, pass ALLOW_KEY_SHRINK=1.
```

**Half rather than "any decrease"** - removing a secret from `.env` is legitimate, and a guard that fires on a one-key change is one people learn to bypass. Half is clear of routine churn and far above the collapse this exists to catch.

## Verified

| case | result |
|---|---|
| 132 → 4 collapse | **refused**, existing file untouched (still 132 keys) |
| `ALLOW_KEY_SHRINK=1` | proceeds |
| fresh install, no prior `.env.baked` | proceeds (check skipped) |
| normal re-bake, 132 → 132 | proceeds |

shellcheck clean.

## Scope

This does **not** fix the underlying design. Deriving the key set from an ambient-environment diff is the actual defect; reading `.env` directly would be deterministic and immune to the caller's shell. That is a larger change and worth doing separately. This is the guard that makes the failure loud in the meantime.

Downstream tracking: scrollinondubs/new-jaxity#432.