### PR TITLE
fix(audit): Gap 3 resolves the memory graph, not the config shape (#142)

### DIFF
--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -28,6 +28,8 @@ on:
       - 'plugins/dating/scripts/gather-dating-swipe.sh'
       - 'plugins/dating/scheduled-tasks/recovery-hooks.d/dating-emulator-recovery.sh'
       - 'plugins/dating/tests/test-emulator-state.sh'
+      - 'chassis/scripts/bootstrap-audit.sh'
+      - 'chassis/scripts/test-bootstrap-audit-memory.sh'
       - '.github/workflows/shell-tests.yml'
   push:
     branches: [main]
@@ -49,6 +51,8 @@ on:
       - 'plugins/dating/scripts/gather-dating-swipe.sh'
       - 'plugins/dating/scheduled-tasks/recovery-hooks.d/dating-emulator-recovery.sh'
       - 'plugins/dating/tests/test-emulator-state.sh'
+      - 'chassis/scripts/bootstrap-audit.sh'
+      - 'chassis/scripts/test-bootstrap-audit-memory.sh'
       - '.github/workflows/shell-tests.yml'
   workflow_dispatch:
 
@@ -99,6 +103,18 @@ jobs:
       # _env.sh resolves docker-exec sessions through the state symlink.
       # No docker daemon, runs against temp dirs.
       - run: bash chassis/scripts/test-chassis-root-resolution.sh
+
+  bootstrap-audit-memory:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Behavioural coverage for #142: bootstrap-audit Gap 3 read
+      # env.MEMORY_FILE_PATH only, while the current .mcp.json.template sets no
+      # env block, so the check could never pass on a healthy install. The
+      # suite asserts both config shapes pass on a reachable graph AND that
+      # every unreachable / non-writable graph still fails, so the fix cannot
+      # degrade into a check that passes everything.
+      - run: bash chassis/scripts/test-bootstrap-audit-memory.sh
 
   dating-emulator-state:
     runs-on: ubuntu-latest

--- a/chassis/CHANGELOG.md
+++ b/chassis/CHANGELOG.md
@@ -18,6 +18,13 @@ Semver:
 
 ## Unreleased
 
+### Fixed
+
+- **`bootstrap-audit.sh` Gap 3 could never pass, so the memory-graph check had never caught anything (#142).** Gap 3 read `.mcpServers.memory.env.MEMORY_FILE_PATH` out of the customer's `.mcp.json`, but the current `.mcp.json.template` deliberately sets no `env` block - it resolves `$(pwd)/memory/memory.jsonl` inside an `sh -c` wrapper, because the host and the chassis container see the same bind-mounted directory at different absolute paths (`/Users/<user>/.behalfbot` vs `/app/customer`) and a single baked absolute path is therefore valid in only one namespace. Every install on the current template reported a false Gap 3 failure, and the check that exists to catch an unreachable knowledge graph could not pass on any of them. Gap 3 now resolves the graph path from either shape - legacy `env.MEMORY_FILE_PATH` when present, otherwise the cwd-resolved `$CUSTOMER_HOME/memory/memory.jsonl` the wrapper produces - and fails only when the resolved graph is unreachable or non-writable.
+- **A memory graph whose directory does not exist is now a Gap 3 failure rather than a warning.** That is the original amnesiac-bot symptom (an absolute path baked in one namespace and read in the other), not a nit.
+- **`${CHASSIS_HOME:-default}` in a hand-edited `.mcp.json` is expanded.** The old substitution handled only the bare `${CHASSIS_HOME}` token, so the defaulted form fell through as a literal path and failed. Expansion stays scoped to `CHASSIS_HOME` and `CUSTOMER_HOME`: the config is data, not shell to evaluate.
+- New behavioural suite `chassis/scripts/test-bootstrap-audit-memory.sh` (wired into `shell-tests.yml`) covers both config shapes and forces every unreachable-graph case - missing dir, non-writable dir, foreign-namespace absolute path, absent memory block - so the fix cannot degrade into a check that passes everything.
+
 ## v0.4.0 - 2026-07-28
 
 ### Added

--- a/chassis/scheduled-tasks/bootstrap-audit-prompt.md
+++ b/chassis/scheduled-tasks/bootstrap-audit-prompt.md
@@ -10,7 +10,7 @@ The transcript walks five known install gaps:
 
 1. **HEARTBEATS.md backup row** - a regular backup heartbeat is registered. Failure means scheduled backups aren't firing.
 2. **Customer GitHub remote** - `origin` points at the customer's own private repo, not the chassis template. Failure means changes here only exist on this machine.
-3. **Memory MCP** - the knowledge graph MCP is wired into `.mcp.json` and its `MEMORY_FILE_PATH` is writable. Failure means narrative memory across sessions is broken.
+3. **Memory MCP** - the knowledge graph MCP is wired into `.mcp.json` and the graph file it resolves to is writable from the launch cwd. The path comes either from a legacy `env.MEMORY_FILE_PATH` or, on the current template, from `$(pwd)/memory/memory.jsonl`. Failure means narrative memory across sessions is broken - most often an absolute path baked in one namespace (the host customer dir) and read in the other (`/app/customer` inside the container).
 4. **LaunchDaemons** - `com.behalfbot.<bot>-discord-restart` and `-discord-watchdog` are loaded in the system domain. Failure means the Discord bridge has no persistent `claude` process to route into.
 5. **Tmux session** - the bot's tmux session exists. A failure here is a warning unless paired with a failing LaunchDaemon check (the daemon creates the session at 05:00 + RunAtLoad).
 

--- a/chassis/scripts/bootstrap-audit.sh
+++ b/chassis/scripts/bootstrap-audit.sh
@@ -14,9 +14,9 @@
 #   Gap 2 - `git remote -v` returns no customer-owned URL.
 #           Same install. Means customizations only exist on the install
 #           machine - no off-machine push target.
-#   Gap 3 - `.mcp.json.mcpServers.memory` block is missing OR points at a
-#           non-writable MEMORY_FILE_PATH. Surfaced via William Holdeman
-#           2026-06-20 amnesiac-bot incident.
+#   Gap 3 - `.mcp.json.mcpServers.memory` block is missing OR the memory graph
+#           it resolves to is unreachable / non-writable in this namespace.
+#           Surfaced via William Holdeman 2026-06-20 amnesiac-bot incident.
 #   Gap 4 - macOS LaunchDaemons not loaded. discord-restart + discord-watchdog
 #           must be `launchctl print system/com.behalfbot.<name>` OK. Without
 #           the Daemons loaded, the tmux session that backs Discord routing
@@ -196,6 +196,37 @@ audit_gap_2_customer_remote() {
 # Gap 3 - .mcp.json has memory server with writable path
 # ============================================================
 
+# Substitute ${CHASSIS_HOME} / ${CUSTOMER_HOME}, including the ${VAR:-default}
+# form, in a path read out of .mcp.json. Deliberately limited to those two
+# names: the config is data, and a generic expansion would evaluate whatever a
+# hand-edited .mcp.json happens to contain. A set env var wins; otherwise the
+# inline default is used; otherwise the same fallback bootstrap.sh assumes.
+expand_home_tokens() {
+    local s="$1"
+    local re='\$\{(CHASSIS_HOME|CUSTOMER_HOME)(:-[^}]*)?\}'
+    local i=0
+    while [[ $i -lt 10 && "$s" =~ $re ]]; do
+        i=$((i + 1))
+        local token="${BASH_REMATCH[0]}"
+        local name="${BASH_REMATCH[1]}"
+        local inline="${BASH_REMATCH[2]:-}"
+        local value=""
+        case "$name" in
+            CHASSIS_HOME)  value="${CHASSIS_HOME:-}" ;;
+            CUSTOMER_HOME) value="${CUSTOMER_HOME:-}" ;;
+        esac
+        if [[ -z "$value" ]]; then
+            if [[ -n "$inline" ]]; then
+                value="${inline#:-}"
+            elif [[ "$name" == "CHASSIS_HOME" ]]; then
+                value="${HOME}/behalfbot"
+            fi
+        fi
+        s="${s//"$token"/$value}"
+    done
+    printf '%s' "$s"
+}
+
 audit_gap_3_memory_mcp() {
     group "Gap 3: memory MCP wired with writable path"
     local mcp="$CUSTOMER_HOME/.mcp.json"
@@ -219,27 +250,52 @@ audit_gap_3_memory_mcp() {
         hint "    --output $mcp"
         return
     fi
-    local mem_path
+    # Two config shapes are legitimate, so resolve the path rather than
+    # asserting a shape:
+    #
+    #   legacy  - env.MEMORY_FILE_PATH baked into the block, possibly carrying
+    #             a ${CHASSIS_HOME} / ${CUSTOMER_HOME} token.
+    #   current - no env block at all. The template wraps the server in
+    #             `sh -c 'export MEMORY_FILE_PATH="$(pwd)/memory/memory.jsonl"; ...'`
+    #             because the host and the chassis container see the same
+    #             bind-mounted directory at different absolute paths, so a
+    #             single baked absolute path is valid in only one namespace.
+    #             Claude Code spawns the server with cwd = the customer root in
+    #             both, so the resolved graph is $CUSTOMER_HOME/memory/memory.jsonl.
+    #
+    # Before this, Gap 3 read env.MEMORY_FILE_PATH only and therefore failed on
+    # every install running the current template - the check that exists to
+    # catch an unreachable memory graph could never pass (#142).
+    local mem_path shape
     mem_path="$(jq -r '.mcpServers.memory.env.MEMORY_FILE_PATH // empty' "$mcp" 2>/dev/null)"
-    if [[ -z "$mem_path" ]]; then
-        fail "mcpServers.memory.env.MEMORY_FILE_PATH not set"
-        return
+    if [[ -n "$mem_path" ]]; then
+        shape="env.MEMORY_FILE_PATH"
+    else
+        mem_path="memory/memory.jsonl"
+        shape="cwd-resolved, no env block"
     fi
-    # Expand ${CHASSIS_HOME} / ${CUSTOMER_HOME} for the writability check
-    local expanded="$mem_path"
-    expanded="${expanded//\$\{CHASSIS_HOME\}/${CHASSIS_HOME:-${HOME}/behalfbot}}"
-    expanded="${expanded//\$\{CUSTOMER_HOME\}/$CUSTOMER_HOME}"
+
+    local expanded
+    expanded="$(expand_home_tokens "$mem_path")"
+    # A relative path is resolved against the launch cwd, which is the
+    # customer root for both the host and the container.
+    [[ "$expanded" != /* ]] && expanded="$CUSTOMER_HOME/$expanded"
+
     local parent
     parent="$(dirname "$expanded")"
     if [[ ! -d "$parent" ]]; then
-        warn "parent dir does not exist: $parent"
-        hint "  mkdir -p \"$parent\""
+        # Not a warning. A memory graph whose directory does not exist here is
+        # exactly the amnesiac-bot failure - most often an absolute path baked
+        # in one namespace and read in the other.
+        fail "memory graph dir does not exist in this namespace: $parent ($shape)"
+        hint "A path baked on the host is not valid inside the container, and vice versa."
+        hint "  mkdir -p \"$parent\"   (or re-hydrate .mcp.json from the current template)"
         return
     fi
     if touch "$expanded" 2>/dev/null; then
-        ok "memory MCP wired; MEMORY_FILE_PATH writable: $expanded"
+        ok "memory MCP wired; graph writable: $expanded ($shape)"
     else
-        fail "MEMORY_FILE_PATH not writable: $expanded"
+        fail "memory graph not writable: $expanded ($shape)"
         hint "  chown \$(whoami) \"$expanded\" (or fix parent permissions)"
     fi
 }

--- a/chassis/scripts/test-bootstrap-audit-memory.sh
+++ b/chassis/scripts/test-bootstrap-audit-memory.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# test-bootstrap-audit-memory.sh - behavioural tests for bootstrap-audit.sh Gap 3.
+#
+# Gap 3 exists to catch an unreachable memory graph (the William Holdeman
+# 2026-06-20 amnesiac-bot incident). It read .mcpServers.memory.env.MEMORY_FILE_PATH
+# only, while the current .mcp.json.template deliberately sets no env block, so
+# it failed on every install running that template and could never pass - a
+# check that cannot pass has never caught anything (#142).
+#
+# Per the "checks that cannot fail" rule: the fix is only trusted once the
+# check has been SEEN to fail. Half of these cases force a broken memory graph
+# and assert Gap 3 reports it.
+#
+# Scenarios:
+#   1. current template shape, memory/ writable        -> pass  (the #142 bug)
+#   2. legacy env, absolute writable path              -> pass
+#   3. legacy env, ${CUSTOMER_HOME} token              -> pass
+#   4. legacy env, ${CHASSIS_HOME:-default} form       -> pass  (second symptom)
+#   5. legacy env, ${CHASSIS_HOME} bare, var set       -> pass
+#   6. current template shape, memory/ MISSING         -> FAIL
+#   7. legacy env, absolute path from another namespace-> FAIL
+#   8. non-writable parent dir                         -> FAIL  (skipped as root)
+#   9. mcpServers.memory block absent entirely         -> FAIL
+#
+# No docker, no network - pure temp dirs + jq. Exit 0 all pass, 1 on failure,
+# 2 on harness error.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT="${SCRIPT_DIR}/bootstrap-audit.sh"
+
+if [[ ! -f "$AUDIT" ]]; then
+    echo "test-bootstrap-audit-memory: audit script not found at $AUDIT" >&2
+    exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "test-bootstrap-audit-memory: jq required" >&2
+    exit 2
+fi
+
+fail=0
+pass=0
+
+TMP="$(mktemp -d)"
+cleanup() { chmod -R u+rwX "$TMP" 2>/dev/null; rm -rf "$TMP"; }
+trap cleanup EXIT
+
+# Build a customer home. $1 = dir name under $TMP, $2 = memory json block,
+# $3 = "nomemdir" to skip creating memory/.
+make_home() {
+    local home="$TMP/$1" block="$2" opt="${3:-}"
+    mkdir -p "$home"
+    [[ "$opt" == "nomemdir" ]] || mkdir -p "$home/memory"
+    printf '{"mcpServers":{%s}}\n' "$block" > "$home/.mcp.json"
+    printf '%s' "$home"
+}
+
+# Run the audit against $1 and print only the Gap 3 section. CHASSIS_HOME is
+# cleared unless passed as $2, so the ${VAR:-default} case exercises the
+# default rather than an ambient value.
+run_gap3() {
+    local home="$1" chassis_home="${2:-}"
+    env -u CHASSIS_HOME CHASSIS_HOME="$chassis_home" BOT_NAME=testbot \
+        bash "$AUDIT" --customer-home "$home" 2>/dev/null \
+        | sed 's/\x1b\[[0-9;]*m//g' \
+        | awk '/^Gap 3:/{f=1;next} /^Gap 4:/{f=0} f'
+}
+
+assert_case() {
+    local name="$1" out="$2" want="$3"   # want = pass | fail
+    local got
+    if printf '%s' "$out" | grep -q '✓'; then
+        got=pass
+    elif printf '%s' "$out" | grep -q '✗'; then
+        got=fail
+    else
+        got="none"
+    fi
+    if [[ "$got" == "$want" ]]; then
+        printf '  ok   %s (Gap 3 %s)\n' "$name" "$got"
+        pass=$((pass + 1))
+    else
+        printf '  FAIL %s: expected Gap 3 to %s, got %s\n' "$name" "$want" "$got"
+        printf '%s\n' "$out" | sed 's/^/       | /'
+        fail=$((fail + 1))
+    fi
+}
+
+TEMPLATE_BLOCK='"memory":{"command":"sh","args":["-c","export MEMORY_FILE_PATH=\"$(pwd)/memory/memory.jsonl\"; exec npx -y @modelcontextprotocol/server-memory"]}'
+
+echo "test-bootstrap-audit-memory"
+
+# 1. The bug itself: current template shape on a healthy install must PASS.
+h="$(make_home current "$TEMPLATE_BLOCK")"
+assert_case "current template shape, memory/ writable" "$(run_gap3 "$h")" pass
+
+# 2. Legacy absolute env path that is valid here.
+h="$(make_home legacy-abs '"memory":{"command":"npx","env":{"MEMORY_FILE_PATH":"'"$TMP"'/legacy-abs/memory/memory.jsonl"}}')"
+assert_case "legacy env, absolute writable path" "$(run_gap3 "$h")" pass
+
+# 3. ${CUSTOMER_HOME} token.
+h="$(make_home legacy-customer '"memory":{"command":"npx","env":{"MEMORY_FILE_PATH":"${CUSTOMER_HOME}/memory/memory.jsonl"}}')"
+assert_case "legacy env, \${CUSTOMER_HOME} token" "$(run_gap3 "$h")" pass
+
+# 4. ${CHASSIS_HOME:-default} form, CHASSIS_HOME unset. The old expansion only
+#    handled the bare token, so this fell through as a literal and failed.
+mkdir -p "$TMP/chassis-default/memory"
+h="$(make_home legacy-default '"memory":{"command":"npx","env":{"MEMORY_FILE_PATH":"${CHASSIS_HOME:-'"$TMP"'/chassis-default}/memory/memory.jsonl"}}')"
+assert_case "legacy env, \${CHASSIS_HOME:-default} form" "$(run_gap3 "$h")" pass
+
+# 5. Bare ${CHASSIS_HOME} with the var set wins over any inline default.
+mkdir -p "$TMP/chassis-set/memory"
+h="$(make_home legacy-bare '"memory":{"command":"npx","env":{"MEMORY_FILE_PATH":"${CHASSIS_HOME}/memory/memory.jsonl"}}')"
+assert_case "legacy env, bare \${CHASSIS_HOME}, var set" "$(run_gap3 "$h" "$TMP/chassis-set")" pass
+
+# 6. Template shape but no memory/ dir - the unreachable-graph failure the gap
+#    exists for. Must still FAIL, otherwise the fix passes everything.
+h="$(make_home current-broken "$TEMPLATE_BLOCK" nomemdir)"
+assert_case "current template shape, memory/ MISSING" "$(run_gap3 "$h")" fail
+
+# 7. Absolute path baked in another namespace (host path read in a container).
+h="$(make_home legacy-foreign '"memory":{"command":"npx","env":{"MEMORY_FILE_PATH":"/Users/nobody-'"$$"'/.behalfbot/memory/memory.jsonl"}}')"
+assert_case "legacy env, path from another namespace" "$(run_gap3 "$h")" fail
+
+# 8. Parent dir exists but is not writable. Root ignores mode bits, so skip.
+if [[ "$(id -u)" -eq 0 ]]; then
+    echo "  skip non-writable parent dir (running as root, chmod is not enforced)"
+else
+    h="$(make_home unwritable "$TEMPLATE_BLOCK")"
+    chmod 500 "$h/memory"
+    assert_case "memory/ not writable" "$(run_gap3 "$h")" fail
+    chmod 700 "$h/memory"
+fi
+
+# 9. No memory server at all.
+h="$(make_home nomemory '"filesystem":{"command":"npx"}')"
+assert_case "mcpServers.memory absent" "$(run_gap3 "$h")" fail
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ $fail -eq 0 ]] || exit 1


### PR DESCRIPTION
Fixes #142.

## What was wrong

`bootstrap-audit.sh` Gap 3 read `.mcpServers.memory.env.MEMORY_FILE_PATH` out of the customer's `.mcp.json`. The current `.mcp.json.template` deliberately sets no `env` block - it exports `MEMORY_FILE_PATH="$(pwd)/memory/memory.jsonl"` inside an `sh -c` wrapper, because the host and the chassis container see the same bind-mounted directory at different absolute paths (`/Users/<user>/.behalfbot` vs `/app/customer`) and a single baked absolute path is valid in only one namespace.

So Gap 3 failed on every install running the current template, and the check that exists to catch an unreachable knowledge graph had never been able to pass, let alone catch anything.

Second symptom of the same drift, same function: the expansion block substituted only the bare `${CHASSIS_HOME}` token, never the `${CHASSIS_HOME:-default}` form.

## What changed

`chassis/scripts/bootstrap-audit.sh`

- Gap 3 resolves the graph path instead of asserting a config shape: legacy `env.MEMORY_FILE_PATH` when present, otherwise the cwd-resolved `$CUSTOMER_HOME/memory/memory.jsonl` that the `sh -c` wrapper produces. A relative path resolves against the customer root, which is the launch cwd on both the host and inside the container.
- A missing graph directory is now a **failure**, not a warning. That is the original amnesiac-bot symptom - an absolute path baked in one namespace and read in the other - not a nit.
- New `expand_home_tokens` handles `${VAR}` and `${VAR:-default}`, scoped to `CHASSIS_HOME` and `CUSTOMER_HOME` only. A set env var wins, then the inline default, then the same fallback bootstrap assumes. Deliberately not a generic expansion: the config is data, and evaluating whatever a hand-edited `.mcp.json` contains is a different bug.
- The pass/fail line now names which shape it resolved from, so a legacy install is distinguishable from a template one in the transcript.

`chassis/scripts/test-bootstrap-audit-memory.sh` (new, wired into `shell-tests.yml`)

Nine cases, five pass-expected and four fail-expected, so the fix cannot degrade into a check that passes everything: both config shapes on a reachable graph, `${CUSTOMER_HOME}`, `${CHASSIS_HOME:-default}` and bare `${CHASSIS_HOME}` forms, then missing graph dir, non-writable graph dir, foreign-namespace absolute path, and an absent memory block. No docker, no network - temp dirs plus jq. The non-writable case self-skips under uid 0 since root ignores mode bits.

Also: `bootstrap-audit-prompt.md` gap-3 description updated to describe the two shapes, and a `CHANGELOG.md` Unreleased entry.

## Why not the live-spawn check

The issue names a stronger option: spawn the configured server and assert the graph file exists and is writable after startup. Skipped, because it would not actually be stronger here. A spawn run by the audit uses the **audit's** cwd, not Claude Code's runtime cwd, so it cannot distinguish "template shape, working" from "template shape, broken" any better than the static resolution against `$CUSTOMER_HOME`. What it would add is an `npx` download and a network dependency in a bootstrap audit, plus - since `server-memory` creates the graph lazily on first write - either a startup assertion that proves nothing or an MCP handshake and a write into the customer's real knowledge graph. The path resolution here is the part that was wrong, and it is now checked directly.

Same reasoning against regex-extracting the export line out of the wrapper's `args`: it re-implements shell expansion and re-couples the audit to a config shape, which is what caused this bug.

## Verification

Run against Sean's live install inside the chassis container, on a demonstrably working memory MCP (the graph is 36 lines and read/written across host and container sessions).

**Before** - `docker exec -w /app/customer behalfbot bash /app/chassis/scripts/bootstrap-audit.sh`

```
Gap 3: memory MCP wired with writable path
  X mcpServers.memory.env.MEMORY_FILE_PATH not set

Summary: 2 passed, 2 warned, 1 failed
```

**After** - same install, patched script copied in with `docker cp` to `/tmp` (nothing under `/app/chassis` touched)

```
Gap 3: memory MCP wired with writable path
  OK memory MCP wired; graph writable: /app/customer/memory/memory.jsonl (cwd-resolved, no env block)

Summary: 3 passed, 2 warned, 0 failed
```

The real `memory.jsonl` was `touch`ed only - still 35175 bytes, 36 lines, unchanged content.

**Negative cases, same container, temp customer homes** - a check that passes everything is worse than the bug:

```
### NEGATIVE 1: host-baked absolute path, read inside the container
  X memory graph dir does not exist in this namespace: /Users/jax/.behalfbot/memory (env.MEMORY_FILE_PATH)

### NEGATIVE 2: template shape, resolved dir is non-writable
  X memory graph not writable: /tmp/tmp.mFspEyNrgm/n2/memory/memory.jsonl (cwd-resolved, no env block)

### NEGATIVE 3: template shape, memory/ dir absent entirely
  X memory graph dir does not exist in this namespace: /tmp/tmp.mFspEyNrgm/n3/memory (cwd-resolved, no env block)

### CONTROL: template shape, memory/ present and writable
  OK memory MCP wired; graph writable: /tmp/tmp.mFspEyNrgm/n4/memory/memory.jsonl (cwd-resolved, no env block)
```

**New suite** - `bash chassis/scripts/test-bootstrap-audit-memory.sh`, run on the macOS host and inside the container, identical output both times:

```
test-bootstrap-audit-memory
  ok   current template shape, memory/ writable (Gap 3 pass)
  ok   legacy env, absolute writable path (Gap 3 pass)
  ok   legacy env, ${CUSTOMER_HOME} token (Gap 3 pass)
  ok   legacy env, ${CHASSIS_HOME:-default} form (Gap 3 pass)
  ok   legacy env, bare ${CHASSIS_HOME}, var set (Gap 3 pass)
  ok   current template shape, memory/ MISSING (Gap 3 fail)
  ok   legacy env, path from another namespace (Gap 3 fail)
  ok   memory/ not writable (Gap 3 fail)
  ok   mcpServers.memory absent (Gap 3 fail)

9 passed, 0 failed
```

**Mutation check** - the suite pointed at the unpatched `bootstrap-audit.sh` from `main`, to prove it can fail and that it fails on exactly the three symptoms in the issue:

```
  FAIL current template shape, memory/ writable: expected Gap 3 to pass, got fail
       |   X mcpServers.memory.env.MEMORY_FILE_PATH not set
  FAIL legacy env, ${CHASSIS_HOME:-default} form: expected Gap 3 to pass, got none
       |   ! parent dir does not exist: ${CHASSIS_HOME:-/var/folders/.../chassis-default}/memory
  FAIL legacy env, path from another namespace: expected Gap 3 to fail, got none
       |   ! parent dir does not exist: /Users/nobody-92003/.behalfbot/memory

  6 passed, 3 failed
```

**Other suites**

- `shellcheck -S error` on both shell files: clean. Full-severity run shows only SC2016 info on the deliberately-single-quoted `${VAR}` literals in the test fixtures.
- `python3 -m pytest chassis/second_brain/tests/ chassis/scripts/tests/`: **320 passed, 7 skipped, 8 subtests passed**. Not triggered by this PR's paths, run anyway.
- `shell-tests.yml` parses and lists the new `bootstrap-audit-memory` job; the new files are in both the `pull_request` and `push` path lists.

## Not verified

- Gap 3 has not been run on an actual legacy install carrying a real baked `env.MEMORY_FILE_PATH`. Sean's install is on the current template, so the legacy path is covered by the test fixtures only.
- The Darwin host-side path was exercised only via the test suite's temp homes, not against a real host-side install run of the full audit (Gap 4 needs LaunchDaemons that only exist on a configured host).

## Test plan

- [x] Gap 3 passes on the live install with the current template
- [x] Gap 3 still fails on a foreign-namespace absolute path
- [x] Gap 3 still fails on a non-writable graph dir
- [x] Gap 3 still fails on a missing graph dir and an absent memory block
- [x] Legacy `env.MEMORY_FILE_PATH` shape still passes
- [x] Suite proven to fail against the unpatched script
- [x] shellcheck clean at `severity: error`
- [x] Existing pytest suites green
