### PR TITLE
ci(shell-lint): exclude the second zsh file from shellcheck

### DIFF
--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           severity: error
           scandir: '.'
-          # heartbeat-dispatcher.sh is zsh (not bash/sh); shellcheck
-          # doesn't support zsh, so exclude it from the scan.
-          ignore_names: heartbeat-dispatcher.sh
+          # These are zsh (not bash/sh); shellcheck doesn't support zsh, so
+          # exclude them from the scan. Both carry a #!/bin/zsh shebang - keep
+          # this list in sync with:
+          #   grep -rl '^#!/bin/zsh' --include='*.sh' .
+          ignore_names: heartbeat-dispatcher.sh test_state_write_race.sh


### PR DESCRIPTION
"Shell scripts lint" has been red on `main` since 2026-08-02. Split out of #143 so an unrelated CI fix did not ride along with a bug fix.

## The failure

```
chassis/scheduled-tasks/tests/test_state_write_race.sh:1:1: error: ShellCheck only supports sh/bash/dash/ksh scripts. Sorry! [SC1071]
```

The file is `#!/bin/zsh` and was added in `a22251c`. `shell-lint.yml` set `ignore_names: heartbeat-dispatcher.sh` only, so the new zsh file was scanned and shellcheck has no zsh support.

Failing runs on `main`: 30740467957, 30756430283, 31217157661. Last green was 2026-08-01.

## The fix

Add `test_state_write_race.sh` to `ignore_names`.

Checked that this is the complete set rather than fixing one instance:

```
$ grep -rl '^#!/bin/zsh' --include='*.sh' .
chassis/scheduled-tasks/heartbeat-dispatcher.sh
chassis/scheduled-tasks/tests/test_state_write_race.sh
```

Comment updated to name the grep, so the next zsh file added is a known maintenance step rather than a surprise red build.

Not addressed here: nothing enforces that the list stays in sync. If this recurs, the durable fix is a lint step that derives the exclusions from the shebangs instead of hardcoding names.