### PR TITLE
fix(chassis-update): detect the install layout from the resolved chassis root

### DIFF
--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -37,6 +37,7 @@ on:
       - 'chassis/scripts/tests/stub-memory-server.sh'
       - 'chassis/scripts/gather-chassis-update-check.sh'
       - 'chassis/scripts/test-chassis-update-check.sh'
+      - 'chassis/scripts/test-chassis-update-mode.sh'
       - '.github/workflows/shell-tests.yml'
   push:
     branches: [main]
@@ -67,6 +68,7 @@ on:
       - 'chassis/scripts/tests/stub-memory-server.sh'
       - 'chassis/scripts/gather-chassis-update-check.sh'
       - 'chassis/scripts/test-chassis-update-check.sh'
+      - 'chassis/scripts/test-chassis-update-mode.sh'
       - '.github/workflows/shell-tests.yml'
   workflow_dispatch:
 
@@ -166,3 +168,17 @@ jobs:
       # locked from unlocked, the gather reports emulator_locked instead of
       # ready, and the recovery hook unlocks rather than restart-looping.
       - run: bash plugins/dating/tests/test-emulator-state.sh
+
+  chassis-update-mode:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Behavioural coverage for #152: detect_mode read CHASSIS_HOME's git
+      # origin, so an overlay-mount install (a separate behalfbot clone mounted
+      # underneath the customer repo) fell through to vendored_subtree and
+      # planned a subtree pull into a foreign repository. The suite proves all
+      # three layouts classify, an unrecognised one refuses instead of
+      # defaulting to the destructive strategy, and the final status line no
+      # longer reports success for a run that pulled nothing. No docker daemon,
+      # no network - upstream is served over file:// and docker is stubbed.
+      - run: bash chassis/scripts/test-chassis-update-mode.sh

--- a/chassis/scripts/chassis-update.sh
+++ b/chassis/scripts/chassis-update.sh
@@ -7,7 +7,9 @@
 #   1. Pre-flight (clean working tree)
 #   2. Snapshot pre-update state + effective compose config
 #   3. Drain in-flight heartbeats (state file lock)
-#   4. Pull upstream (canonical-clone mode: git pull; vendored mode: git subtree pull)
+#   4. Pull upstream, into the repo that actually owns the chassis tree
+#      (canonical-clone / overlay-mount: git pull --ff-only; vendored: git
+#      subtree pull) - see "Mode detection" below
 #   5. Compose pull + up -d THROUGH compose.sh so the per-install override
 #      applies (behalfbot#100) - bare compose only when the install has none
 #   6. Healthcheck poll (60s)
@@ -22,6 +24,13 @@
 #   chassis-update.sh --force        # apply BREAKING-CHANGE update (operator reviewed)
 #   chassis-update.sh --dry-run      # print plan, don't execute
 #   chassis-update.sh --rollback     # restore the most recent pre-update snapshot
+#
+# Exit codes:
+#   0 - update applied (or dry-run printed, or already up to date)
+#   1 - refused / failed (pre-flight, unrecognised layout, healthcheck rollback)
+#   2 - bad usage
+#   3 - PARTIAL: the tree was updated on disk but the running container was not
+#       refreshed, so it still executes the previous code
 #
 # Invoked by `skills/chassis-update.md` in response to the Discord trigger
 # `update chassis` / `update chassis --force` in the alerts channel.
@@ -173,23 +182,135 @@ CONFIG_PRE="${STATE_DIR}/compose-config-pre.yaml"
 CONFIG_POST="${STATE_DIR}/compose-config-post.yaml"
 CONFIG_DIFF="${STATE_DIR}/compose-config.diff"
 
-# --- Mode detection ---
-# canonical_clone: CHASSIS_HOME's git origin is scrollinondubs/behalfbot itself.
-#                  Update with `git pull --ff-only`.
-# vendored_subtree: CHASSIS_HOME is a customer repo with chassis/ pulled in via
-#                   `git subtree`. Update with `git subtree pull`.
-detect_mode() {
-    local origin_url
-    origin_url=$(cd "$CHASSIS_HOME" && git config --get remote.origin.url 2>/dev/null || echo "")
-    if [[ "$origin_url" == *"scrollinondubs/behalfbot"* ]]; then
-        echo "canonical_clone"
-    else
-        echo "vendored_subtree"
-    fi
+# --- Mode detection (behalfbot#152) ---
+#
+# The question this answers is "which git repository owns the chassis tree this
+# install actually runs", and the answer decides the pull strategy:
+#
+#   canonical_clone  - CHASSIS_HOME is itself a clone of scrollinondubs/behalfbot.
+#                      Update with `git pull --ff-only` there.
+#   overlay_mount    - the chassis tree resolves into a SEPARATE git worktree
+#                      that is a clone of scrollinondubs/behalfbot, mounted or
+#                      nested underneath CHASSIS_HOME. This is the supported
+#                      overlay layout (new-jaxity#136) the reference install
+#                      runs, the one gather-chassis-update-check.sh names in its
+#                      own header and resolve-chassis-root.sh already resolves.
+#                      Update with `git pull --ff-only` in THAT repo.
+#   vendored_subtree - CHASSIS_HOME is a customer repo that genuinely carries
+#                      chassis/ as a git subtree. Update with `git subtree pull`.
+#
+# What was wrong before: detection asked one question - is CHASSIS_HOME's origin
+# behalfbot? - and treated every "no" as vendored_subtree. On an overlay-mount
+# install that planned `git subtree pull --prefix=chassis` inside the CUSTOMER
+# repo for a path owned by a different repository, so the supported update path
+# had never once worked there. An unrecognised layout now refuses rather than
+# falling through to the destructive strategy: silently picking a subtree merge
+# for a shape you cannot identify is worse than doing nothing.
+
+git_origin_url() {
+    git -C "$1" config --get remote.origin.url 2>/dev/null || true
 }
 
-MODE=$(detect_mode)
+git_worktree_root() {
+    git -C "$1" rev-parse --show-toplevel 2>/dev/null || true
+}
+
+is_behalfbot_origin() {
+    [[ "$1" == *"scrollinondubs/behalfbot"* ]]
+}
+
+# The chassis tree this install actually runs. resolve-chassis-root.sh decides
+# that at boot and records the answer; read it rather than re-deriving one (the
+# pattern gather-chassis-root-health.sh already uses). SCRIPT_DIR/.. is the
+# fallback for installs whose resolver has never run - this script always ships
+# at <chassis>/scripts/, in every layout.
+resolve_chassis_source_root() {
+    local state_file="${CUSTOMER_HOME}/chassis-root.state.json" root=""
+    if [[ -f "$state_file" ]] && command -v jq >/dev/null 2>&1; then
+        root=$(jq -r '.resolved_root // ""' "$state_file" 2>/dev/null || echo "")
+    fi
+    if [[ -z "$root" || ! -d "$root" ]]; then
+        root=$(cd "${SCRIPT_DIR}/.." && pwd)
+    fi
+    printf '%s' "$root"
+}
+
+MODE=""
+CHASSIS_REPO_DIR=""       # the repo the pull runs in
+CHASSIS_SOURCE_ROOT=""    # the chassis tree itself
+CUSTOMER_WORKTREE=""
+CHASSIS_WORKTREE=""
+CUSTOMER_ORIGIN=""
+CHASSIS_ORIGIN=""
+
+# Sets MODE + CHASSIS_REPO_DIR as globals (NOT via echo - the caller needs both,
+# and a command substitution would throw the assignments away with the subshell).
+# Returns non-zero when the layout is unrecognised.
+detect_mode() {
+    CHASSIS_SOURCE_ROOT=$(resolve_chassis_source_root)
+    CUSTOMER_WORKTREE=$(git_worktree_root "$CHASSIS_HOME")
+    CHASSIS_WORKTREE=$(git_worktree_root "$CHASSIS_SOURCE_ROOT")
+    CUSTOMER_ORIGIN=$(git_origin_url "$CHASSIS_HOME")
+
+    if is_behalfbot_origin "$CUSTOMER_ORIGIN"; then
+        CHASSIS_REPO_DIR="$CHASSIS_HOME"
+        MODE="canonical_clone"
+        return 0
+    fi
+
+    # Overlay: the chassis tree sits in a git worktree that is NOT the one
+    # CHASSIS_HOME belongs to, and that worktree is a behalfbot clone.
+    if [[ -n "$CHASSIS_WORKTREE" && "$CHASSIS_WORKTREE" != "$CUSTOMER_WORKTREE" ]]; then
+        CHASSIS_ORIGIN=$(git_origin_url "$CHASSIS_WORKTREE")
+        if is_behalfbot_origin "$CHASSIS_ORIGIN"; then
+            CHASSIS_REPO_DIR="$CHASSIS_WORKTREE"
+            MODE="overlay_mount"
+            return 0
+        fi
+    fi
+
+    # Vendored subtree: the chassis tree is inside CHASSIS_HOME and chassis/ is
+    # a tracked path of CHASSIS_HOME's repo. Both halves matter - a directory
+    # that merely exists at chassis/ is what the old detection settled for.
+    if [[ "$CHASSIS_SOURCE_ROOT" == "$CHASSIS_HOME"/* ]] \
+        && [[ -n "$(git -C "$CHASSIS_HOME" ls-tree -d --name-only HEAD chassis 2>/dev/null)" ]]; then
+        CHASSIS_REPO_DIR="$CHASSIS_HOME"
+        MODE="vendored_subtree"
+        return 0
+    fi
+
+    MODE="unknown"
+    return 1
+}
+
+if ! detect_mode; then
+    cat >&2 <<EOF
+[chassis-update] FATAL: cannot classify this install's chassis layout, so there
+[chassis-update] FATAL: is no update strategy that is safe to pick. Observed:
+[chassis-update] FATAL:
+[chassis-update] FATAL:   CHASSIS_HOME              = ${CHASSIS_HOME}
+[chassis-update] FATAL:   CHASSIS_HOME git worktree = ${CUSTOMER_WORKTREE:-<none>}
+[chassis-update] FATAL:   CHASSIS_HOME origin       = ${CUSTOMER_ORIGIN:-<none>}
+[chassis-update] FATAL:   resolved chassis root     = ${CHASSIS_SOURCE_ROOT:-<none>}
+[chassis-update] FATAL:   its git worktree          = ${CHASSIS_WORKTREE:-<none>}
+[chassis-update] FATAL:   its origin                = ${CHASSIS_ORIGIN:-<none>}
+[chassis-update] FATAL:
+[chassis-update] FATAL: Expected one of: a behalfbot clone at CHASSIS_HOME
+[chassis-update] FATAL: (canonical_clone), a behalfbot clone mounted underneath it
+[chassis-update] FATAL: (overlay_mount), or chassis/ vendored into CHASSIS_HOME's
+[chassis-update] FATAL: own repo as a subtree (vendored_subtree).
+[chassis-update] FATAL:
+[chassis-update] FATAL: An empty worktree or origin above usually means git REFUSED
+[chassis-update] FATAL: the directory rather than that it is not a repo - run
+[chassis-update] FATAL: 'git -C <path> status' and look for a dubious-ownership
+[chassis-update] FATAL: refusal, then add the safe.directory exception it asks for.
+EOF
+    die "unrecognised chassis layout - refusing to guess an update strategy (behalfbot#152)"
+fi
+
 log "Mode: $MODE"
+log "Chassis tree: $CHASSIS_SOURCE_ROOT"
+log "Pull target repo: $CHASSIS_REPO_DIR"
 
 # --- Snapshot restore, shared by --rollback and the healthcheck failure path ---
 #
@@ -268,16 +389,31 @@ fi
 
 # --- Step 1: pre-flight ---
 log "Pre-flight: working tree clean check..."
-DIRTY=$(cd "$CHASSIS_HOME" && git status --porcelain -- chassis/ 2>/dev/null | head)
+if [[ "$MODE" == "overlay_mount" ]]; then
+    # Ask the repo the pull will actually run in. Checking CHASSIS_HOME here was
+    # the same wrong-repo defect as the mode detection, and on the reference
+    # install it was worse than wrong: git refuses that directory outright, so
+    # the check returned empty and passed vacuously.
+    #
+    # Whole repo, because `git pull --ff-only` in the clone is blocked by any
+    # modified TRACKED file, not only ones under chassis/. Untracked files
+    # cannot block a fast-forward, so -uno keeps a stray scratch file from
+    # bricking the supported update path.
+    DIRTY=$(git -C "$CHASSIS_REPO_DIR" status --porcelain -uno 2>/dev/null | head)
+    DIRTY_HINT="git -C '$CHASSIS_REPO_DIR' stash push"
+else
+    DIRTY=$(cd "$CHASSIS_HOME" && git status --porcelain -- chassis/ 2>/dev/null | head)
+    DIRTY_HINT="git -C '$CHASSIS_HOME' stash push -- chassis/"
+fi
 if [[ -n "$DIRTY" ]]; then
     cat <<EOF >&2
-Pre-flight FAILED: dirty chassis/ working tree.
-Local edits in chassis/ would be clobbered by an update. Listing:
+Pre-flight FAILED: dirty working tree in $CHASSIS_REPO_DIR ($MODE).
+Local edits would be clobbered by an update. Listing:
 
 $DIRTY
 
 Resolve by upstreaming the change or stashing it:
-  git -C "$CHASSIS_HOME" stash push -- chassis/
+  $DIRTY_HINT
 EOF
     exit 1
 fi
@@ -379,22 +515,63 @@ fi
 
 # --- Step 5: pull upstream ---
 case "$MODE" in
-    canonical_clone)
-        dry_or_run "cd '$CHASSIS_HOME' && git pull --ff-only origin $UPSTREAM_BRANCH"
+    canonical_clone|overlay_mount)
+        # Same command, different repo. CHASSIS_REPO_DIR is CHASSIS_HOME for a
+        # canonical clone and the overlaid behalfbot clone otherwise.
+        dry_or_run "cd '$CHASSIS_REPO_DIR' && git pull --ff-only origin $UPSTREAM_BRANCH"
         ;;
     vendored_subtree)
         # Ensure the chassis remote exists (idempotent: ignore "already exists")
         if [[ $DRY_RUN -eq 0 ]]; then
-            (cd "$CHASSIS_HOME" && git remote add "$UPSTREAM_REMOTE_NAME" "$UPSTREAM_REMOTE_URL" 2>/dev/null) || true
+            (cd "$CHASSIS_REPO_DIR" && git remote add "$UPSTREAM_REMOTE_NAME" "$UPSTREAM_REMOTE_URL" 2>/dev/null) || true
         fi
-        dry_or_run "cd '$CHASSIS_HOME' && git subtree pull --prefix=chassis '$UPSTREAM_REMOTE_NAME' '$UPSTREAM_BRANCH' --squash -m 'chore(chassis): pull v$UPSTREAM_VERSION (#33)'"
+        dry_or_run "cd '$CHASSIS_REPO_DIR' && git subtree pull --prefix=chassis '$UPSTREAM_REMOTE_NAME' '$UPSTREAM_BRANCH' --squash -m 'chore(chassis): pull v$UPSTREAM_VERSION (#33)'"
         ;;
     *)
         die "unknown mode: $MODE"
         ;;
 esac
 
+# --- Step 5.5: did the pull actually deliver a new tree? ---
+#
+# behalfbot#152 defect 3. The pull step can return 0 having moved nothing (wrong
+# repo, already-merged subtree squash, a ff-only pull with no new commits), and
+# everything after this point - healthcheck, migration, last-applied.json, the
+# final status line - then describes an update that did not happen. VERSION on
+# the chassis tree is the ground truth for what landed, so read it back before
+# building anything else on top of the claim.
+#
+# LOCAL_VERSION_FILE is SCRIPT_DIR/../VERSION, so a real run must be launched
+# from the chassis tree's own copy of this script. Running a detached copy (the
+# baked image tree, a scratch dir) still pulls the correct repo but then reads
+# back its own untouched VERSION and fails here. Use --dry-run for those.
+POST_PULL_VERSION="$CURRENT_VERSION"
+if [[ $DRY_RUN -eq 0 ]]; then
+    POST_PULL_VERSION=$(tr -d '[:space:]' < "$LOCAL_VERSION_FILE" 2>/dev/null || echo "")
+    if [[ -z "$POST_PULL_VERSION" ]]; then
+        die "pull reported success but $LOCAL_VERSION_FILE is now unreadable (mode: $MODE, repo: $CHASSIS_REPO_DIR)"
+    fi
+    if [[ "$POST_PULL_VERSION" == "$CURRENT_VERSION" ]]; then
+        log "FAIL: the pull returned success but $LOCAL_VERSION_FILE still reads"
+        log "FAIL: v$CURRENT_VERSION. Nothing was delivered, so there is no update"
+        log "FAIL: to healthcheck and nothing to report as complete."
+        die "pull did not advance the chassis tree (mode: $MODE, repo: $CHASSIS_REPO_DIR)"
+    fi
+    if [[ "$POST_PULL_VERSION" != "$UPSTREAM_VERSION" ]]; then
+        log "WARN: the tree advanced to v$POST_PULL_VERSION, not the v$UPSTREAM_VERSION this"
+        log "WARN: run set out to apply - upstream most likely moved mid-update. The"
+        log "WARN: healthcheck below still requires v$UPSTREAM_VERSION."
+    fi
+fi
+
 # --- Step 6: docker compose pull + up (through compose.sh, behalfbot#100) ---
+#
+# CONTAINER_REFRESHED is carried to the final status line: a skipped refresh
+# used to be a single mid-log note under a closing line that said the update was
+# complete, which is how a containerized install could go on running the old
+# code while the operator read "complete" (behalfbot#152 defect 2).
+CONTAINER_REFRESHED="no"
+CONTAINER_REFRESH_NOTE="no docker-compose.yml at $COMPOSE_DIR"
 if [[ ! -f "${COMPOSE_DIR}/docker-compose.yml" ]]; then
     log "No docker-compose.yml at $COMPOSE_DIR; skipping container refresh"
 else
@@ -414,6 +591,8 @@ else
     fi
     dry_or_run "$(compose_invoke "pull")"
     dry_or_run "$(compose_invoke "up -d")"
+    CONTAINER_REFRESHED="yes"
+    CONTAINER_REFRESH_NOTE=""
 fi
 
 # --- Step 7: healthcheck ---
@@ -567,15 +746,63 @@ if [[ -f "$MIGRATION_SCRIPT" ]]; then
     dry_or_run "bash '$MIGRATION_SCRIPT'"
 fi
 
-# --- Step 9: record successful apply ---
+# --- Step 9: record what was applied ---
+# `to` is the version read back off the tree after the pull, not the version
+# this run set out to apply. Those differ exactly when the update did not do
+# what it intended, which is the case worth recording accurately.
 if [[ $DRY_RUN -eq 0 ]]; then
     jq -n \
         --arg from "$CURRENT_VERSION" \
-        --arg to "$UPSTREAM_VERSION" \
+        --arg to "$POST_PULL_VERSION" \
         --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
         --arg snapshot "$SNAPSHOT" \
-        '{"from": $from, "to": $to, "applied_at": $ts, "snapshot": $snapshot}' \
+        --arg mode "$MODE" \
+        --arg repo "$CHASSIS_REPO_DIR" \
+        --argjson container_refreshed "$([[ "$CONTAINER_REFRESHED" == "yes" ]] && echo true || echo false)" \
+        '{"from": $from, "to": $to, "applied_at": $ts, "snapshot": $snapshot,
+          "mode": $mode, "repo": $repo, "container_refreshed": $container_refreshed}' \
         > "${STATE_DIR}/last-applied.json"
 fi
 
-log "Update complete: v$CURRENT_VERSION → v$UPSTREAM_VERSION"
+# --- Step 10: report what actually happened (behalfbot#152 defect 3) ---
+#
+# The old final line was a constant - `Update complete: vX → vY` printed
+# whatever the run did, including a dry run that changed nothing and a run whose
+# container was never refreshed. An operator who reads only the last line has to
+# be able to trust it.
+#
+# A skipped refresh is not automatically a failure: an install with no docker
+# and no compose file legitimately runs the dispatcher on the host, and its disk
+# tree IS the artifact. What makes it a partial update is a chassis container
+# that is up and therefore still executing the previous code.
+STALE_CONTAINER=""
+if [[ "$CONTAINER_REFRESHED" == "no" ]] && command -v docker >/dev/null 2>&1; then
+    STALE_CONTAINER=$(chassis_find_container "$COMPOSE_DIR")
+fi
+
+if [[ $DRY_RUN -eq 1 ]]; then
+    log "DRY-RUN complete: nothing was changed."
+    log "DRY-RUN plan was: v$CURRENT_VERSION → v$UPSTREAM_VERSION via $MODE in $CHASSIS_REPO_DIR"
+    if [[ "$CONTAINER_REFRESHED" == "no" ]]; then
+        log "DRY-RUN: container refresh WOULD BE SKIPPED - $CONTAINER_REFRESH_NOTE"
+        if [[ -n "$STALE_CONTAINER" ]]; then
+            log "DRY-RUN: container '$STALE_CONTAINER' would keep running its current code"
+        fi
+    fi
+    exit 0
+fi
+
+if [[ "$CONTAINER_REFRESHED" == "yes" ]]; then
+    log "Update complete: v$CURRENT_VERSION → v$POST_PULL_VERSION (tree pulled, container refreshed)"
+    exit 0
+fi
+
+if [[ -n "$STALE_CONTAINER" ]]; then
+    log "Update PARTIAL: the chassis tree is now v$POST_PULL_VERSION but no container"
+    log "Update PARTIAL: was refreshed - $CONTAINER_REFRESH_NOTE."
+    log "Update PARTIAL: container '$STALE_CONTAINER' is still running its previous code."
+    log "Update PARTIAL: bring the stack up from wherever its compose file lives, then re-check."
+    exit 3
+fi
+
+log "Update complete (host install): v$CURRENT_VERSION → v$POST_PULL_VERSION (tree pulled; no container to refresh - $CONTAINER_REFRESH_NOTE)"

--- a/chassis/scripts/test-chassis-update-mode.sh
+++ b/chassis/scripts/test-chassis-update-mode.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+# test-chassis-update-mode.sh - behavioural tests for chassis-update.sh's
+# install-layout detection and its end-of-run status reporting.
+#
+# The bug this suite exists for (#152)
+# ====================================
+# detect_mode asked exactly one question - is CHASSIS_HOME's git origin
+# scrollinondubs/behalfbot? - and treated every "no" as vendored_subtree. On an
+# overlay-mount install (new-jaxity#136, the reference install's layout) the
+# chassis is not in CHASSIS_HOME's repo at all: it is a separate behalfbot clone
+# bind-mounted underneath it. The else branch therefore planned
+# `git subtree pull --prefix=chassis` inside the CUSTOMER repo, for a path owned
+# by a different repository, and the supported update path had never once worked
+# there. Every real update on that install was a hand-run `git pull`.
+#
+# Two more defects rode along in the same six lines of output: the container
+# refresh was skipped with a one-line note, and the final line said
+# `Update complete: v0.4.0 → v0.5.0` on a run that pulled nothing and refreshed
+# nothing. An operator reading only the last line believed the update landed.
+#
+# Per the "checks that cannot fail" rule, classification tests alone would prove
+# little - they would pass on a script that printed a mode string and did the
+# wrong thing anyway. So each case asserts the PLANNED COMMAND, and the overlay
+# cases assert the absence of the subtree pull specifically.
+#
+# Scenarios:
+#    1. canonical clone                       -> canonical_clone, git pull in CHASSIS_HOME
+#    2. vendored subtree                      -> vendored_subtree, git subtree pull
+#    3. overlay mount, state file present     -> overlay_mount, git pull in the clone
+#    4. overlay mount                         -> never plans a subtree pull  (the #152 bug)
+#    5. overlay mount, no state file          -> resolves via SCRIPT_DIR/..
+#    6. state file beats SCRIPT_DIR/..        -> baked copy still classifies overlay
+#    7. unrecognised layout                   -> refuses loudly, plans nothing
+#    8. dry run                               -> never prints "Update complete"
+#    9. real run whose pull delivers nothing  -> dies, no success line
+#   10. skipped container refresh             -> visible in the final outcome
+#
+# No network and no docker daemon: upstream is served from a temp dir over
+# file:// via CHASSIS_UPDATE_RAW_BASE, and `docker` is stubbed on PATH so the
+# container probes answer "nothing running" instead of reaching a real daemon.
+#
+# Exit codes: 0 all pass, 1 on failure, 2 on harness error.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UPDATER="${SCRIPT_DIR}/chassis-update.sh"
+
+for f in "$UPDATER" "${SCRIPT_DIR}/_chassis-update-health.sh" "${SCRIPT_DIR}/_compose-verify.sh"; do
+    if [[ ! -f "$f" ]]; then
+        echo "test-chassis-update-mode: missing $f" >&2
+        exit 2
+    fi
+done
+for bin in git jq curl; do
+    if ! command -v "$bin" >/dev/null 2>&1; then
+        echo "test-chassis-update-mode: $bin required" >&2
+        exit 2
+    fi
+done
+
+fail=0
+pass=0
+
+# Physical path: `git rev-parse --show-toplevel` reports one, and on macOS
+# mktemp hands back /var/... which is a symlink to /private/var/....
+TMP="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- docker stub -------------------------------------------------------------
+# `command -v docker` must succeed (that is the real container-mode signal) but
+# every probe must answer empty, so the suite never touches a real daemon and
+# never depends on whether one is running.
+STUB_BIN="$TMP/bin"
+mkdir -p "$STUB_BIN"
+printf '#!/bin/bash\nexit 0\n' > "$STUB_BIN/docker"
+chmod +x "$STUB_BIN/docker"
+export PATH="$STUB_BIN:$PATH"
+
+# --- upstream served over file:// -------------------------------------------
+UPSTREAM_DIR="$TMP/upstream"
+mkdir -p "$UPSTREAM_DIR/chassis"
+UPSTREAM_VERSION="0.9.0"
+printf '%s\n' "$UPSTREAM_VERSION" > "$UPSTREAM_DIR/chassis/VERSION"
+cat > "$UPSTREAM_DIR/chassis/CHANGELOG.md" <<'EOF'
+# Chassis Changelog
+
+## v0.9.0 - 2026-08-09
+
+### Fixed
+
+- Nothing that breaks anything.
+
+## v0.1.0 - 2026-01-01
+
+### Added
+
+- The beginning.
+EOF
+export CHASSIS_UPDATE_RAW_BASE="file://${UPSTREAM_DIR}"
+
+# --- assertions --------------------------------------------------------------
+
+report_pass() { pass=$((pass + 1)); }
+report_fail() {
+    echo "FAIL [$1] $2"
+    fail=$((fail + 1))
+}
+
+assert_contains() {
+    local name="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        report_pass
+    else
+        report_fail "$name" "expected output to contain: $needle"
+        printf '%s\n' "$haystack" | sed 's/^/        | /'
+    fi
+}
+
+assert_not_contains() {
+    local name="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        report_pass
+    else
+        report_fail "$name" "expected output NOT to contain: $needle"
+        printf '%s\n' "$haystack" | sed 's/^/        | /'
+    fi
+}
+
+assert_status() {
+    local name="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        report_pass
+    else
+        report_fail "$name" "expected exit $expected, got $actual"
+    fi
+}
+
+# --- fixture helpers ---------------------------------------------------------
+
+git_q() { git -c user.name=test -c user.email=test@example.invalid -C "$1" "${@:2}"; }
+
+# Drop the scripts under test into a chassis tree at $1, with VERSION $2.
+plant_chassis_tree() {
+    local tree="$1" version="$2"
+    mkdir -p "$tree/scripts" "$tree/scheduled-tasks"
+    cp "$UPDATER" "${SCRIPT_DIR}/_chassis-update-health.sh" \
+       "${SCRIPT_DIR}/_compose-verify.sh" "$tree/scripts/"
+    printf '%s\n' "$version" > "$tree/VERSION"
+    printf '#!/bin/bash\n:\n' > "$tree/scheduled-tasks/heartbeat-dispatcher.sh"
+    chmod +x "$tree/scheduled-tasks/heartbeat-dispatcher.sh"
+}
+
+write_state_file() {
+    local customer_home="$1" resolved_root="$2"
+    jq -n --arg r "$resolved_root" \
+        '{"schema": 1, "mode": "live", "resolved_root": $r,
+          "baked_root": "/app/chassis", "live_root": $r,
+          "baked_version": "0.1.0", "live_version": "0.1.0",
+          "resolved_at": "2026-08-09T00:00:00Z", "error": null}' \
+        > "$customer_home/chassis-root.state.json"
+}
+
+# Run the updater copy that lives in the given chassis tree.
+run_updater() {
+    local chassis_home="$1" tree="$2"
+    shift 2
+    CHASSIS_HOME="$chassis_home" CUSTOMER_HOME="$chassis_home" \
+        bash "$tree/scripts/chassis-update.sh" "$@" 2>&1
+}
+
+# --- Scenario 1: canonical clone --------------------------------------------
+# CHASSIS_HOME is itself a behalfbot clone. Unchanged behaviour.
+CANON="$TMP/canonical"
+mkdir -p "$CANON"
+git_q "$CANON" init -q -b main
+git_q "$CANON" remote add origin https://github.com/scrollinondubs/behalfbot.git
+plant_chassis_tree "$CANON/chassis" "0.1.0"
+git_q "$CANON" add -A
+git_q "$CANON" commit -qm "chassis"
+out=$(run_updater "$CANON" "$CANON/chassis" --dry-run); status=$?
+assert_status "canonical: exits clean" 0 $status
+assert_contains "canonical: mode" "Mode: canonical_clone" "$out"
+assert_contains "canonical: plans a ff-only pull in CHASSIS_HOME" \
+    "DRY-RUN: cd '$CANON' && git pull --ff-only origin main" "$out"
+
+# --- Scenario 2: vendored subtree -------------------------------------------
+# Customer repo carrying the behalfbot repo at prefix chassis/, so the chassis
+# tree nests one level down. Unchanged behaviour.
+VENDOR="$TMP/vendored"
+mkdir -p "$VENDOR"
+git_q "$VENDOR" init -q -b main
+git_q "$VENDOR" remote add origin https://github.com/acme/acme-behalfbot.git
+plant_chassis_tree "$VENDOR/chassis/chassis" "0.1.0"
+git_q "$VENDOR" add -A
+git_q "$VENDOR" commit -qm "vendor chassis subtree"
+out=$(run_updater "$VENDOR" "$VENDOR/chassis/chassis" --dry-run); status=$?
+assert_status "vendored: exits clean" 0 $status
+assert_contains "vendored: mode" "Mode: vendored_subtree" "$out"
+assert_contains "vendored: plans a subtree pull in CHASSIS_HOME" \
+    "DRY-RUN: cd '$VENDOR' && git subtree pull --prefix=chassis" "$out"
+
+# --- Scenario 3 + 4: overlay mount, state file present ----------------------
+# The #152 shape: $CHASSIS_HOME/chassis is a SEPARATE behalfbot clone, not a
+# subtree of the customer repo.
+OVERLAY="$TMP/overlay"
+mkdir -p "$OVERLAY"
+git_q "$OVERLAY" init -q -b main
+git_q "$OVERLAY" remote add origin https://github.com/acme/acme-behalfbot.git
+printf 'customer\n' > "$OVERLAY/README.md"
+git_q "$OVERLAY" add -A
+git_q "$OVERLAY" commit -qm "customer repo"
+mkdir -p "$OVERLAY/chassis"
+git_q "$OVERLAY/chassis" init -q -b main
+git_q "$OVERLAY/chassis" remote add origin https://github.com/scrollinondubs/behalfbot.git
+plant_chassis_tree "$OVERLAY/chassis/chassis" "0.1.0"
+write_state_file "$OVERLAY" "$OVERLAY/chassis/chassis"
+out=$(run_updater "$OVERLAY" "$OVERLAY/chassis/chassis" --dry-run); status=$?
+assert_status "overlay: exits clean" 0 $status
+assert_contains "overlay: mode" "Mode: overlay_mount" "$out"
+assert_contains "overlay: pull target is the chassis clone" \
+    "Pull target repo: $OVERLAY/chassis" "$out"
+assert_contains "overlay: plans a ff-only pull in the chassis clone" \
+    "DRY-RUN: cd '$OVERLAY/chassis' && git pull --ff-only origin main" "$out"
+# Scenario 4 - the regression that motivated the issue.
+assert_not_contains "overlay: never plans a subtree pull" "git subtree pull" "$out"
+# No git operation of any kind is planned against the customer repo. The
+# snapshot tar still runs from CHASSIS_HOME (out of scope for #152, see the PR),
+# so this is scoped to git rather than to every command.
+assert_not_contains "overlay: no git operation planned in the customer repo" \
+    "cd '$OVERLAY' && git" "$out"
+
+# --- Scenario 5: overlay mount with no state file ---------------------------
+# Pre-#118 install, or one whose resolver has never run: fall back to
+# SCRIPT_DIR/.. and still classify correctly.
+OVERLAY_NS="$TMP/overlay-nostate"
+mkdir -p "$OVERLAY_NS/chassis"
+git_q "$OVERLAY_NS" init -q -b main
+git_q "$OVERLAY_NS" remote add origin https://github.com/acme/acme-behalfbot.git
+git_q "$OVERLAY_NS/chassis" init -q -b main
+git_q "$OVERLAY_NS/chassis" remote add origin https://github.com/scrollinondubs/behalfbot.git
+plant_chassis_tree "$OVERLAY_NS/chassis/chassis" "0.1.0"
+out=$(run_updater "$OVERLAY_NS" "$OVERLAY_NS/chassis/chassis" --dry-run); status=$?
+assert_status "overlay no-state: exits clean" 0 $status
+assert_contains "overlay no-state: mode" "Mode: overlay_mount" "$out"
+assert_contains "overlay no-state: plans a ff-only pull in the chassis clone" \
+    "DRY-RUN: cd '$OVERLAY_NS/chassis' && git pull --ff-only origin main" "$out"
+assert_not_contains "overlay no-state: never plans a subtree pull" "git subtree pull" "$out"
+
+# --- Scenario 6: the state file beats SCRIPT_DIR/.. -------------------------
+# The container case: the operator runs the BAKED copy of this script, which
+# lives outside every git repo. SCRIPT_DIR/.. resolves to the baked tree and
+# tells you nothing, so the recorded resolution has to win.
+BAKED="$TMP/baked-chassis"
+plant_chassis_tree "$BAKED" "0.1.0"
+out=$(run_updater "$OVERLAY" "$BAKED" --dry-run); status=$?
+assert_status "baked copy: exits clean" 0 $status
+assert_contains "baked copy: still classifies overlay from the state file" \
+    "Mode: overlay_mount" "$out"
+assert_contains "baked copy: chassis tree comes from the state file" \
+    "Chassis tree: $OVERLAY/chassis/chassis" "$out"
+assert_contains "baked copy: plans a ff-only pull in the chassis clone" \
+    "DRY-RUN: cd '$OVERLAY/chassis' && git pull --ff-only origin main" "$out"
+
+# --- Scenario 7: unrecognised layout refuses --------------------------------
+# CHASSIS_HOME is not a repo, the chassis tree is not a repo, nothing is
+# vendored. The old code called this vendored_subtree and planned a subtree
+# merge into a directory it knew nothing about.
+UNKNOWN="$TMP/unknown"
+plant_chassis_tree "$UNKNOWN/chassis/chassis" "0.1.0"
+out=$(run_updater "$UNKNOWN" "$UNKNOWN/chassis/chassis" --dry-run); status=$?
+assert_status "unknown: refuses" 1 $status
+assert_contains "unknown: says why" "cannot classify this install's chassis layout" "$out"
+assert_contains "unknown: prints the evidence" "resolved chassis root" "$out"
+assert_not_contains "unknown: does not fall through to a subtree pull" \
+    "git subtree pull" "$out"
+assert_not_contains "unknown: plans nothing at all" "DRY-RUN: cd" "$out"
+
+# --- Scenario 8 + 10: dry-run honesty ---------------------------------------
+# The exact line from the issue: `Update complete: v0.4.0 → v0.5.0` printed by a
+# run that changed nothing. And the skipped container refresh, which used to be
+# a mid-log note under that same success line.
+out=$(run_updater "$OVERLAY" "$OVERLAY/chassis/chassis" --dry-run)
+assert_not_contains "dry-run: never claims the update completed" "Update complete" "$out"
+assert_contains "dry-run: says nothing changed" "DRY-RUN complete: nothing was changed." "$out"
+assert_contains "dry-run: surfaces the skipped container refresh in the outcome" \
+    "container refresh WOULD BE SKIPPED" "$out"
+
+# --- Scenario 9: a real run whose pull delivers nothing ---------------------
+# Canonical clone that is already level with its origin, while upstream VERSION
+# says there is a newer release. `git pull --ff-only` returns 0 and moves
+# nothing. The pre-#152 script did eventually catch this - but only by burning
+# the full 60-second healthcheck poll and then rolling back a snapshot of a tree
+# that had never changed. The failure is now named at the point it happens.
+ORIGIN_DIR="$TMP/remote/scrollinondubs/behalfbot.git"
+mkdir -p "$ORIGIN_DIR"
+git_q "$ORIGIN_DIR" init -q --bare -b main
+SEED="$TMP/seed"
+mkdir -p "$SEED"
+git_q "$SEED" init -q -b main
+plant_chassis_tree "$SEED/chassis" "0.1.0"
+git_q "$SEED" add -A
+git_q "$SEED" commit -qm "seed"
+git_q "$SEED" remote add origin "$ORIGIN_DIR"
+git_q "$SEED" push -q origin main
+NOPULL="$TMP/nopull"
+git -c user.name=test -c user.email=test@example.invalid \
+    clone -q "$ORIGIN_DIR" "$NOPULL"
+out=$(run_updater "$NOPULL" "$NOPULL/chassis"); status=$?
+assert_status "no-op pull: fails instead of reporting success" 1 $status
+assert_not_contains "no-op pull: never prints a success line" "Update complete" "$out"
+assert_contains "no-op pull: names the defect" "did not advance the chassis tree" "$out"
+if [[ -f "$NOPULL/state/chassis-update/last-applied.json" ]]; then
+    report_fail "no-op pull: last-applied.json" "written for an update that never landed"
+else
+    report_pass
+fi
+
+# --- summary ----------------------------------------------------------------
+echo
+if [[ $fail -eq 0 ]]; then
+    echo "test-chassis-update-mode: ${pass} passed"
+    exit 0
+fi
+echo "test-chassis-update-mode: ${pass} passed, ${fail} FAILED"
+exit 1


### PR DESCRIPTION
Fixes #152.

## What changed

`chassis/scripts/chassis-update.sh`

- **Mode detection reads the resolved chassis root, not `CHASSIS_HOME`.** `resolved_root` comes from `$CUSTOMER_HOME/chassis-root.state.json` (the pattern `gather-chassis-root-health.sh` already uses), falling back to `SCRIPT_DIR/..`. When that path's enclosing git worktree is a `scrollinondubs/behalfbot` clone distinct from `CHASSIS_HOME`'s, the mode is the new `overlay_mount` and the pull is `git pull --ff-only origin main` in **that** repo.
- **`canonical_clone` is byte-identical.** `vendored_subtree` keeps the same command and the same repo, but now has to be earned: the chassis tree must be inside `CHASSIS_HOME` *and* `chassis/` must be a tracked path of its repo. It is no longer the default that catches everything.
- **An unrecognised layout refuses.** It prints the observed origins and worktrees for both candidates, plus the hint that an empty value usually means git refused the directory (dubious ownership) rather than that it is not a repo. That is exactly what happens on the reference install.
- **Pre-flight checks the repo the pull runs in.** In overlay mode it was asking `CHASSIS_HOME`, which git refuses outright there, so the check returned empty and passed vacuously. Tracked files only (`-uno`) - untracked files cannot block a fast-forward, and a stray scratch file must not brick the supported path.
- **The final line reports what happened.** A dry run says nothing changed. A skipped container refresh is named in the outcome instead of only mid-log. A pull that returned 0 without advancing `VERSION` now fails at the point it happens.
- `last-applied.json` records the version read back off the tree, plus `mode`, `repo`, `container_refreshed`. Nothing in the repo consumes that file (verified by grep), so the added keys are safe.

`chassis/scripts/test-chassis-update-mode.sh` - new, 32 assertions across 10 scenarios. `.github/workflows/shell-tests.yml` - one appended job and one appended path entry per list.

## Verification

### 1. Dry-run against the reference install: before and after

Both scripts were run from an isolated mirror at `/tmp/c152-a` inside the `behalfbot` container, so nothing under `/app/chassis` or `/app/customer/chassis` was touched. **Disclosure:** the mirror stages `VERSION=0.4.0` to reproduce the pre-0.5.0 state the issue was filed from - the live tree is already at 0.5.0. Everything mode detection actually reads is live: `/app/customer/chassis-root.state.json`, `/app/customer`, and the `/app/customer/chassis` clone.

Before (`origin/main`):

```
[chassis-update] Mode: vendored_subtree
[chassis-update] Current: v0.4.0
[chassis-update] Latest:  v0.5.0
[chassis-update] Pre-flight: working tree clean check...
[chassis-update] Snapshot: /app/customer/backups/chassis-update/chassis-pre-v0.5.0-20260809T123437Z.tgz
[chassis-update] DRY-RUN: cd '/app/customer' && tar czf '...' chassis/
[chassis-update] Drain: waiting for in-flight heartbeat (timeout 60s)...
[chassis-update] DRY-RUN: cd '/app/customer' && git subtree pull --prefix=chassis 'chassis' 'main' --squash -m 'chore(chassis): pull v0.5.0 (#33)'
[chassis-update] No docker-compose.yml at /app/customer; skipping container refresh
[chassis-update] Healthcheck: host mode, polling (timeout 60s)...
[chassis-update] Update complete: v0.4.0 → v0.5.0
exit=0
```

After (this branch):

```
[chassis-update] Mode: overlay_mount
[chassis-update] Chassis tree: /app/customer/chassis/chassis
[chassis-update] Pull target repo: /app/customer/chassis
[chassis-update] Current: v0.4.0
[chassis-update] Latest:  v0.5.0
[chassis-update] Pre-flight: working tree clean check...
[chassis-update] Snapshot: /app/customer/backups/chassis-update/chassis-pre-v0.5.0-20260809T123437Z.tgz
[chassis-update] DRY-RUN: cd '/app/customer' && tar czf '...' chassis/
[chassis-update] Drain: waiting for in-flight heartbeat (timeout 60s)...
[chassis-update] DRY-RUN: cd '/app/customer/chassis' && git pull --ff-only origin main
[chassis-update] No docker-compose.yml at /app/customer; skipping container refresh
[chassis-update] Healthcheck: host mode, polling (timeout 60s)...
[chassis-update] DRY-RUN complete: nothing was changed.
[chassis-update] DRY-RUN plan was: v0.4.0 → v0.5.0 via overlay_mount in /app/customer/chassis
[chassis-update] DRY-RUN: container refresh WOULD BE SKIPPED - no docker-compose.yml at /app/customer
exit=0
```

That the planned command would actually have delivered 0.5.0 is not an inference - it is the command that did:

```
$ git -C /app/customer/chassis status -sb | head -1
## main...origin/main
$ git -C /app/customer/chassis show HEAD:chassis/VERSION
0.5.0
```

The clone tracks `origin/main` and its HEAD carries `chassis/VERSION` = 0.5.0, reached by hand-run `git pull --ff-only origin main`. That is the plan the fixed script prints.

### 2. `canonical_clone` and `vendored_subtree` still classify

From `test-chassis-update-mode.sh`, against temp repos:

```
canonical:  Mode: canonical_clone
            DRY-RUN: cd '<CHASSIS_HOME>' && git pull --ff-only origin main
vendored:   Mode: vendored_subtree
            DRY-RUN: cd '<CHASSIS_HOME>' && git subtree pull --prefix=chassis 'chassis' 'main' --squash -m '...'
```

The overlay cases additionally assert the **absence** of `git subtree pull` and of any git operation against the customer repo, so the fix cannot regress into planning both.

### 3. An unrecognised layout fails loudly

`CHASSIS_HOME` is not a repo and neither is the chassis tree:

```
[chassis-update] FATAL: cannot classify this install's chassis layout, so there
[chassis-update] FATAL: is no update strategy that is safe to pick. Observed:
[chassis-update] FATAL:
[chassis-update] FATAL:   CHASSIS_HOME              = /tmp/.../unk
[chassis-update] FATAL:   CHASSIS_HOME git worktree = <none>
[chassis-update] FATAL:   CHASSIS_HOME origin       = <none>
[chassis-update] FATAL:   resolved chassis root     = /tmp/.../unk/chassis/chassis
[chassis-update] FATAL:   its git worktree          = <none>
[chassis-update] FATAL:   its origin                = <none>
[chassis-update] FATAL:
[chassis-update] FATAL: Expected one of: a behalfbot clone at CHASSIS_HOME
[chassis-update] FATAL: (canonical_clone), a behalfbot clone mounted underneath it
[chassis-update] FATAL: (overlay_mount), or chassis/ vendored into CHASSIS_HOME's
[chassis-update] FATAL: own repo as a subtree (vendored_subtree).
[chassis-update] FATAL:
[chassis-update] FATAL: An empty worktree or origin above usually means git REFUSED
[chassis-update] FATAL: the directory rather than that it is not a repo - run
[chassis-update] FATAL: 'git -C <path> status' and look for a dubious-ownership
[chassis-update] FATAL: refusal, then add the safe.directory exception it asks for.
[chassis-update] FATAL: unrecognised chassis layout - refusing to guess an update strategy (behalfbot#152)
exit=1
```

The pre-fix script called this same fixture `vendored_subtree` and printed a plan.

### 4. The status line no longer claims success for a run that pulled nothing

Two cases, both asserted:

- **Dry run:** the last three lines are the `DRY-RUN complete: nothing was changed.` block above. The string `Update complete` does not appear anywhere in the output.
- **Real run, no-op pull:** a canonical clone already level with its origin while upstream `VERSION` advertises a newer release. `git pull --ff-only` returns 0 and moves nothing:

```
[chassis-update] FAIL: the pull returned success but <...>/VERSION still reads
[chassis-update] FAIL: v0.1.0. Nothing was delivered, so there is no update
[chassis-update] FAIL: to healthcheck and nothing to report as complete.
[chassis-update] FATAL: pull did not advance the chassis tree (mode: canonical_clone, repo: <...>)
exit=1
```

`last-applied.json` is not written. To be precise about what changed here: the pre-fix script did *eventually* fail this case, by burning the full 60-second healthcheck poll and then rolling back a snapshot of a tree that had never changed. The fix makes the failure immediate and named; it does not invent detection that was absent.

### Test suites

```
$ bash chassis/scripts/test-chassis-update-mode.sh
test-chassis-update-mode: 32 passed                                    exit=0
```

Same suite run against `origin/main`'s `chassis-update.sh`: **19 of 32 assertions fail.** The suite locks down the bug rather than describing the new code.

Existing suites, unchanged and passing:

```
test-chassis-update-health.sh     exit=0  16 passed, 0 failed
test-chassis-update-check.sh      exit=0  23 passed, 0 failed
test-chassis-root-health.sh       exit=0  PASS: 8  FAIL: 0
test-chassis-root-resolution.sh   exit=0  35 passed, 0 failed
```

`shellcheck -S error` clean on both changed shell files. `pytest` was not run - the suites touched here are shell-only.

## Deliberate non-fixes

Named rather than silently omitted:

1. **`COMPOSE_DIR` is still `CHASSIS_HOME` in overlay mode.** The install's compose file lives in the chassis clone, so the refresh is still skipped. The issue calls this "fine in itself" and asks for the skip to be visible in the outcome, which it now is. Relocating compose discovery is a separate change with its own blast radius.
2. **Snapshot and restore still tar `chassis/` from `CHASSIS_HOME`.** Through the mount that reaches the right files, but it is not mode-aware. Out of scope here.
3. **The new PARTIAL / exit-3 path is blind on the reference install.** It fires when a chassis container is up but was not refreshed. Run from inside the container there is no reachable docker socket (`/var/run/docker.sock` is a 0-byte file; `docker ps` reports "Cannot connect to the Docker daemon"), so the probe returns nothing and the run reports the host-install wording instead. The `WOULD BE SKIPPED` outcome line still fires, which is what the criterion asked for.
4. **A real run must be launched from the chassis tree's own copy of the script.** `LOCAL_VERSION_FILE` is `SCRIPT_DIR/../VERSION`, so a detached copy (baked image tree, scratch dir) pulls the right repo and then reads back its own untouched VERSION and fails the new step-5.5 check. Noted in a comment at that check. Use `--dry-run` for detached copies - which is what the demonstration above did.

## Housekeeping

- `/tmp/c152-a` is left in the container's tmpfs (mirror used for the demonstration). It disappears on restart; I did not delete it because `rm -rf` is guardrail-blocked in my session.
- Worked in an isolated worktree at `/Users/jax/work/behalfbot-152` so as not to collide with the concurrent #151 work. The one `shell-tests.yml` edit is a single appended job plus one appended path entry per list, to keep that conflict small.

## Test plan

- [x] `--dry-run` on the reference install classifies `overlay_mount` and plans a ff-only pull in the chassis clone
- [x] `canonical_clone` and `vendored_subtree` classify and plan correctly
- [x] Unrecognised layout refuses with evidence and plans nothing
- [x] No success line for a dry run or for a pull that delivered nothing
- [x] New suite passes (32/32) and fails against pre-fix code (19 failures)
- [x] All four existing shell suites pass
- [x] `shellcheck -S error` clean
