### PR TITLE
fix(liveness): distinguish "checked nothing" from "checked and healthy"

### DIFF
--- a/chassis/HEARTBEATS.md.template
+++ b/chassis/HEARTBEATS.md.template
@@ -222,8 +222,17 @@ entrypoint -> crash-loop), so an unmonitored loop is a live risk.
 
 Set `CHASSIS_LIVENESS_CONTAINERS` in the install's environment to the full
 stack (default `behalfbot,behalfbot-postgres`). Requires the docker socket
-bind-mount (same one `docker-prune` uses); docker-unreachable is a deliberate
-no-op so socket-less installs never false-alarm.
+bind-mount (same one `docker-prune` uses); docker-unreachable stays a
+deliberate no-op so socket-less installs never false-alarm.
+
+**Read `blind` before trusting `count`.** The gather emits `blind: true` when
+it could not inspect anything - no docker socket, or no containers configured.
+`count: 0` with `blind: true` is not a pass, it is a check that never happened,
+and the `threshold count > 0` condition below cannot tell the two apart. That
+is intentional for the in-container heartbeat on a socket-less install, where
+silence is the correct behaviour. Any caller that is supposed to have a working
+socket should set `CHASSIS_LIVENESS_REQUIRE_SOCKET=1`, which turns an
+unreachable daemon into a real `docker_unreachable` issue.
 
 **Structural caveat:** the dispatcher runs INSIDE `behalfbot`, so this
 in-container heartbeat cannot catch a `behalfbot` that never completes a tick

--- a/chassis/scheduled-tasks/container-liveness-prompt.md
+++ b/chassis/scheduled-tasks/container-liveness-prompt.md
@@ -26,8 +26,24 @@ This heartbeat's gather runs INSIDE the `behalfbot` container. When `behalfbot` 
 To catch a `behalfbot` that is fully down within one interval, run the SAME script from OUTSIDE the container - it is location-agnostic (pure docker CLI + a state file). Wire a host-side watcher against the host docker daemon:
 
 - macOS LaunchAgent / Linux systemd timer / cron running, every few minutes:
-  `CUSTOMER_HOME=<host-customer-dir> CHASSIS_LIVENESS_CONTAINERS=behalfbot bash <chassis>/scripts/gather-container-liveness.sh`
-  and paging (Discord webhook / `notify`) when `count > 0`.
+  `CUSTOMER_HOME=<host-customer-dir> CHASSIS_LIVENESS_CONTAINERS=behalfbot CHASSIS_LIVENESS_REQUIRE_SOCKET=1 bash <chassis>/scripts/gather-container-liveness.sh`
+  and paging (Discord webhook / `notify`) when `count > 0` **or** `blind` is true.
+
+  Two things a host-side caller must get right, both learned the hard way on
+  the reference install (new-jaxity#497):
+
+  1. **Gate on `blind`, not `count` alone.** `count: 0` means "nothing is
+     wrong" only when `blind` is false. A host watcher that read `count > 0`
+     by itself logged `ok` every five minutes while the docker daemon was
+     unreachable and nothing at all was being inspected. Set
+     `CHASSIS_LIVENESS_REQUIRE_SOCKET=1` from the host: a host that has no
+     reachable daemon has a real problem, unlike a socket-less container.
+  2. **Check that the page actually sent.** The same watcher posted to a
+     Discord webhook with python `urllib` and no `User-Agent`; Cloudflare
+     fronts discord.com and rejects that with HTTP 403 (`error code: 1010`).
+     It ignored the return value, logged `ALERTED`, and delivered nothing for
+     16 days. Send with `curl` (or set a `User-Agent`), check the HTTP status,
+     and only record the alert as sent on 200/204.
 - This is the belt-and-suspenders layer: in-container catches siblings + loops, host-side catches a dead `behalfbot`. An install that already runs a Discord-bridge watchdog LaunchAgent can fold this check into it.
 
 ## Heartbeat registration

--- a/chassis/scripts/gather-container-liveness.sh
+++ b/chassis/scripts/gather-container-liveness.sh
@@ -40,10 +40,22 @@
 #   CHASSIS_LIVENESS_STATE       State file path for restart-loop detection.
 #                                Default: $CUSTOMER_HOME/scheduled-tasks/
 #                                container-liveness-state.json
+#   CHASSIS_LIVENESS_REQUIRE_SOCKET
+#                                Set to 1 when the caller KNOWS a docker daemon
+#                                should be reachable - a host-side LaunchAgent
+#                                always does. Turns an unreachable socket from
+#                                a silent no-op into a real issue
+#                                (docker_unreachable, count 1). Unset by
+#                                default so socket-less in-container installs
+#                                stay quiet, which is why the no-op exists.
 #
 # Gather JSON contract:
-#   { "count": N, "issues": [...], "checked": M, "status": "...",
-#     "ts_utc": "..." }
+#   { "count": N, "issues": [...], "checked": M, "blind": true|false,
+#     "status": "...", "ts_utc": "..." }
+#
+# `blind` is the field that makes "I looked and everything is fine" different
+# from "I could not look at all". Both used to emit count=0, and every caller
+# that gated on `count > 0` alone read blindness as health. Gate on `blind`.
 #
 # Issue tags (per container <c>):
 #   <c>_absent            - no such container (never created / removed)
@@ -54,9 +66,11 @@
 #
 # Emits no secrets: only container names and states.
 #
-# docker unreachable is a deliberate NO-OP (count=0, status=docker_unreachable):
+# docker unreachable stays a NO-OP by default (count=0, status=docker_unreachable):
 # a broken socket is gather-docker-prune.sh's job to flag, and on an install
 # that never mounts the socket this heartbeat must not false-alarm every tick.
+# It now also sets blind=true, and a caller that knows better can set
+# CHASSIS_LIVENESS_REQUIRE_SOCKET=1 to make it count.
 
 set -uo pipefail
 
@@ -70,19 +84,26 @@ fi
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 emit() {
-    # $1 count, $2 issues_json, $3 checked, $4 status
+    # $1 count, $2 issues_json, $3 checked, $4 status, $5 blind (true|false)
     jq -n \
         --argjson count "$1" \
         --argjson issues "$2" \
         --argjson checked "$3" \
         --arg status "$4" \
+        --argjson blind "${5:-false}" \
         --arg ts "$TS" \
-        '{count: $count, issues: $issues, checked: $checked, status: $status, ts_utc: $ts}'
+        '{count: $count, issues: $issues, checked: $checked, blind: $blind, status: $status, ts_utc: $ts}'
 }
 
-# --- Cheap no-op gate: docker must be reachable. If not, do not alarm. -------
+# --- Docker must be reachable. Blind either way; only alarm when asked. ------
 if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
-    emit 0 '[]' 0 "docker_unreachable"
+    if [[ "${CHASSIS_LIVENESS_REQUIRE_SOCKET:-0}" == "1" ]]; then
+        # The caller asserted a daemon should be here, so its absence is a
+        # finding, not the socket-less install's deliberate silence.
+        emit 1 '["docker_unreachable"]' 0 "docker_unreachable" true
+    else
+        emit 0 '[]' 0 "docker_unreachable" true
+    fi
     exit 0
 fi
 
@@ -96,7 +117,8 @@ while IFS= read -r line; do
 done <<< "${RAW//,/$'\n'}"
 
 if (( ${#CONTAINERS[@]} == 0 )); then
-    emit 0 '[]' 0 "no_containers_configured"
+    # Nothing to check is also blind: checked=0 is not a clean bill of health.
+    emit 0 '[]' 0 "no_containers_configured" true
     exit 0
 fi
 
@@ -167,4 +189,4 @@ else
     status_out="containers_unhealthy"
 fi
 
-emit "$count" "$issues_json" "$checked" "$status_out"
+emit "$count" "$issues_json" "$checked" "$status_out" false


### PR DESCRIPTION
Companion to scrollinondubs/new-jaxity#498. Chassis half of new-jaxity#497.

## The defect

`gather-container-liveness.sh` emitted `count: 0` in two very different situations:

- it inspected every container and found them all healthy
- it could not reach docker at all, so it inspected nothing (`checked: 0`)

No caller could tell those apart. Worse, the host-side wiring documented in `container-liveness-prompt.md` told callers to page when `count > 0` - precisely the condition that cannot distinguish them.

That advice was followed literally on the reference install. The resulting host watchdog spent weeks logging:

```
ok (checked, status=docker_unreachable)
```

on ticks where it had inspected nothing at all.

## The fix

- **`blind: true|false` added to the gather contract.** True whenever `checked: 0` - docker unreachable, or no containers configured. All existing keys are unchanged, so current callers keep working; verified the emitted key set is a strict superset.
- **`CHASSIS_LIVENESS_REQUIRE_SOCKET=1`.** A caller that knows a daemon should be reachable (any host-side LaunchAgent or systemd timer) sets it, and an unreachable socket becomes a real `docker_unreachable` issue instead of silence.
- **Unset by default.** Socket-less in-container installs stay quiet. That default is the entire reason the no-op exists, and flipping it unconditionally would false-alarm every such install on every tick - which the issue explicitly warned against. Strictness is opt-in, and it is the host-side caller that opts in, because the host always has a daemon.
- **Docs updated** in `HEARTBEATS.md.template` and the prompt, so the next person wiring a host-side watcher gates on `blind`, not `count` alone.

### Tradeoff worth naming

The issue floated an alternative: make silence require an explicit "this install has no socket" opt-in, so an un-opted-in socket-less install alarms. I went the other way - silence stays the default and strictness is opted into - because I cannot test the other installs, and the inverted version breaks every one of them until an operator sets a variable. This version is safe on day one and gives every caller a field they can gate on. The residual gap, stated plainly: a caller that ignores both `blind` and `REQUIRE_SOCKET` can still misread `count: 0`. The contract now makes that a choice rather than a trap.

## Also documented: how the alert failed to arrive

The same install's watchdog posted to Discord with python `urllib` and no `User-Agent`. Cloudflare fronts discord.com and rejects that with HTTP 403 (`error code: 1010`). The return value was ignored, so 22 alerts across 16 days logged `ALERTED` and delivered nothing. The prompt now tells host-side callers to send with `curl` and check the HTTP status before recording an alert as sent. Chassis ships the advice that produced that watchdog, so the correction belongs here too.

## Verification

Run against the live docker daemon on the reference host:

| case | result |
|---|---|
| healthy, real daemon | `count 0, checked 2, blind false, status ok` |
| no daemon, default (socket-less install) | `count 0, checked 0, blind true, status docker_unreachable` |
| no daemon, `REQUIRE_SOCKET=1` | `count 1, issues ["docker_unreachable"], blind true` |
| empty container list | `count 0, checked 0, blind true, status no_containers_configured` |
| emitted keys | `['blind','checked','count','issues','status','ts_utc']` - superset of the old contract |

`bash -n` clean. The in-container half of this heartbeat is not enabled on the reference install (it would be permanently `docker_unreachable` there by design), so the default-silent path is verified by the no-daemon case above rather than in a live container.
