### PR TITLE
fix(plugins): compose plugins-root symlinks as relative, not absolute

### DIFF
--- a/chassis/scripts/resolve-plugin-root.sh
+++ b/chassis/scripts/resolve-plugin-root.sh
@@ -27,6 +27,15 @@
 # including plain globs. Composing also filters the non-plugin dirs the
 # fetched tree carries at its top level (docs/, tools/, registry.json).
 #
+# Composed symlinks are written RELATIVE to $CUSTOMER_HOME, not absolute.
+# CUSTOMER_HOME is the same directory on both sides of the host/container
+# bind mount but is reached through a different absolute path on each side,
+# so an absolute symlink written on one side dangles when read from the
+# other. A relative link resolves correctly through either mount path. This
+# does not help the baked tree when it lives outside CUSTOMER_HOME (i.e.
+# /app/plugins, container-only, never bind-mounted) - that half of the
+# overlay is expected to differ per side and is recorded via built_on below.
+#
 # Operator override contract: if CHASSIS_PLUGINS_ROOT is already set when
 # this script runs, that value is honoured VERBATIM - no overlay, no
 # reordering. The Dockerfile and entrypoint no longer default the variable,
@@ -41,7 +50,9 @@
 #
 # Output: the resolved root on stdout. All logging goes to stderr. Writes
 # $CUSTOMER_HOME/plugins-root.state.json (adjacent to plugins.lock)
-# recording mode, roots, and per-plugin provenance.
+# recording mode, roots, per-plugin provenance, and built_on (host or
+# container - whichever side ran this resolution), so a disagreement between
+# the two views of the composed tree is visible after the fact.
 #
 # Env seams:
 #   CHASSIS_BAKED_PLUGINS_ROOT - override the baked-tree location (tests,
@@ -69,6 +80,31 @@ usable() {
     compgen -G "$dir"/*/openclaw.plugin.json > /dev/null 2>&1
 }
 
+# relpath TARGET BASE - relative path from BASE to TARGET, POSIX-portable
+# (host is macOS/BSD, container is Linux; neither `realpath --relative-to`
+# nor GNU-only readlink flags can be assumed on both, so this shells out to
+# python3, already a hard dependency of this script via write_state).
+relpath() {
+    python3 -c 'import os, sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))' "$1" "$2"
+}
+
+# resolved_path PATH - realpath, following symlinks. Used instead of `readlink`
+# so the post-compose assertion below compares fully-resolved absolute paths
+# rather than raw (now relative) link targets.
+resolved_path() {
+    python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$1"
+}
+
+# Which side is resolving right now. Same probe write_state's BAKED_ROOT
+# detection uses below (/app/plugins only exists inside the container) -
+# recorded so a disagreement between the host and container view of
+# state/plugins-root is visible after the fact instead of just dangling.
+if [[ -d /app/plugins ]]; then
+    BUILT_ON="container"
+else
+    BUILT_ON="host"
+fi
+
 STATE_FILE="$CUSTOMER_HOME/plugins-root.state.json"
 
 # MODE is one of: explicit | baked | overlay
@@ -77,7 +113,7 @@ write_state() {
     local mode="$1" root="$2" error="${3:-}"
     MODE="$mode" ROOT="$root" ERROR="$error" \
     BAKED="${BAKED_ROOT:-}" FETCHED="${FETCHED_ROOT:-}" \
-    PROVENANCE="${PROVENANCE:-}" \
+    PROVENANCE="${PROVENANCE:-}" BUILT_ON="$BUILT_ON" \
     python3 - "$STATE_FILE" <<'PY' 2>/dev/null || log "WARN: could not write $STATE_FILE"
 import datetime, json, os, sys
 prov = {}
@@ -92,6 +128,7 @@ state = {
     "baked_root": os.environ["BAKED"] or None,
     "fetched_root": os.environ["FETCHED"] or None,
     "resolved_at": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "built_on": os.environ["BUILT_ON"],
     "plugins": prov,
     "error": os.environ["ERROR"] or None,
 }
@@ -153,7 +190,7 @@ if [[ -n "$staging" ]]; then
     if [[ -n "$BAKED_ROOT" ]]; then
         for d in "$BAKED_ROOT"/*/; do
             [[ -d "$d" ]] || continue
-            ln -s "${d%/}" "$staging/$(basename "$d")"
+            ln -s "$(relpath "${d%/}" "$staging")" "$staging/$(basename "$d")"
             PROVENANCE+="$(basename "$d")"$'\t'"baked"$'\n'
         done
     fi
@@ -168,7 +205,7 @@ if [[ -n "$staging" ]]; then
             continue
         fi
         rm -f "$staging/$name"
-        ln -s "${d%/}" "$staging/$name"
+        ln -s "$(relpath "${d%/}" "$staging")" "$staging/$name"
         PROVENANCE=$(printf '%s' "$PROVENANCE" | grep -v "^$name"$'\t' || true)
         PROVENANCE+=$'\n'"$name"$'\t'"fetched"$'\n'
     done
@@ -209,8 +246,8 @@ assert_error=""
 for d in "$FETCHED_ROOT"/*/; do
     [[ -f "$d/openclaw.plugin.json" ]] || continue
     name=$(basename "$d")
-    target=$(readlink "$COMPOSED_ROOT/$name" 2>/dev/null || true)
-    if [[ "$target" != "${d%/}" ]]; then
+    target=$(resolved_path "$COMPOSED_ROOT/$name" 2>/dev/null || true)
+    if [[ "$target" != "$(resolved_path "${d%/}")" ]]; then
         assert_error="fetched plugin '$name' is not active in $COMPOSED_ROOT (resolves to '${target:-missing}')"
         log "ERROR: PLUGIN ROOT ASSERTION FAILED - $assert_error"
         break

--- a/chassis/scripts/test-plugin-root-resolution.sh
+++ b/chassis/scripts/test-plugin-root-resolution.sh
@@ -206,6 +206,29 @@ check "s9 _env.sh resolves overlay" "$CUSTOMER/state/plugins-root" "$RESOLVED_RO
 check "s9 fetched active via _env.sh" "0.2.0" \
     "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$RESOLVED_ROOT/loom-vision/openclaw.plugin.json")"
 
+# --- scenario 10: composed symlinks resolve through a second mount path -----
+# THE regression test for the dangling-absolute-symlink bug: build the tree
+# under one path, then read the very same tree through a second path that
+# symlinks to it (a synthetic stand-in for the host/container bind mount) and
+# assert every composed entry still resolves. Absolute symlinks pass s1-s9
+# above (same path both times) but fail here.
+fresh_env s10
+FETCHED="$CUSTOMER/vendored-plugins"
+manifest "$FETCHED/loom-vision" "loom-vision" "0.2.0"
+run_resolver
+OTHER_MOUNT="$TMP/s10/othermount"
+mkdir -p "$OTHER_MOUNT"
+ln -s "$CUSTOMER" "$OTHER_MOUNT/customer"
+OTHER_ROOT="$OTHER_MOUNT/customer/state/plugins-root"
+check "s10 baked entry resolves via other mount" "0.1.0" \
+    "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$OTHER_ROOT/bfl/openclaw.plugin.json" 2>/dev/null)"
+check "s10 fetched entry resolves via other mount" "0.2.0" \
+    "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$OTHER_ROOT/loom-vision/openclaw.plugin.json" 2>/dev/null)"
+check "s10 symlinks are relative, not absolute" "relative" \
+    "$([[ "$(readlink "$RESOLVED_ROOT/loom-vision")" = /* ]] && echo absolute || echo relative)"
+check "s10 state records built_on" "yes" \
+    "$([[ -n "$(state_field "$CUSTOMER" built_on)" ]] && echo yes || echo no)"
+
 # ---------------------------------------------------------------------------
 echo
 echo "test-plugin-root-resolution: $pass passed, $fail failed"


### PR DESCRIPTION
## Summary

`resolve-plugin-root.sh` composes `state/plugins-root/` out of absolute
symlinks. `CUSTOMER_HOME` is the same directory on both sides of the
host/container bind mount but is reached through a different absolute path
on each side, so a tree built on one side dangles when read from the other.
Verified live on 2026-08-11: all 12 entries under `state/plugins-root/`
resolved to nothing from inside the container, against a tree rebuilt
host-side the same day.

This PR is the bounded first fix per the issue: relative symlinks plus
provenance, nothing else.

- Composed symlinks (both the baked-tree and fetched-tree branches of the
  overlay loop) are now written relative to their containing directory via
  a small `relpath()` helper (shells out to `python3`, already a hard
  dependency of this script), instead of the literal absolute source path.
- The post-compose boot-time assertion that checks every fetched plugin is
  actually active now resolves both sides through `os.path.realpath`
  instead of comparing a raw (now relative) `readlink` target against an
  absolute path - it would otherwise false-positive on every run.
- `plugins-root.state.json` gains a `built_on` field (`"host"` or
  `"container"`, probed the same way `BAKED_ROOT` detection already does)
  so a disagreement between the two sides' view of the tree is visible
  after the fact instead of both exiting 0 with `error: null`.

Explicitly out of scope, per the issue: the `BAKED_ROOT` probe-order
redesign. Not touched.

Closes #159

## Test plan

- [x] `bash chassis/scripts/test-plugin-root-resolution.sh` - 36 passed, 0
      failed (32 pre-existing + 4 new). New scenario 10 builds the composed
      tree under one path, reads it back through a *second* path that
      symlinks to the first (a synthetic stand-in for the host/container
      bind mount, no container required), and asserts both a baked-only and
      a fetched entry resolve through it - plus asserts the written links
      are relative, not absolute, and that `built_on` is recorded.
- [x] Manual smoke test: built a composed tree, confirmed
      `chef -> ../../../baked/chef` / `loom-vision ->
      ../../vendored-plugins/loom-vision` (relative, both resolve through a
      second symlinked mount path), and `built_on` present in the state
      file.
- [ ] Post-merge, confirm from inside the running container per the issue's
      own instruction: `ls -l /app/customer/state/plugins-root/` should
      show relative targets that resolve, not the dangling absolute ones
      from the bug report.

## Independent verification

Fresh-context verifier (new-jaxity#483). This checker did not inherit the
working session context - it saw the issue, the diff and the asserted
claims, and nothing else.

**Verdict: Confirmed**

Authoritative surface checked: fresh clone of scrollinondubs/behalfbot @ fix/mo-159 (chassis/scripts/resolve-plugin-root.sh, chassis/scripts/test-plugin-root-resolution.sh), test command executed against that checkout, manual reproduction of the resolver run outside the test harness

<details><summary>Full verdict</summary>

```
VERDICT: confirmed
SURFACE: fresh clone of scrollinondubs/behalfbot @ fix/mo-159 (chassis/scripts/resolve-plugin-root.sh, chassis/scripts/test-plugin-root-resolution.sh), test command executed against that checkout, manual reproduction of the resolver run outside the test harness

EVIDENCE:
- Composed symlinks are now written relative, not absolute
  checked: read chassis/scripts/resolve-plugin-root.sh at HEAD (5d2545a) lines 83-96 and 190-208, plus a manual run: `env -u CHASSIS_PLUGINS_ROOT CUSTOMER_HOME="$WORK/customer" CHASSIS_BAKED_PLUGINS_ROOT="$WORK/baked" bash chassis/scripts/resolve-plugin-root.sh` against a temp tree with a baked plugin (bfl) and a fetched plugin (loom-vision)
  observed: `ls -l $WORK/customer/state/plugins-root/` showed `bfl -> ../../../baked/bfl` and `loom-vision -> ../../vendored-plugins/loom-vision` - both relative link targets, no leading `/`
  verdict: confirmed

- `bash chassis/scripts/test-plugin-root-resolution.sh` passes 36/36 on this branch
  checked: `bash chassis/scripts/test-plugin-root-resolution.sh` run directly in the fresh clone
  observed: `test-plugin-root-resolution: 36 passed, 0 failed` with zero `FAIL [...]` lines printed (the harness only emits a FAIL line per failing check, confirmed by reading the `check()` function at lines 43-50)
  verdict: confirmed

- s10 builds the tree on one path, reads it back through a second independently-created symlinked path, and asserts a baked entry and a fetched entry both resolve
  checked: read chassis/scripts/test-plugin-root-resolution.sh lines 272-293 (scenario 10 block); reproduced the same shape manually - built a tree, then `ln -s "$WORK/customer" "$WORK/othermount/customer"` and read `openclaw.plugin.json` for both a baked-only plugin (bfl) and a fetched plugin (loom-vision) through `$WORK/othermount/customer/...`
  observed: test file shows `check "s10 baked entry resolves via other mount" "0.1.0" ...` and `check "s10 fetched entry resolves via other mount" "0.2.0" ...` reading through `$OTHER_MOUNT/customer/state/plugins-root/{bfl,loom-vision}`; my manual rerun of the same pattern printed the correct manifests through the second mount path, and both s10 checks were among the 36 that passed with no FAIL line
  verdict: confirmed

- `plugins-root.state.json` includes a `built_on` field set to "host" or "container"
  checked: read resolve-plugin-root.sh lines 98-106, 116, 131 (BUILT_ON probe, passed into write_state, written into the JSON); manual run's output file
  observed: `cat $WORK/customer/plugins-root.state.json` included `"built_on": "container"`, consistent with the `[[ -d /app/plugins ]]` probe in this environment
  verdict: confirmed

- The post-compose assertion now compares realpath-resolved targets instead of raw `readlink` strings
  checked: read resolve-plugin-root.sh lines 91-96 (`resolved_path()` using `os.path.realpath`) and lines 246-255 (assertion loop using `resolved_path` on both sides instead of `readlink`); ran the resolver manually and captured its exit code
  observed: diff replaces `target=$(readlink ...)` / `[[ "$target" != "${d%/}" ]]` with `target=$(resolved_path ...)` / `[[ "$target" != "$(resolved_path "${d%/}")" ]]`; manual run against relative symlinks exited 0 (no assertion failure), which is only possible because the comparison resolves the now-relative link rather than string-matching it against the absolute source path
  verdict: confirmed

NOTES:
All five claims were checked against a fresh clone of the actual PR branch (fix/mo-159, commit 5d2545a), not against the diff text or the working session's summary. The test suite (36 checks including the new s10 regression scenario) passed with zero failures when run directly. Additionally reproduced the core behavior by hand, outside the test harness, using a synthetic baked tree outside CUSTOMER_HOME and a fetched tree inside it, then reading the composed root through a second symlinked "mount" path - both plugin manifests resolved correctly, confirming the relative-symlink fix actually solves the dangling-link defect described in the issue, not just that the diff looks plausible. No claim required speculation about behavior that could not be observed directly.
```

</details>
