### PR TITLE
fix(entrypoint): keep dispatcher.alive fresh during long ticks

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,8 +14,10 @@
 #
 # The dispatcher loop reads HEARTBEATS.md from /app/customer (bind-mounted)
 # and invokes /app/chassis/scheduled-tasks/heartbeat-dispatcher.sh on a fixed
-# tick. /tmp/dispatcher.alive is touched after each tick so the container
-# healthcheck stays green.
+# tick. /tmp/dispatcher.alive is touched at tick start, kept fresh by a
+# keepalive while the tick runs, and touched again at tick end - so the
+# container healthcheck reflects "the loop is alive", not "a tick recently
+# finished" (behalfbot#160).
 
 set -euo pipefail
 
@@ -143,9 +145,21 @@ run_dispatcher_once() {
         log "FATAL: dispatcher not found at $DISPATCHER_SCRIPT"
         exit 2
     fi
+    # Keep /tmp/dispatcher.alive fresh for the duration of the tick, not just
+    # at the end of it. Without this, the sentinel's age at the next touch is
+    # tick_duration + sleep interval - any tick over ~300s crosses the
+    # healthcheck's 1200s staleness threshold, flipping the container to
+    # unhealthy while the dispatcher is doing exactly what it should
+    # (behalfbot#160). If the loop dies, the keepalive subshell dies with it
+    # and the sentinel goes stale as intended.
+    touch /tmp/dispatcher.alive
+    ( while sleep 60; do touch /tmp/dispatcher.alive; done ) &
+    local keepalive=$!
     if ! CHASSIS_HOME="$CHASSIS_HOME" /usr/bin/zsh "$DISPATCHER_SCRIPT"; then
         log "dispatcher tick failed (continuing)"
     fi
+    kill "$keepalive" 2>/dev/null
+    wait "$keepalive" 2>/dev/null
     touch /tmp/dispatcher.alive
 }
 


### PR DESCRIPTION
## Problem

`docker/entrypoint.sh`'s `run_dispatcher_once()` only touched `/tmp/dispatcher.alive` after a tick returned. The `Dockerfile` healthcheck fails if the sentinel is more than 1200s stale. Sentinel age at the next touch was `tick_duration + DISPATCHER_INTERVAL_SECONDS (900)`, so any tick over ~300s crossed the threshold and the container flipped to `unhealthy` mid-tick, even though the dispatcher was working correctly. Observed on Sean's install 2026-08-12 09:20 UTC - `docker inspect` showed `Up 2 days (healthy)` two minutes later, with the healthcheck itself logging `exit 1` then `exit 0` a minute apart.

## Fix

Touch the sentinel at tick start, then run a background loop that re-touches it every 60s for the duration of the tick, killed once the tick's zsh process exits. This makes the sentinel mean "the dispatcher loop is alive" instead of "a tick recently finished" - if the loop itself dies, the keepalive subshell dies with it and the sentinel goes stale as intended, so a real hang is still detected.

Also updated the stale header comment describing sentinel behavior.

Closes #160

## Independent verification

Fresh-context verifier (new-jaxity#483). This checker did not inherit the
working session context - it saw the issue, the diff and the asserted
claims, and nothing else.

**Verdict: Confirmed**

Authoritative surface checked: docker/entrypoint.sh on branch fix/mo-160 in a fresh clone of scrollinondubs/behalfbot (commit 4bb9dda), bash -n on that file

<details><summary>Full verdict</summary>

```
VERDICT: confirmed
SURFACE: docker/entrypoint.sh on branch fix/mo-160 in a fresh clone of scrollinondubs/behalfbot (commit 4bb9dda), bash -n on that file

EVIDENCE:
- run_dispatcher_once() touches /tmp/dispatcher.alive every 60s while the tick runs, via a backgrounded `while sleep 60; do touch ...; done` subshell
  checked: `git clone --filter=blob:none --branch fix/mo-160 https://github.com/scrollinondubs/behalfbot.git`, then `git show fix/mo-160:docker/entrypoint.sh | sed -n '/^run_dispatcher_once/,/^}/p'`
  observed: function body contains `touch /tmp/dispatcher.alive` followed immediately by `( while sleep 60; do touch /tmp/dispatcher.alive; done ) &` and `local keepalive=$!`, placed before the `if ! CHASSIS_HOME="$CHASSIS_HOME" /usr/bin/zsh "$DISPATCHER_SCRIPT"; then` line - so the subshell is backgrounded and runs concurrently with the zsh dispatcher invocation, re-touching every 60s for the tick's duration
  verdict: confirmed

- The keepalive subshell is killed after the dispatcher tick's zsh process exits, and the sentinel is touched once more immediately after
  checked: same `git show` output as above
  observed: immediately following the `if ! ... zsh "$DISPATCHER_SCRIPT" ... fi` block: `kill "$keepalive" 2>/dev/null`, `wait "$keepalive" 2>/dev/null`, then `touch /tmp/dispatcher.alive` as the function's last statement
  verdict: confirmed

- docker/entrypoint.sh passes `bash -n` syntax check
  checked: `bash -n docker/entrypoint.sh; echo "exit code: $?"` run against the cloned fix/mo-160 checkout
  observed: no output from `bash -n` (no syntax errors reported), `exit code: 0`
  verdict: confirmed

NOTES:
Cloned branch fix/mo-160 fresh (commit 4bb9dda4e5dccfc0bcab8c7b032aa3b5a110217c, "fix(entrypoint): keep dispatcher.alive fresh during long ticks, not just after") and confirmed the live file content matches the diff shown in the packet verbatim, including the comment block referencing behalfbot#160. All three claims describe code structure/behavior verifiable directly from the file text and a syntax check, both of which were read/run against the actual cloned repo rather than inferred from the diff text alone. Did not verify the deployed/runtime effect (e.g. an actual long-running tick keeping a live container healthy) - that would require a running container and is out of scope for what the three claims assert, which are all about the code as written.
```

</details>
