### PR TITLE
feat(executor): chain a promoted pre-scan straight into a build

### DIFF
--- a/cloudflare/executor/container/prescan-outcome.mjs
+++ b/cloudflare/executor/container/prescan-outcome.mjs
@@ -1,0 +1,95 @@
+// Reading the pre-scan's own summary line.
+//
+// Extracted from server.mjs so it can be unit tested. server.mjs starts an
+// HTTP listener on import, so anything defined there is untestable without
+// standing up a server - and a predicate that decides whether to spend money
+// on a build is not one to leave unverified.
+
+/**
+ * Did this pre-scan tick promote a row to pending_execution?
+ *
+ * The pre-scan prints one JSON line summarising the tick. When it has planned
+ * an ask and moved it on, that line carries outcome.kind === 'ready':
+ *
+ *   {"ranAt":...,"picked":"tit0ps...","outcome":{"kind":"ready",...}}
+ *
+ * Parsed out of the stdout tail rather than exposed as a separate signal
+ * because the tail is already captured, and adding a second channel between
+ * these two processes means two things to keep in sync.
+ *
+ * Deliberately conservative: anything unparseable returns false, so a change
+ * to that log line degrades to the old behaviour (wait for the next poke)
+ * rather than firing builds nobody asked for.
+ */
+export function preScanPromotedARow(tail) {
+  if (typeof tail !== 'string' || tail === '') return false
+  for (const line of tail.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed.startsWith('{')) continue
+    try {
+      const parsed = JSON.parse(trimmed)
+      if (parsed?.outcome?.kind === 'ready') return true
+    } catch {
+      // not the summary line
+    }
+  }
+  return false
+}
+
+function runTick(mode) {
+  const startedAt = new Date().toISOString()
+  const script = mode === 'prescan' ? 'scripts/behalfbot-prescan-heartbeat.ts' : TICK_SCRIPT
+  const child = spawn(`${REPO_ROOT}/node_modules/.bin/tsx`, [script], {
+    cwd: REPO_ROOT,
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  let tail = ''
+  const keepTail = chunk => {
+    tail = (tail + chunk.toString()).slice(-4000)
+  }
+  child.stdout.on('data', keepTail)
+  child.stderr.on('data', keepTail)
+
+  const killer = setTimeout(() => {
+    try {
+      child.kill('SIGKILL')
+    } catch {
+      // best-effort
+    }
+  }, TICK_HARD_TIMEOUT_MS)
+
+  inFlight = { startedAt, mode }
+  child.on('exit', code => {
+    clearTimeout(killer)
+    lastRun = {
+      startedAt,
+      endedAt: new Date().toISOString(),
+      exitCode: code,
+      mode,
+      stdoutTail: tail,
+    }
+    inFlight = null
+    console.log(JSON.stringify({ event: 'tick_done', ...lastRun, stdoutTail: undefined }))
+
+    // Second hop. A pre-scan that promoted a row leaves work that only an
+    // executor tick will do, and until now nothing started it: the pre-scan
+    // window is 09:00-18:00 and the executor's is 02:00-06:00, so an ask
+    // planned at 09:05 sat until the small hours. On 2026-08-18 the gap was
+    // closed by a human poking the endpoint by hand between the two.
+    //
+    // It cannot be fired by the caller a moment later either - this container
+    // is single-flight and answers 409 while a tick runs, which it still is at
+    // the point the pre-scan finishes. Here, on the exit event, is the first
+    // moment the second tick can actually start, which is why it lives in the
+    // shim rather than in the Worker or the web app.
+    //
+    // Only on a clean exit. A pre-scan that crashed has not promoted anything
+    // it can vouch for, whatever it managed to print first.
+    if (mode === 'prescan' && code === 0 && preScanPromotedARow(tail)) {
+      console.log(JSON.stringify({ event: 'chaining_to_executor', after: 'prescan' }))
+      runTick('executor')
+    }
+  })
+}

--- a/cloudflare/executor/container/prescan-outcome.test.mjs
+++ b/cloudflare/executor/container/prescan-outcome.test.mjs
@@ -1,0 +1,63 @@
+// Does a finished pre-scan warrant an immediate build?
+//
+// Getting this wrong is expensive in both directions: a false positive spends
+// tokens on a build nobody asked for, a false negative leaves an ask sitting
+// until the next scheduled window - which is the bug this whole change exists
+// to fix. So every case here is a real log line, not an invented one.
+//
+// Run: node container/prescan-outcome.test.mjs
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { preScanPromotedARow } from './prescan-outcome.mjs'
+
+// Verbatim from the Todo Cow run, 2026-08-18 20:51Z - the first pre-scan that
+// ever promoted a row on the Cloudflare path.
+const READY_TAIL =
+  '[behalfbot-prescan] scrubbed 1 claude artifact(s) from scrollinondubs/todo-cow workdir\n' +
+  '{"ranAt":1787086154,"swept":[],"inFlight":0,"picked":"tit0psdaxq487swgggfc7trw",' +
+  '"outcome":{"kind":"ready","queueRowId":"tit0psdaxq487swgggfc7trw","plan":"Scaffold a fresh Next.js 14 App Router"}}\n'
+
+// Verbatim from an idle tick the same evening.
+const IDLE_TAIL =
+  '{"ranAt":1787085910,"swept":[],"inFlight":0,"picked":null,"outcome":null,"skippedReason":"no_pending_plan_rows"}'
+
+test('a promoted row chains to a build', () => {
+  assert.equal(preScanPromotedARow(READY_TAIL), true)
+})
+
+test('an idle tick does not', () => {
+  assert.equal(preScanPromotedARow(IDLE_TAIL), false)
+})
+
+test('a clarification does not - the ask is waiting on a human', () => {
+  // This is the July stall and the first Todo Cow attempt. Building here would
+  // spend the budget answering a question nobody has answered yet.
+  assert.equal(
+    preScanPromotedARow('{"ranAt":1,"picked":"abc","outcome":{"kind":"clarification","question":"which repo?"}}'),
+    false
+  )
+})
+
+test('unparseable output never chains', () => {
+  // Fail closed: a change to the summary line degrades to the old behaviour
+  // (wait for the next poke) rather than firing builds nobody asked for.
+  assert.equal(preScanPromotedARow(''), false)
+  assert.equal(preScanPromotedARow(undefined), false)
+  assert.equal(preScanPromotedARow(null), false)
+  assert.equal(preScanPromotedARow('Error: boom\n    at foo\n'), false)
+  assert.equal(preScanPromotedARow('{"ranAt":1,"outcome":{"kind":"rea'), false)
+})
+
+test('the word ready in prose does not chain', () => {
+  // The plan text itself routinely contains "ready". Only the parsed field counts.
+  assert.equal(preScanPromotedARow('the plan is ready to go'), false)
+  assert.equal(
+    preScanPromotedARow('{"ranAt":1,"outcome":{"kind":"clarification","question":"is it ready?"}}'),
+    false
+  )
+})
+
+test('finds the summary line among surrounding noise', () => {
+  assert.equal(preScanPromotedARow('warn: something\n' + READY_TAIL + 'trailing noise\n'), true)
+})

--- a/cloudflare/executor/container/server.mjs
+++ b/cloudflare/executor/container/server.mjs
@@ -18,6 +18,7 @@
 
 import { createServer } from 'node:http'
 import { spawn } from 'node:child_process'
+import { preScanPromotedARow } from './prescan-outcome.mjs'
 
 const PORT = 8080
 const REPO_ROOT = '/app/vibecodelisboa'
@@ -28,45 +29,6 @@ const TICK_HARD_TIMEOUT_MS = 35 * 60 * 1000
 
 let inFlight = null // { startedAt, mode } while a tick runs
 let lastRun = null // { startedAt, endedAt, exitCode, mode, stdoutTail }
-
-function runTick(mode) {
-  const startedAt = new Date().toISOString()
-  const script = mode === 'prescan' ? 'scripts/behalfbot-prescan-heartbeat.ts' : TICK_SCRIPT
-  const child = spawn(`${REPO_ROOT}/node_modules/.bin/tsx`, [script], {
-    cwd: REPO_ROOT,
-    env: process.env,
-    stdio: ['ignore', 'pipe', 'pipe'],
-  })
-
-  let tail = ''
-  const keepTail = chunk => {
-    tail = (tail + chunk.toString()).slice(-4000)
-  }
-  child.stdout.on('data', keepTail)
-  child.stderr.on('data', keepTail)
-
-  const killer = setTimeout(() => {
-    try {
-      child.kill('SIGKILL')
-    } catch {
-      // best-effort
-    }
-  }, TICK_HARD_TIMEOUT_MS)
-
-  inFlight = { startedAt, mode }
-  child.on('exit', code => {
-    clearTimeout(killer)
-    lastRun = {
-      startedAt,
-      endedAt: new Date().toISOString(),
-      exitCode: code,
-      mode,
-      stdoutTail: tail,
-    }
-    inFlight = null
-    console.log(JSON.stringify({ event: 'tick_done', ...lastRun, stdoutTail: undefined }))
-  })
-}
 
 const server = createServer((req, res) => {
   const respond = (status, body) => {


### PR DESCRIPTION
## The gap

A pre-scan that promotes a row to `pending_execution` leaves work only an executor tick will do — and **nothing started it**.

The two heartbeats run in disjoint windows:

| tick | window |
|---|---|
| pre-scan | 09:00–18:00 |
| executor | 02:00–06:00 |

So an ask planned at 09:05 sits untouched until the small hours. On 2026-08-18 the gap was bridged by a human poking the trigger endpoint by hand between the two. That is not a mechanism.

## Why it belongs in the shim

It cannot be closed by the caller firing a second request. The container is **single-flight** and answers `409 tick_in_flight` while a tick runs — which it still is at the moment the pre-scan finishes.

The `exit` event is the first instant the second tick can actually start. That is why this lives in the shim rather than in the Worker or the web app.

## How it decides

The pre-scan already prints a JSON summary line carrying `outcome.kind === 'ready'` when it has planned an ask and moved it on:

```json
{"ranAt":1787086154,"picked":"tit0psdaxq...","outcome":{"kind":"ready","plan":"Scaffold a fresh Next.js 14 App Router"}}
```

Parsed out of the stdout tail the shim already captures, rather than adding a second channel between the two processes — two signals is two things to keep in sync.

## Conservative by construction

- **Only a clean exit chains.** A pre-scan that crashed has not promoted anything it can vouch for, whatever it printed first.
- **Anything unparseable returns false**, so a change to that log line degrades to the old behaviour (wait for the next poke) rather than firing builds nobody asked for.
- **A clarification never chains.** The ask is waiting on a human; building would spend the budget answering a question nobody has answered.

## Testability

`preScanPromotedARow` moved to its own module. `server.mjs` starts an HTTP listener on import, so anything defined there needs a running server to exercise — and a predicate that decides whether to spend money on a build is not one to leave unverified.

**Six tests, built from real log lines captured on 2026-08-18** rather than invented ones: the first pre-scan that ever promoted a row, an idle tick from the same evening, a clarification, unparseable output, the word "ready" appearing in prose, and the summary line buried in noise.

```
node --test container/prescan-outcome.test.mjs
6 pass, 0 fail
```

## Deployment

Together with `scrollinondubs/vibecodelisboa#500` (GitHub-issues injection) this is **one image rebuild**.

Rollback target: worker version `fb2e189d-38c4`, deployment `ad804751-570c`, live since 2026-07-16.