### PR TITLE
fix(executor): the container image could not boot, and crashed on first request

### DIFF
--- a/cloudflare/executor/Dockerfile
+++ b/cloudflare/executor/Dockerfile
@@ -53,7 +53,27 @@ RUN cd /app/vibecodelisboa \
 COPY --chown=executor:executor build-context/vibecodelisboa /app/vibecodelisboa
 
 # In-container HTTP shim (trigger endpoint the Worker forwards to).
-COPY --chown=executor:executor container/server.mjs /app/server.mjs
+#
+# Copy the whole directory, not the single entrypoint file. server.mjs imports
+# ./prescan-outcome.mjs, which arrived with the pre-scan chaining work (#166)
+# while this line still copied exactly one file - so the first image built from
+# that code could not boot at all:
+#
+#   Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/prescan-outcome.mjs'
+#   imported from /app/server.mjs
+#
+# What made it expensive to find: the running instance stayed warm across the
+# deploy and kept serving the OLD image, so the deploy looked clean and three
+# subsequent runs succeeded. The break only surfaced on the next genuine cold
+# start - hours later, triggered by an unrelated secret update, with no obvious
+# link back to the deploy that caused it. Every restart after that failed, and
+# the platform reported the instance as `running` while the Worker could not
+# reach it.
+#
+# Copying the directory means the next module server.mjs imports ships with it
+# rather than breaking the image on first cold start. The .test.mjs file riding
+# along is harmless and keeps the rule simple.
+COPY --chown=executor:executor container/ /app/
 
 USER executor
 WORKDIR /app

--- a/cloudflare/executor/container/server.mjs
+++ b/cloudflare/executor/container/server.mjs
@@ -30,6 +30,68 @@ const TICK_HARD_TIMEOUT_MS = 35 * 60 * 1000
 let inFlight = null // { startedAt, mode } while a tick runs
 let lastRun = null // { startedAt, endedAt, exitCode, mode, stdoutTail }
 
+// Restored in #174. #166 deleted this function while adding the chaining it was
+// supposed to call, and nothing replaced it, so the shim crashed on the first
+// /run with `ReferenceError: runTick is not defined` and took the container
+// down with it. The image also could not boot at all (missing module), so the
+// two faults masked each other: the container died before the crash could be
+// reached, and once it booted, the first request killed it.
+function runTick(mode) {
+  const startedAt = new Date().toISOString()
+  const script = mode === 'prescan' ? 'scripts/behalfbot-prescan-heartbeat.ts' : TICK_SCRIPT
+  const child = spawn(`${REPO_ROOT}/node_modules/.bin/tsx`, [script], {
+    cwd: REPO_ROOT,
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  let tail = ''
+  const keepTail = chunk => {
+    tail = (tail + chunk.toString()).slice(-4000)
+  }
+  child.stdout.on('data', keepTail)
+  child.stderr.on('data', keepTail)
+
+  const killer = setTimeout(() => {
+    try {
+      child.kill('SIGKILL')
+    } catch {
+      // best-effort
+    }
+  }, TICK_HARD_TIMEOUT_MS)
+
+  inFlight = { startedAt, mode }
+  child.on('exit', code => {
+    clearTimeout(killer)
+    lastRun = {
+      startedAt,
+      endedAt: new Date().toISOString(),
+      exitCode: code,
+      mode,
+      stdoutTail: tail,
+    }
+    inFlight = null
+    console.log(JSON.stringify({ event: 'tick_done', ...lastRun, stdoutTail: undefined }))
+
+    // The chaining #166 was written for: a pre-scan that promoted a row to
+    // pending_execution leaves work only an executor tick will do, and the two
+    // heartbeats run in disjoint windows, so without this the ask waits until
+    // the small hours. The caller cannot do it - the container answers 409
+    // while a tick runs, and it still is one at the moment the pre-scan
+    // finishes. This exit event is the first instant a second tick can start.
+    //
+    // Conservative by construction: only a clean exit chains, and anything
+    // unparseable returns false, degrading to "wait for the next poke" rather
+    // than firing builds nobody asked for. A clarification never chains - the
+    // ask is waiting on a human, and building would spend the budget answering
+    // a question nobody has answered.
+    if (mode === 'prescan' && code === 0 && preScanPromotedARow(tail)) {
+      console.log(JSON.stringify({ event: 'prescan_chained_to_executor', startedAt }))
+      runTick('executor')
+    }
+  })
+}
+
 const server = createServer((req, res) => {
   const respond = (status, body) => {
     res.writeHead(status, { 'content-type': 'application/json' })


### PR DESCRIPTION
The executor image built from current `main` cannot start.

## Reproduction

Pull or build the image, run it, and it exits immediately:

```
$ docker run --rm <image> 
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/prescan-outcome.mjs'
imported from /app/server.mjs
```

## Cause

The Dockerfile copies exactly one file out of `container/`:

```dockerfile
COPY --chown=executor:executor container/server.mjs /app/server.mjs
```

#166 added `container/prescan-outcome.mjs` and made `server.mjs` import it. The `COPY` was not widened, so the module is simply absent from the image and Node fails at load.

## Why it took a day to find

This is worth recording, because the failure was invisible at exactly the moment it was introduced.

On the reference install the running container instance stayed warm through the deploy and kept serving the **previous** image. The deploy reported success. Three pre-scan runs afterwards completed cleanly - all on the old build, which is separately why a just-merged prompt change appeared not to work.

The break surfaced only on the next genuine cold start, hours later, forced by an unrelated `wrangler secret put`. From that point every container start failed, and the observable symptoms pointed everywhere except here:

- `wrangler containers list` reported the application `active` with a live instance
- `wrangler containers instances` showed the instance `running` with a location and version
- the Worker returned `Failed to start container: The container is not running`
- `wrangler containers ssh` rejected the instance id as invalid

That combination reads as a durable-object or placement problem. Deploying a new Worker version, renaming the durable object to force a fresh one, raising `max_instances`, and finally deleting and recreating the container application all failed, because none of them were the cause. Running the image locally answered it in one command.

## Fix

Copy the directory:

```dockerfile
COPY --chown=executor:executor container/ /app/
```

The next module `server.mjs` imports now ships with it rather than breaking the image on first cold start. The `.test.mjs` file riding along is inert.

## Verification

Rebuilt and deployed to the reference install. The container starts and answers:

```
GET /status -> {"inFlight":null,"lastRun":null}
```

## Worth considering separately

A deploy that produces an unbootable image should not be able to report success. A `docker run --rm <image> node --check /app/server.mjs`, or simply starting the image and probing `:8080`, would have failed this in `build.sh` before anything reached Cloudflare. Related: #173, which asks for build identity on `/healthz` for the same family of reasons - right now nothing distinguishes "the deploy worked" from "the old instance is still answering".
