### PR TITLE
fix(backup-posture): emit stable alert_signature so drift repeats register

### DIFF
--- a/chassis/scripts/check-backup-posture.sh
+++ b/chassis/scripts/check-backup-posture.sh
@@ -105,6 +105,7 @@ aws_audit() {
 }
 
 FINDINGS=()
+DRIFT_MSGS=()
 DRIFT=0
 
 note_finding() {
@@ -118,6 +119,7 @@ flag_drift() {
     local msg="$1"
     [[ $VERBOSE -eq 1 ]] && echo "drift: $msg" >&2
     FINDINGS+=("$(printf '"drift_%d": "%s"' "${#FINDINGS[@]}" "$msg")")
+    DRIFT_MSGS+=("$msg")
 }
 
 # 1. Versioning.
@@ -239,10 +241,29 @@ JOINED_FINDINGS=$(printf '%s,' "${FINDINGS[@]}")
 JOINED_FINDINGS="${JOINED_FINDINGS%,}"
 DRIFT_BOOL=$([[ $DRIFT -eq 0 ]] && echo "false" || echo "true")
 
+# Stable fingerprint of WHAT drifted, deliberately excluding ts_utc/bucket/
+# region so the dispatcher's repeat-alert cooldown ladder (new-jaxity#433)
+# can recognize "same drift as last run" instead of treating every run as
+# new just because the timestamp changed. Built from the drift messages
+# only - not the full FINDINGS blob - so a non-drift value shifting (e.g.
+# object_lock_days on a run with no drift) can't perturb the signature for
+# an unrelated drift condition. No drift -> a fixed sentinel, not a hash of
+# nothing.
+if [[ ${#DRIFT_MSGS[@]} -gt 0 ]]; then
+    if command -v sha256sum >/dev/null 2>&1; then
+        ALERT_SIG=$(printf '%s\n' "${DRIFT_MSGS[@]}" | sort | sha256sum | cut -c1-16)
+    else
+        ALERT_SIG=$(printf '%s\n' "${DRIFT_MSGS[@]}" | sort | shasum -a 256 | cut -c1-16)
+    fi
+else
+    ALERT_SIG="no_drift"
+fi
+
 cat <<JSON
 {
   "count": $DRIFT_COUNT,
   "drift": $DRIFT_BOOL,
+  "alert_signature": "$ALERT_SIG",
   "ts_utc": "$TS",
   "bucket": "$S3_BACKUP_BUCKET",
   "region": "$S3_BACKUP_REGION",


### PR DESCRIPTION
Closes #165.

## What

`check-backup-posture.sh` had no stable fingerprint of *what* drifted - only `ts_utc`, which changes every run. The dispatcher's repeat-alert cooldown ladder (new-jaxity#433) needs to recognize "same drift as last run" to work at all; without a stable signature every nightly run looked new.

Applied the fix exactly as scoped and diffed in the issue's own parked-session comment (a prior window wrote and tested this, then stopped mid-session on an unrelated incident before it could ship). This PR is that diff, re-verified.

`alert_signature` is a sha256 (16-char) of the sorted drift messages only - not the full `FINDINGS` blob, so a non-drift value shifting (e.g. `object_lock_days` on a clean run) can't perturb the signature for an unrelated drift condition. No drift emits the `"no_drift"` sentinel rather than hashing nothing.

## Scope

One script only, per the issue's own scoping. No dispatcher changes - `scheduled-tasks/heartbeat-dispatcher.sh:1210-1219` (customer-side) already implements the preference this signature feeds; the chassis copy of the dispatcher does not carry that block yet, so on Sean's install this works the moment it lands, but on a fresh install it stays inert until the dispatcher preference also goes upstream. Widening this card to fix that is explicitly out of scope per the issue.

## Test evidence

Ran the whole script end-to-end against a fake `aws` CLI stub (no real AWS calls), `bash -n` clean first:

1. Same drift (versioning `Suspended` + missing lifecycle rule), two runs a second apart: identical `alert_signature` (`7d289c4b436ceb51`), different `ts_utc`.
2. Different drift (only the lifecycle rule missing, versioning fine): different `alert_signature` (`9258c401e538043e`).
3. No drift at all: `"alert_signature": "no_drift"`, `count: 0`, `drift: false`.
4. All four outputs (including a same-drift/no-lifecycle-vs-versioning-drift case) parse cleanly with `jq .`.

Signatures match exactly what the parked-session comment on #165 reported, confirming the diff applied cleanly against the current file.

## Independent verification

Fresh-context verifier (new-jaxity#483). This checker did not inherit the
working session context - it saw the issue, the diff and the asserted
claims, and nothing else.

**Verdict: Confirmed**

Authoritative surface checked: cloned repo at branch fix/mo-165 (commit e5e5bf7), actual script execution of chassis/scripts/check-backup-posture.sh with a stubbed aws CLI on PATH, bash -n syntax check, git diff against origin/main

<details><summary>Full verdict</summary>

```
VERDICT: confirmed
SURFACE: cloned repo at branch fix/mo-165 (commit e5e5bf7), actual script execution of chassis/scripts/check-backup-posture.sh with a stubbed aws CLI on PATH, bash -n syntax check, git diff against origin/main

EVIDENCE:
- chassis/scripts/check-backup-posture.sh now emits alert_signature derived from sorted drift messages, excluding ts_utc/bucket/region
  checked: git show e5e5bf7 and reading the full script
  observed: ALERT_SIG hashes DRIFT_MSGS only via sha256sum, or "no_drift" sentinel when empty; JSON output includes alert_signature; diff matches PR exactly
  verdict: confirmed

- Two runs with identical drift one second apart produce the same alert_signature while ts_utc differs
  checked: ran the real script twice via bash chassis/scripts/check-backup-posture.sh --no-iam against a stub aws CLI reproducing versioning Suspended + missing lifecycle rule
  observed: both runs returned alert_signature 7d289c4b436ceb51, ts_utc differed
  verdict: confirmed

- Different drift conditions produce a different alert_signature
  checked: same setup with only lifecycle rule missing, versioning enabled
  observed: alert_signature 9258c401e538043e, distinct from the identical-drift case
  verdict: confirmed

- No drift at all produces alert_signature "no_drift" and count 0
  checked: same setup with no drift conditions triggered
  observed: count 0, drift false, alert_signature "no_drift"
  verdict: confirmed

- bash -n passes and the diff touches only chassis/scripts/check-backup-posture.sh
  checked: bash -n exit code, git diff --stat/--name-only against origin/main
  observed: bash -n clean; diff scoped to exactly one file, 21 insertions
  verdict: confirmed

NOTES:
All five claims verified by actually running the modified script against a stubbed AWS CLI reproducing each drift scenario, not by reading the diff alone. One cosmetic note not affecting any claim: the issue text cites chassis/chassis/scripts/... (double chassis) while the real path is chassis/scripts/... (single) - an issue-text imprecision, not a PR problem.
```

</details>
