### PR TITLE
fix(entrypoint): stop `wait` on the killed keepalive from killing PID 1

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -158,8 +158,14 @@ run_dispatcher_once() {
     if ! CHASSIS_HOME="$CHASSIS_HOME" /usr/bin/zsh "$DISPATCHER_SCRIPT"; then
         log "dispatcher tick failed (continuing)"
     fi
-    kill "$keepalive" 2>/dev/null
-    wait "$keepalive" 2>/dev/null
+    # `|| true` on BOTH is load-bearing under `set -e`. `wait` on a job we
+    # just SIGTERM'd returns 143, and `kill` returns 1 if the subshell already
+    # exited - either one takes PID 1 down and the container restarts. That is
+    # not theoretical: it shipped in the 2026-08-18 image and put this install
+    # into a ~19s restart loop for 25 hours (every boot ran one full tick, then
+    # died on the `wait` the moment the tick returned).
+    kill "$keepalive" 2>/dev/null || true
+    wait "$keepalive" 2>/dev/null || true
     touch /tmp/dispatcher.alive
 }
 


### PR DESCRIPTION
## What broke

The chassis container has been restarting every ~19 seconds since the
2026-08-18 image build. On the Lisbon install that is 967 restarts
between 2026-08-19 08:46 and 2026-08-20 09:24.

Not a crash on boot - every boot succeeded, ran one complete pass over
`HEARTBEATS.md`, and then died the instant the pass returned. Docker's
die events say `execDuration=17, exitCode=143` every time. 143 is
128+SIGTERM, and no host process was sending it.

## Why

`run_dispatcher_once()` starts a keepalive subshell to keep
`/tmp/dispatcher.alive` fresh during a long tick (#164), then tears it
down at the end of the tick:

```bash
kill "$keepalive" 2>/dev/null
wait "$keepalive" 2>/dev/null
```

The entrypoint runs under `set -euo pipefail`. `wait` on a job that was
terminated by a signal returns 143. `set -e` sees a non-zero simple
command in the `while true` body and exits the shell - which is PID 1.
`restart: unless-stopped` brings it back, the next tick completes, and
it dies again.

Repro with no chassis involved:

```bash
bash -c 'set -euo pipefail
( while sleep 60; do :; done ) &
k=$!
kill "$k" 2>/dev/null
wait "$k" 2>/dev/null
echo SURVIVED'
# prints nothing, exits 143
```

## Why the healthcheck did not catch it

It could not. The healthcheck asks "is `/tmp/dispatcher.alive` fresher
than 1200s", and it always was - the loop really was alive, it just
never reached `sleep 900`. The container reported `healthy` throughout.
Only the host-side liveness watchdog noticed, via restart count.

## The fix

`|| true` on both teardown lines, plus a comment saying why it is
load-bearing. `kill` gets the same guard for the same reason: it returns
1 when the subshell has already exited, which a failed `touch` on a full
disk is enough to cause.

## Blast radius while it was broken

Twelve `claude -p` runs were killed mid-flight and burned all three
retry attempts: dream, daily-log, memory-canary, pulse-triage,
morning-briefing, dating-pipeline-health. Most recovered on a later tick
(the morning briefing shipped at 08:59); `dream` did not run. The
gather-condition cooldown absorbed the rest of the storm - roughly 4,700
tick passes produced only 84 claude invocations. Dispatcher logs grew to
31MB across two days.

## Verification

Patched entrypoint `docker cp`'d into the running container and
restarted at 09:24:29Z. Container is up, `RestartCount` frozen at 0, and
it survived well past the ~19s mark where every previous boot died.

That `docker cp` lives in the container's writable layer only - it
survives `docker restart` but is lost on recreate or the next image
pull, so this PR is the real fix.
