### PR TITLE
fix(plugins): union both baked plugin roots instead of picking one by branch order

### DIFF
--- a/chassis/scripts/resolve-plugin-root.sh
+++ b/chassis/scripts/resolve-plugin-root.sh
@@ -55,9 +55,13 @@
 # the two views of the composed tree is visible after the fact.
 #
 # Env seams:
-#   CHASSIS_BAKED_PLUGINS_ROOT - override the baked-tree location (tests,
-#       host installs with a non-standard layout). Defaults to /app/plugins,
-#       then $CHASSIS_HOME/plugins.
+#   CHASSIS_BAKED_PLUGINS_ROOT - pin the baked tree to a single explicit
+#       root, bypassing the union below entirely (operator override, tests
+#       with a non-standard layout).
+#   CHASSIS_IMAGE_PLUGINS_ROOT - override the image-baked half of the union
+#       (tests only; real installs always have this at /app/plugins, which
+#       is the default). The other half is $CHASSIS_HOME/plugins, already
+#       reachable via CHASSIS_HOME in tests.
 #   CHASSIS_PLUGINS_FETCH_ROOT - override the fetched-tree location.
 #       Defaults to $CUSTOMER_HOME/vendored-plugins (matches fetch-plugins.sh).
 #
@@ -71,6 +75,11 @@
 set -uo pipefail
 
 : "${CUSTOMER_HOME:=${CHASSIS_HOME:-/app/customer}}"
+
+# Populated by the baked-root probe below. Declared here (empty) so
+# write_state can always expand it under `set -u`, even from the explicit
+# operator-override branch, which returns before the probe runs.
+BAKED_ROOTS=()
 
 log() { printf '[resolve-plugin-root] %s\n' "$*" >&2; }
 
@@ -95,8 +104,8 @@ resolved_path() {
     python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$1"
 }
 
-# Which side is resolving right now. Same probe write_state's BAKED_ROOT
-# detection uses below (/app/plugins only exists inside the container) -
+# Which side is resolving right now. Same real /app/plugins probe the
+# image-baked half of the union below defaults to (container-only) -
 # recorded so a disagreement between the host and container view of
 # state/plugins-root is visible after the fact instead of just dangling.
 if [[ -d /app/plugins ]]; then
@@ -112,7 +121,8 @@ STATE_FILE="$CUSTOMER_HOME/plugins-root.state.json"
 write_state() {
     local mode="$1" root="$2" error="${3:-}"
     MODE="$mode" ROOT="$root" ERROR="$error" \
-    BAKED="${BAKED_ROOT:-}" FETCHED="${FETCHED_ROOT:-}" \
+    BAKED="${BAKED_ROOTS[0]:-}" FETCHED="${FETCHED_ROOT:-}" \
+    BAKED_ROOTS_LIST="$(printf '%s\n' "${BAKED_ROOTS[@]:-}")" \
     PROVENANCE="${PROVENANCE:-}" BUILT_ON="$BUILT_ON" \
     python3 - "$STATE_FILE" <<'PY' 2>/dev/null || log "WARN: could not write $STATE_FILE"
 import datetime, json, os, sys
@@ -121,11 +131,13 @@ for line in os.environ.get("PROVENANCE", "").splitlines():
     if "\t" in line:
         name, src = line.split("\t", 1)
         prov[name] = src
+baked_roots = [r for r in os.environ.get("BAKED_ROOTS_LIST", "").splitlines() if r]
 state = {
     "schema": 1,
     "mode": os.environ["MODE"],
     "resolved_root": os.environ["ROOT"],
     "baked_root": os.environ["BAKED"] or None,
+    "baked_roots": baked_roots,
     "fetched_root": os.environ["FETCHED"] or None,
     "resolved_at": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     "built_on": os.environ["BUILT_ON"],
@@ -140,7 +152,7 @@ PY
 
 # --- operator override: set means set, honour verbatim ----------------------
 if [[ -n "${CHASSIS_PLUGINS_ROOT:-}" ]]; then
-    BAKED_ROOT="" FETCHED_ROOT="${CHASSIS_PLUGINS_FETCH_ROOT:-$CUSTOMER_HOME/vendored-plugins}"
+    BAKED_ROOTS=() FETCHED_ROOT="${CHASSIS_PLUGINS_FETCH_ROOT:-$CUSTOMER_HOME/vendored-plugins}"
     if usable "$FETCHED_ROOT" && [[ "$CHASSIS_PLUGINS_ROOT" != "$FETCHED_ROOT" ]]; then
         log "operator override: CHASSIS_PLUGINS_ROOT=$CHASSIS_PLUGINS_ROOT (explicitly set)"
         log "note: a usable fetched tree exists at $FETCHED_ROOT and is being ignored BY EXPLICIT CHOICE"
@@ -150,20 +162,32 @@ if [[ -n "${CHASSIS_PLUGINS_ROOT:-}" ]]; then
     exit 0
 fi
 
-# --- locate the two source trees --------------------------------------------
-BAKED_ROOT=""
+# --- locate the baked root(s) -----------------------------------------------
+# /app/plugins (image-baked, container-only) and $CHASSIS_HOME/plugins
+# (host-side legacy layout) can both exist and hold DISJOINT plugin sets.
+# Picking one by elif branch order (the pre-#163 behaviour) meant the two
+# sides of the same bind mount answered differently and both exited 0 -
+# whichever plugin only lived in the root that lost silently vanished. Union
+# both instead, same shape as the baked-then-fetched overlay below: base
+# first, later root overlaid on top so a same-named plugin in the later root
+# wins. CHASSIS_BAKED_PLUGINS_ROOT is an explicit operator override and stays
+# a single root, not part of the union - explicit still beats inferred.
 if [[ -n "${CHASSIS_BAKED_PLUGINS_ROOT:-}" && -d "${CHASSIS_BAKED_PLUGINS_ROOT}" ]]; then
-    BAKED_ROOT="$CHASSIS_BAKED_PLUGINS_ROOT"
-elif [[ -d /app/plugins ]]; then
-    BAKED_ROOT="/app/plugins"
-elif [[ -n "${CHASSIS_HOME:-}" && -d "$CHASSIS_HOME/plugins" ]]; then
-    BAKED_ROOT="$CHASSIS_HOME/plugins"
+    BAKED_ROOTS=("$CHASSIS_BAKED_PLUGINS_ROOT")
+else
+    IMAGE_BAKED_ROOT="${CHASSIS_IMAGE_PLUGINS_ROOT:-/app/plugins}"
+    [[ -d "$IMAGE_BAKED_ROOT" ]] && BAKED_ROOTS+=("$IMAGE_BAKED_ROOT")
+    [[ -n "${CHASSIS_HOME:-}" && -d "$CHASSIS_HOME/plugins" ]] && BAKED_ROOTS+=("$CHASSIS_HOME/plugins")
 fi
 
 FETCHED_ROOT="${CHASSIS_PLUGINS_FETCH_ROOT:-$CUSTOMER_HOME/vendored-plugins}"
 
-# --- no usable fetched tree: baked only, exactly the pre-#82 behaviour ------
-if ! usable "$FETCHED_ROOT"; then
+# --- zero or one baked root, no usable fetched tree: pass through directly --
+# Exactly the pre-#82 behaviour (no filesystem writes) for the common case.
+# Two baked roots, or a usable fetched tree, both need a composed union and
+# fall through to the overlay below instead.
+if ! usable "$FETCHED_ROOT" && [[ "${#BAKED_ROOTS[@]}" -le 1 ]]; then
+    BAKED_ROOT="${BAKED_ROOTS[0]:-}"
     PROVENANCE=""
     if [[ -n "$BAKED_ROOT" ]]; then
         for d in "$BAKED_ROOT"/*/; do
@@ -187,13 +211,20 @@ fi
 
 PROVENANCE=""
 if [[ -n "$staging" ]]; then
-    if [[ -n "$BAKED_ROOT" ]]; then
-        for d in "$BAKED_ROOT"/*/; do
+    # Base first, each later root overlaid on top - same rm-then-relink
+    # pattern the fetched loop below uses, so a same-named plugin in a
+    # higher-precedence baked root wins instead of colliding.
+    for br in "${BAKED_ROOTS[@]:-}"; do
+        [[ -n "$br" ]] || continue
+        for d in "$br"/*/; do
             [[ -d "$d" ]] || continue
-            ln -s "$(relpath "${d%/}" "$staging")" "$staging/$(basename "$d")"
-            PROVENANCE+="$(basename "$d")"$'\t'"baked"$'\n'
+            name=$(basename "$d")
+            rm -f "$staging/$name"
+            ln -s "$(relpath "${d%/}" "$staging")" "$staging/$name"
+            PROVENANCE=$(printf '%s' "$PROVENANCE" | grep -v "^$name"$'\t' || true)
+            PROVENANCE+=$'\n'"$name"$'\t'"baked"$'\n'
         done
-    fi
+    done
     for d in "$FETCHED_ROOT"/*/; do
         [[ -d "$d" ]] || continue
         name=$(basename "$d")
@@ -229,12 +260,13 @@ else
 fi
 
 if [[ -n "$compose_failed" ]]; then
-    # Fetched tree is usable but we cannot activate it. Fall back to baked
-    # (the larger set) and fail LOUDLY - this is the exact silent-no-op class
-    # v0.2.0 shipped, so it must never pass quietly.
-    log "ERROR: fetched plugin tree at $FETCHED_ROOT is usable but could NOT be activated (compose failed under $CUSTOMER_HOME/state)"
-    write_state baked "$BAKED_ROOT" "compose failed - fetched tree present but not active"
-    printf '%s\n' "$BAKED_ROOT"
+    # The union/overlay is usable but we cannot activate it. Fall back to the
+    # single highest-precedence baked root and fail LOUDLY - this is the
+    # exact silent-no-op class v0.2.0 shipped, so it must never pass quietly.
+    fallback_root="${BAKED_ROOTS[-1]:-}"
+    log "ERROR: composed plugin tree (baked union and/or fetched overlay from $FETCHED_ROOT) is usable but could NOT be activated (compose failed under $CUSTOMER_HOME/state)"
+    write_state baked "$fallback_root" "compose failed - overlay present but not active"
+    printf '%s\n' "$fallback_root"
     exit 5
 fi
 

--- a/chassis/scripts/test-plugin-root-resolution.sh
+++ b/chassis/scripts/test-plugin-root-resolution.sh
@@ -229,6 +229,38 @@ check "s10 symlinks are relative, not absolute" "relative" \
 check "s10 state records built_on" "yes" \
     "$([[ -n "$(state_field "$CUSTOMER" built_on)" ]] && echo yes || echo no)"
 
+# --- scenario 11: two baked roots holding disjoint plugin sets union -------
+# THE regression test for behalfbot#163: the image-baked root (/app/plugins,
+# container-only) and $CHASSIS_HOME/plugins (host-side legacy layout) can
+# both exist with DISJOINT plugin sets. Picking one by branch order made a
+# plugin that only lived in the other root vanish depending on which side
+# resolved. CHASSIS_IMAGE_PLUGINS_ROOT stands in for /app/plugins here since
+# the real path is container-only and not writable in this test harness.
+fresh_env s11
+IMAGE_BAKED="$TMP/s11/image-baked"
+manifest "$IMAGE_BAKED/angel-protocol" "angel-protocol" "0.1.0"
+manifest "$IMAGE_BAKED/bfl" "bfl" "0.1.0"
+CHASSIS_HOME_PLUGINS="$CUSTOMER/plugins"
+manifest "$CHASSIS_HOME_PLUGINS/midnight-oil" "midnight-oil" "0.1.0"
+RESOLVED_ROOT="$(env -u CHASSIS_PLUGINS_ROOT -u CHASSIS_BAKED_PLUGINS_ROOT     CUSTOMER_HOME="$CUSTOMER" CHASSIS_HOME="$CUSTOMER"     CHASSIS_IMAGE_PLUGINS_ROOT="$IMAGE_BAKED"     bash "$RESOLVER" 2>>"$TMP/resolver.log")"
+RESOLVER_RC=$?
+check "s11 exit" "0" "$RESOLVER_RC"
+check "s11 root is composed" "$CUSTOMER/state/plugins-root" "$RESOLVED_ROOT"
+check "s11 union plugin count" "3" "$(ls -d "$RESOLVED_ROOT"/*/ | wc -l | tr -d ' ')"
+check "s11 image-only plugin present" "yes" "$([[ -e "$RESOLVED_ROOT/angel-protocol" ]] && echo yes || echo no)"
+check "s11 chassis-home-only plugin present" "yes" "$([[ -e "$RESOLVED_ROOT/midnight-oil" ]] && echo yes || echo no)"
+check "s11 state names both baked roots" "2" "$(python3 -c '''import json,sys; print(len(json.load(open(sys.argv[1]))["baked_roots"]))''' "$CUSTOMER/plugins-root.state.json")"
+check "s11 state mode" "overlay" "$(state_field "$CUSTOMER" mode)"
+
+# --- scenario 12: same-named plugin in both baked roots - later root wins --
+fresh_env s12
+IMAGE_BAKED="$TMP/s12/image-baked"
+manifest "$IMAGE_BAKED/bfl" "bfl" "1.0.0"
+CHASSIS_HOME_PLUGINS="$CUSTOMER/plugins"
+manifest "$CHASSIS_HOME_PLUGINS/bfl" "bfl" "2.0.0"
+RESOLVED_ROOT="$(env -u CHASSIS_PLUGINS_ROOT -u CHASSIS_BAKED_PLUGINS_ROOT     CUSTOMER_HOME="$CUSTOMER" CHASSIS_HOME="$CUSTOMER"     CHASSIS_IMAGE_PLUGINS_ROOT="$IMAGE_BAKED"     bash "$RESOLVER" 2>>"$TMP/resolver.log")"
+check "s12 $CHASSIS_HOME/plugins wins over /app/plugins on collision" "2.0.0"     "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$RESOLVED_ROOT/bfl/openclaw.plugin.json")"
+
 # ---------------------------------------------------------------------------
 echo
 echo "test-plugin-root-resolution: $pass passed, $fail failed"


### PR DESCRIPTION
## What

`resolve-plugin-root.sh` picked the baked plugin root with an `elif` chain
(`CHASSIS_BAKED_PLUGINS_ROOT` override → `/app/plugins` → `$CHASSIS_HOME/plugins`).
`/app/plugins` (image-baked, container-only) and `$CHASSIS_HOME/plugins`
(host-side legacy layout) can both exist holding **disjoint** plugin sets, so
branch order silently decided which plugin set won - both sides exited 0 and
disagreed. Live evidence in the running install: `/app/plugins` has 7 plugins,
`$CHASSIS_HOME/plugins` has `midnight-oil`; in-container the first branch wins
and `midnight-oil` is invisible to the resolver.

## Fix

Union both roots instead of picking one, using the same base-then-overlay
shape the baked-then-fetched compose already uses further down: `/app/plugins`
as the base, `$CHASSIS_HOME/plugins` overlaid on top (same-named plugin in the
overlay wins). `CHASSIS_BAKED_PLUGINS_ROOT` keeps working as a single-root
explicit override, ahead of the union - explicit still beats inferred.

Both resolved roots are now recorded in `plugins-root.state.json` as
`baked_roots`, alongside the existing `baked_root` (first entry, kept for
back-compat) and `built_on`, so a disagreement is visible after the fact.

Adds `CHASSIS_IMAGE_PLUGINS_ROOT` as a test-only seam for the `/app/plugins`
half of the union - the real path is container-only and not writable outside
a real container, so it wasn't previously exercisable by any automated test.

## Scope

This is suggestion 2 from #163 (the `BAKED_ROOT` probe order). Suggestions 1
(relative symlinks) and 3 (`built_on` recorded) already shipped in #162 /
#159.

## Testing

Extended `test-plugin-root-resolution.sh` with two new scenarios: a union of
two baked roots with disjoint plugin sets, and a same-named-plugin collision
between the two roots. `bash chassis/scripts/test-plugin-root-resolution.sh`
→ 44 passed, 0 failed (36 pre-existing + 8 new checks). Also reran
`test-merge-plugin-triggers.sh` (11 passed, 0 failed) since it also depends
on the resolved plugin root.

Closes #163

🌙 Generated by Midnight Oil

## Independent verification

Fresh-context verifier (new-jaxity#483). This checker did not inherit the
working session context - it saw the issue, the diff and the asserted
claims, and nothing else.

**Verdict: Confirmed**

Authoritative surface checked: fresh git clone of scrollinondubs/behalfbot at branch fix/mo-163 (commit 7ce64ae), chassis/scripts/test-plugin-root-resolution.sh run directly, chassis/scripts/test-merge-plugin-triggers.sh run directly, git diff 9d87a16..7ce64ae compared against the packet's diff text, gh pr view 178 for PR metadata

<details><summary>Full verdict</summary>

```
VERDICT: confirmed
SURFACE: fresh git clone of scrollinondubs/behalfbot at branch fix/mo-163 (commit 7ce64ae), chassis/scripts/test-plugin-root-resolution.sh run directly, chassis/scripts/test-merge-plugin-triggers.sh run directly, git diff 9d87a16..7ce64ae compared against the packet's diff text, gh pr view 178 for PR metadata

EVIDENCE:
- `test-plugin-root-resolution.sh` passes 44/44 (36 pre-existing + 8 new)
  checked: `bash chassis/scripts/test-plugin-root-resolution.sh` in a fresh clone of fix/mo-163
  observed: `test-plugin-root-resolution: 44 passed, 0 failed`. Confirmed the 8-new figure independently: `git diff 9d87a16 7ce64ae -- chassis/scripts/test-plugin-root-resolution.sh | grep -c '^+check '` = 8, and total `check "` invocations in the file = 44 (42 top-level + 2 indented inside an s8 conditional block).
  verdict: confirmed

- `test-merge-plugin-triggers.sh` still passes 11/11, unaffected by the change
  checked: `bash chassis/scripts/test-merge-plugin-triggers.sh`; also `git diff 9d87a16 7ce64ae --stat` and `grep -n resolve-plugin-root chassis/scripts/merge-plugin-triggers.sh chassis/scripts/test-merge-plugin-triggers.sh`
  observed: `test-merge-plugin-triggers: 11 passed, 0 failed`. The stat diff shows only `resolve-plugin-root.sh` and `test-plugin-root-resolution.sh` changed - `merge-plugin-triggers.sh` is untouched. The only hits for "resolve-plugin-root" in the merge-trigger files are comment references to the env var it produces, not a call into the resolver, so "unaffected" is accurate rather than coincidentally passing.
  verdict: confirmed

- Disjoint plugin sets in /app/plugins and $CHASSIS_HOME/plugins now resolve to a union, not a branch-order pick
  checked: scenario s11 in test-plugin-root-resolution.sh (image-baked root with angel-protocol+bfl, $CHASSIS_HOME/plugins with midnight-oil, unioned via CHASSIS_IMAGE_PLUGINS_ROOT test seam), part of the 44/44 passing run above; specifically `check "s11 union plugin count" "3"`, `check "s11 image-only plugin present" "yes"`, `check "s11 chassis-home-only plugin present" "yes"` all passed
  observed: all three checks passed (rolled into the 44/0 totals; no individual failure lines were emitted, and the script only prints on failure)
  verdict: confirmed

- plugins-root.state.json now includes a `baked_roots` array listing every contributing baked root
  checked: scenario s11 check `check "s11 state names both baked roots" "2" "$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1]))["baked_roots"]))' "$CUSTOMER/plugins-root.state.json")"`, part of the same passing 44/44 run; also read the diff itself which adds `"baked_roots": baked_roots` to the JSON emitted by write_state's python heredoc
  observed: check passed (length 2, matching the two seeded roots); diff shows the new state field added at chassis/scripts/resolve-plugin-root.sh line ~216
  verdict: confirmed

- CHASSIS_BAKED_PLUGINS_ROOT still overrides to a single explicit root, bypassing the union, unchanged from before
  checked: pre-existing scenarios s1-s7ish in test-plugin-root-resolution.sh use `run_resolver()`, which sets `CHASSIS_BAKED_PLUGINS_ROOT="$BAKED"` and asserts `check "s1 root is baked" "$BAKED" "$RESOLVED_ROOT"`; confirmed via `git diff 9d87a16 7ce64ae -- chassis/scripts/test-plugin-root-resolution.sh` that this test file's diff is pure addition (32 insertions, 0 deletions) so these override-scenario tests are byte-identical to before the PR and still pass; also read the diff's new code path, `if [[ -n "${CHASSIS_BAKED_PLUGINS_ROOT:-}" && -d "${CHASSIS_BAKED_PLUGINS_ROOT}" ]]; then BAKED_ROOTS=("$CHASSIS_BAKED_PLUGINS_ROOT")` which keeps it a single-element array bypassing the else-branch union
  observed: those unmodified scenario checks passed as part of the 44/0 run; diff confirms the override branch short-circuits before the union logic
  verdict: confirmed

NOTES:
Also verified the packet's diff text itself is not a fabrication: `git diff 9d87a16 7ce64ae -- chassis/scripts/resolve-plugin-root.sh` on the real repo is byte-identical to the diff hunk given in the packet, and `gh pr view 178 --repo scrollinondubs/behalfbot` confirms headRefName fix/mo-163 and a PR body independently claiming the same 44/0 and 11/0 numbers, which is corroborating but not itself proof - the proof is the test runs I executed above. All five claims check out against the actual test-runner output on a fresh clone, not against anyone's summary of it. Nothing was skipped; budget was not a constraint here.
```

</details>
