### PR TITLE
fix(image): add pandoc, yt-dlp, youtube-transcript-api, loom-dl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,6 +115,13 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
+# loom-dl — Node CLI that downloads a Loom share URL's mp4 + transcript.
+# Required by the loom-vision plugin; not on Homebrew or apt, ships via npm
+# only, so it installs here right after nodejs rather than in requirements.txt
+# (behalfbot#169).
+RUN npm install -g loom-dl \
+ && npm cache clean --force
+
 # GitHub CLI (gh) - not in Debian default repos so install via the official
 # GitHub Apt repository. Required by any heartbeat that triages issues,
 # manages PRs, or fans out a workflow from inside the container. V1 install
@@ -202,9 +209,11 @@ RUN set -eux; \
 # Used by the notebook-rw.sh script (read renders pages → SVG → PNG; write
 # composes typed-text pages and re-zips the bundle). Installed system-wide
 # so plugin scripts don't need per-user venvs. ImageMagick provides the
-# SVG → PNG raster step.
+# SVG → PNG raster step. pandoc is required by the perplexity-research
+# plugin to build the epub delivered to reMarkable - without it that
+# skill silently degrades (behalfbot#169).
 RUN apt-get update \
- && apt-get install -y --no-install-recommends imagemagick \
+ && apt-get install -y --no-install-recommends imagemagick pandoc \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && pip install --no-cache-dir 'rmscene>=0.6,<1' 'rmc>=0.3,<1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,12 @@
 #   - openai         OpenAI fallback path (TTS, occasional non-Claude calls)
 #   - mcp            official MCP Python SDK - runs the chassis-owned
 #                    `secondbrain` server (chassis/second_brain/mcp_server.py)
+#   - yt-dlp         parse-youtube plugin - video metadata + fallback audio
+#                    download. Ships its own calendar-versioned releases
+#                    (YYYY.M.D), not semver; expect to bump this one more
+#                    often than the rest (behalfbot#169).
+#   - youtube-transcript-api  parse-youtube plugin - transcript fetch
+#                    (behalfbot#169)
 
 pyyaml==6.0.2
 requests==2.32.3
@@ -31,3 +37,5 @@ tzdata==2024.2
 pillow==11.0.0
 openai==1.54.5
 mcp==1.28.1
+yt-dlp==2026.8.19
+youtube-transcript-api==1.2.4


### PR DESCRIPTION
## What

`smoke-test.sh` inside the container currently prints three FAILs, standing since at least rev 0ff75b2:

```
FAIL plugin_loom-vision          [loom-vision] FAIL: loom-dl not in PATH
FAIL plugin_parse-youtube        [parse-youtube] FAIL: youtube_transcript_api not importable
                                 [parse-youtube] WARN: yt-dlp not in PATH - metadata fields will be null
FAIL plugin_perplexity-research  [perplexity-research] FAIL: pandoc not found
```

None of the four tools were in the image - not a regression, a standing hole on every install.

## Fix

- `pandoc` - added to the existing apt block at ~line 207 (the imagemagick/rmscene doc-tooling block).
- `loom-dl` - added via `npm install -g loom-dl` right after the nodejs apt install (~line 113). It's an npm-only CLI (not on Homebrew or apt), so it doesn't belong in either apt block or requirements.txt. Version confirmed available on the npm registry (1.1.1, matching the version the plugin's own docs were verified against) - a clean distributable form existed, so per the issue's proposal this is the "add it" branch, not the "SKIP the validator" branch.
- `yt-dlp` / `youtube-transcript-api` - added to `requirements.txt`, following the file's existing inventory-with-rationale convention. Pinned to current PyPI releases (`yt-dlp==2026.8.19`, `youtube-transcript-api==1.2.4`). Noted in the comment that yt-dlp ships calendar versions and will need more frequent bumps than the rest of the file.

## Verification

I don't have a Docker daemon in this environment, so I couldn't build the image and re-run `smoke-test.sh` locally to paste before/after output as the issue asked. What I did check directly:
- `pip index versions yt-dlp` / `youtube-transcript-api` - both package names and pinned versions resolve on PyPI.
- `npm view loom-dl version` - resolves to `1.1.1` on the npm registry, matching `openclaw.plugin.json`'s documented install command and the version the plugin was built against.
- Package names against the existing Dockerfile conventions (apt block placement, requirements.txt pin style).

This repo's `docker-publish.yml` workflow builds the image on any PR that touches `Dockerfile` (which this one does), so CI is the first real build+install test of this diff - please check that it goes green before merging, since I can't confirm the build succeeds from here.

Closes #169

## Independent verification

Fresh-context verifier (new-jaxity#483). This checker did not inherit the
working session context - it saw the issue, the diff and the asserted
claims, and nothing else.

**Verdict: Confirmed**

Authoritative surface checked: git clone of scrollinondubs/behalfbot at fix/mo-169 (Dockerfile, requirements.txt, plugins/loom-vision/openclaw.plugin.json), customer repo vendored-plugins/parse-youtube/{scripts/parse-youtube.py, openclaw.plugin.json}, PyPI JSON API (pypi.org/pypi/youtube-transcript-api/json and /pypi/yt-dlp/json), npm registry JSON (registry.npmjs.org/loom-dl)

<details><summary>Full verdict</summary>

```
VERDICT: confirmed
SURFACE: git clone of scrollinondubs/behalfbot at fix/mo-169 (Dockerfile, requirements.txt, plugins/loom-vision/openclaw.plugin.json), customer repo vendored-plugins/parse-youtube/{scripts/parse-youtube.py, openclaw.plugin.json}, PyPI JSON API (pypi.org/pypi/youtube-transcript-api/json and /pypi/yt-dlp/json), npm registry JSON (registry.npmjs.org/loom-dl)

EVIDENCE:
- pandoc is added to the apt-get install block that already installs imagemagick, around line 207/214 post-edit.
  checked: git clone --branch fix/mo-169 ...; sed -n '205,220p' Dockerfile
  observed: line 216 reads "apt-get install -y --no-install-recommends imagemagick pandoc" inside the same RUN block that installs rmscene/rmc, with a comment above explaining pandoc is for perplexity-research (behalfbot#169). Line number is 216, not exactly 207/214, but it is the same apt-get block and same edit.
  verdict: confirmed

- loom-dl is installed via npm install -g loom-dl in a new RUN block placed immediately after the nodejs apt install block.
  checked: sed -n '95,125p' Dockerfile
  observed: line 114 installs nodejs via apt, followed by apt cleanup, then a comment block, then line 122 "RUN npm install -g loom-dl" followed by "npm cache clean --force". The new RUN block is the very next statement after the nodejs install finishes.
  verdict: confirmed

- requirements.txt gains yt-dlp==2026.8.19 and youtube-transcript-api==1.2.4.
  checked: tail -20 requirements.txt on the cloned fix/mo-169 branch
  observed: last two lines are yt-dlp==2026.8.19 and youtube-transcript-api==1.2.4, with an inventory comment block above referencing behalfbot#169 for both.
  verdict: confirmed

- youtube-transcript-api (hyphenated) is the correct PyPI distribution name for the youtube_transcript_api Python import used by parse-youtube.
  checked: grep for the import statement in vendored-plugins/parse-youtube/scripts/parse-youtube.py in the customer repo, plus the PyPI JSON API for youtube-transcript-api
  observed: script has "from youtube_transcript_api import YouTubeTranscriptApi" (line 79); PyPI JSON API returns info.name == "youtube-transcript-api" with release 1.2.4 present in the releases list; the plugin's own openclaw.plugin.json independently pins pip install youtube-transcript-api==1.2.4.
  verdict: confirmed

- The loom-dl npm package version 1.1.1 (latest as of this PR) matches what plugins/loom-vision/openclaw.plugin.json documents as the verified version.
  checked: npm registry JSON for loom-dl (live) and plugins/loom-vision/openclaw.plugin.json on fix/mo-169
  observed: npm registry dist-tags.latest == "1.1.1", versions list ends at 1.1.1. Plugin manifest's dependencies.system entry for loom-dl states "Verified against loom-dl 1.1.1, which writes the transcript as <basename>.transcript.json (schemaVersion 1.1.x)."
  verdict: confirmed

NOTES:
All five claims check out against live/authoritative surfaces, not just the diff text: the actual Dockerfile and requirements.txt on the PR branch, the real PyPI and npm registries (queried live, not from memory), and the parse-youtube plugin's own source import statement (found in the customer repo's vendored-plugins/parse-youtube, since parse-youtube and perplexity-research are not part of the behalfbot repo's own plugins/ directory - only loom-vision lives there). One minor imprecision: the working session's claimed line number for pandoc ("around line 207/214") is off by a few lines from the actual line 216 in the cloned file, but it is unambiguously the same apt-get block and the same edit, so this does not rise to a refutation, just a loose line reference.
```

</details>
