### PR TITLE
fix(remarkable): bump pinned rmapi to v0.0.35, fixing upload 400s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,10 +160,18 @@ RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
 # than `latest` so a future upstream change doesn't silently break the
 # image build.
 #
+# v0.0.34 lagged reMarkable's cloud API and every upload returned HTTP
+# 400 (ls/auth still worked, so it looked like a credential problem -
+# behalfbot#175). Upstream cut v0.0.35 on 2026-08-18 from the same
+# master commit that fixed it. The tag can drift again; if uploads
+# start 400ing while `rmapi ls` succeeds, check
+# https://github.com/ddvk/rmapi/tags for a newer release before
+# re-pairing.
+#
 # rmapi releases ship linux-amd64 and linux-arm64 separately. The
 # multi-arch chassis build picks the right asset via $TARGETARCH (set
 # automatically by buildx for each target platform).
-ARG RMAPI_VERSION=v0.0.34
+ARG RMAPI_VERSION=v0.0.35
 ARG TARGETARCH
 RUN set -eux; \
     case "${TARGETARCH}" in \

--- a/plugins/remarkable/scripts/send-to-remarkable.sh
+++ b/plugins/remarkable/scripts/send-to-remarkable.sh
@@ -67,7 +67,7 @@ if [[ ! -x "$RMAPI" ]]; then
     echo "ERR: rmapi binary not found at $RMAPI" >&2
     echo "  Install with:" >&2
     echo "    curl -sSL -o /tmp/rmapi.zip \\" >&2
-    echo "      https://github.com/ddvk/rmapi/releases/download/v0.0.34/rmapi-macos-arm64.zip" >&2
+    echo "      https://github.com/ddvk/rmapi/releases/download/v0.0.35/rmapi-macos-arm64.zip" >&2
     echo "    cd /tmp && unzip rmapi.zip && mv rmapi $RMAPI && chmod +x $RMAPI" >&2
     exit 2
 fi
@@ -90,4 +90,8 @@ if "$RMAPI" put "$LOCAL_FILE" "$REMOTE_PATH" >&2; then
     exit 0
 fi
 echo "ERR: rmapi upload failed (network / API / unknown)" >&2
+echo "  If \`$RMAPI ls /\` above succeeded but this put returned HTTP 400," >&2
+echo "  the binary is stale, not the auth (behalfbot#175). Do NOT re-pair -" >&2
+echo "  check https://github.com/ddvk/rmapi/releases for a tag newer than" >&2
+echo "  what is installed (\`$RMAPI version\`) and reinstall from that." >&2
 exit 4


### PR DESCRIPTION
## Problem

Every `send-to-remarkable.sh` upload has been failing with HTTP 400 since the pinned rmapi tag drifted behind reMarkable's cloud API (#175). `rmapi ls` still works, so the exit-4 failure looks like an auth problem, but it isn't - the client binary is stale.

## Fix

Upstream (`ddvk/rmapi`) cut `v0.0.35` on 2026-08-18 from the exact `master` commit the issue confirmed fixes uploads (verified: `git ls-remote` and the release tag point at the same SHA, `74a8e2e`). This bumps the Docker image's pinned `RMAPI_VERSION` from `v0.0.34` to `v0.0.35`, which has linux-amd64/arm64 release assets - no new build stage or vendoring needed.

Also:
- Points the exit-2 "binary missing" install fallback in `send-to-remarkable.sh` at the same tag.
- Adds guidance to the exit-4 branch: if `rmapi ls` succeeds but `put` returns 400, the binary is stale - check for a newer tag and reinstall, don't re-pair.

## Not done here

The issue's suggestion #3 (a startup/smoke-test round-trip check) is left for a follow-up - out of scope for this fix and would need real reMarkable credentials to validate, which this sandbox doesn't have.

## Verification

- Downloaded the `v0.0.35` linux-arm64 release asset directly from GitHub and ran `./rmapi version` - runs cleanly, prints `v0.0.35`.
- `bash -n` on the edited script - syntax OK.
- Confirmed via `gh api repos/ddvk/rmapi/tags` and `.../commits/master` that the `v0.0.35` tag SHA equals current `master` HEAD.

Closes #175

## Independent verification

Fresh-context verifier (new-jaxity#483). This checker did not inherit the
working session context - it saw the issue, the diff and the asserted
claims, and nothing else.

**Verdict: Confirmed**

Authoritative surface checked: git ls-remote against github.com/ddvk/rmapi.git (tags/heads), GitHub Releases API for the v0.0.35 tag (api.github.com/repos/ddvk/rmapi/releases/tags/v0.0.35), the actual v0.0.35 linux-arm64 release asset downloaded and executed, the cloned fix/mo-175 Dockerfile on disk, HTTP HEAD against the release download URLs, bash -n against the cloned send-to-remarkable.sh on disk

<details><summary>Full verdict</summary>

```
VERDICT: confirmed
SURFACE: git ls-remote against github.com/ddvk/rmapi.git (tags/heads), GitHub Releases API for the v0.0.35 tag (api.github.com/repos/ddvk/rmapi/releases/tags/v0.0.35), the actual v0.0.35 linux-arm64 release asset downloaded and executed, the cloned fix/mo-175 Dockerfile on disk, HTTP HEAD against the release download URLs, bash -n against the cloned send-to-remarkable.sh on disk

EVIDENCE:
- The v0.0.35 tag points at the exact same commit SHA as current master HEAD.
  checked: `git ls-remote --tags --heads https://github.com/ddvk/rmapi.git`
  observed: `74a8e2ec7f324655ef3a3890936ed78e6e13ee51  refs/heads/master` and `74a8e2ec7f324655ef3a3890936ed78e6e13ee51  refs/tags/v0.0.35` (v0.0.34 tag SHA is `0a69a608b22f5c11dff07254a7e30b45f2c041f7`, different)
  verdict: confirmed

- The v0.0.35 GitHub release has linux-amd64 and linux-arm64 tarball assets.
  checked: `curl -fsSL https://api.github.com/repos/ddvk/rmapi/releases/tags/v0.0.35`
  observed: asset names include `"rmapi-linux-amd64.tar.gz"` and `"rmapi-linux-arm64.tar.gz"`
  verdict: confirmed

- Downloading and running the v0.0.35 linux-arm64 binary succeeds and prints "v0.0.35" for `rmapi version`.
  checked: `curl -fsSL -o rmapi.tar.gz https://github.com/ddvk/rmapi/releases/download/v0.0.35/rmapi-linux-arm64.tar.gz && tar -xzf rmapi.tar.gz && ./rmapi version` (host arch confirmed `aarch64` via `uname -m`, matching the asset)
  observed: download exit 0, extracted binary present, `./rmapi version` printed `v0.0.35`, run exit 0
  verdict: confirmed

- Dockerfile ARG RMAPI_VERSION is now v0.0.35 (was v0.0.34) and the URL template still resolves for both amd64 and arm64 assets.
  checked: `grep -n "RMAPI_VERSION" Dockerfile` on the cloned fix/mo-175 branch, plus `curl -fsSL -o /dev/null -w "%{http_code}" -I` against both release download URLs built from that same template
  observed: `ARG RMAPI_VERSION=v0.0.35` on line 174, case block maps amd64/arm64 to `rmapi-linux-amd64.tar.gz` / `rmapi-linux-arm64.tar.gz` and feeds `${RMAPI_VERSION}/${rmapi_asset}` into the download URL; HEAD requests against the resulting amd64 and arm64 URLs both returned HTTP 200
  verdict: confirmed

- plugins/remarkable/scripts/send-to-remarkable.sh passes `bash -n` syntax validation after the edits.
  checked: `bash -n plugins/remarkable/scripts/send-to-remarkable.sh` on the cloned fix/mo-175 branch
  observed: exit code 0, no output
  verdict: confirmed

NOTES:
All five claims checked out against live, independent surfaces (upstream git refs, GitHub Releases API, an actual downloaded-and-executed binary, the cloned PR-branch Dockerfile, live HTTP HEAD checks, and bash -n on the cloned script). No surface was ambiguous and nothing required trusting the working session's own account. One caveat outside the claim list: the diff's comment claims "Upstream cut v0.0.35 on 2026-08-18" and the release page's HTTP Last-Modified on the binary downloaded showed 2026-08-19 - a one-day discrepancy that does not affect any of the five listed claims (none of them assert the exact cut date), so it does not change the verdict, but a reviewer chasing that specific date in the Dockerfile comment should know it wasn't independently re-verified here.
```

</details>
