### PR TITLE
fix(image): make /home/chassis ownership explicit, not cache-dependent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -316,6 +316,22 @@ RUN if [ "${INSTALLER_UID}" != "${MACOS_INSTALLER_UID}" ]; then \
 # Bring in rbw from the builder stage.
 COPY --from=rbw-builder /rbw-out/bin/rbw /usr/local/bin/rbw
 
+# /home/chassis ownership, made explicit rather than assumed.
+# `useradd --create-home` above only takes ownership of the home dir if it
+# does not already exist. #180 moved the loom-dl npm install (behalfbot#169)
+# earlier in this file, and that RUN executes as root with HOME=/home/chassis
+# before useradd runs - npm creates /home/chassis as root to hold its cache,
+# useradd then finds the dir already there and leaves it root-owned. The
+# chassis user's own installs into $HOME below (bun, uv, npm -g claude-code)
+# then fail, e.g. `mkdir: cannot create directory '/home/chassis/.bun':
+# Permission denied` (behalfbot#181). This was masked on main by Docker layer
+# cache reuse across builds, not by the Dockerfile actually being correct -
+# a fresh `--no-cache` build reproduces it every time. Do not fix this by
+# reordering loom-dl back down the file; that only restores the cache
+# accident. chown it explicitly instead so ownership doesn't depend on
+# install order or cache state.
+RUN mkdir -p /home/chassis && chown -R chassis:chassis /home/chassis
+
 # Drop privileges for all subsequent tool installs so npm/bun caches land
 # in chassis user's home.
 USER chassis


### PR DESCRIPTION
## Problem

\`main\` cannot publish an image since PR #180. \`gh run view --log-failed\` shows:

\`\`\`
mkdir: cannot create directory '/home/chassis/.bun': Permission denied
\`\`\`

## Root cause

\`useradd --create-home\` only takes ownership of the home directory if it does
not already exist. #180 moved the \`loom-dl\` npm install (behalfbot#169) earlier
in the Dockerfile, and that \`RUN\` executes as root with \`HOME=/home/chassis\`
before \`useradd\` runs. npm pre-creates \`/home/chassis\` as root to hold its
cache; \`useradd\` then finds the directory already there and leaves it
root-owned. The chassis user's own installs into \`\$HOME\` below (bun, uv,
\`npm -g @anthropic-ai/claude-code\`) then fail with EACCES.

This was masked on \`main\` by Docker layer cache reuse across builds, not by
the Dockerfile actually being correct - a fresh \`--no-cache\` build reproduces
it every time.

## Fix

\`RUN mkdir -p /home/chassis && chown -R chassis:chassis /home/chassis\` right
before dropping to the \`chassis\` user, so ownership is explicit and doesn't
depend on install order or cache state. Did not reorder \`loom-dl\` back down
the file - that would only restore the cache accident that hid the bug.

Closes #181

🤖 Generated with Midnight Oil

## Independent verification

Fresh-context verifier (new-jaxity#483). This checker did not inherit the
working session context - it saw the issue, the diff and the asserted
claims, and nothing else.

**Verdict: Confirmed**

Authoritative surface checked: cloned Dockerfile on fix/mo-181 (700567a), GitHub Actions run 32681905149 job log for "Build + publish chassis image" on PR #184, gh pr checks 184, main branch Dockerfile at origin/main (208ecc2), gh run list for the workflow on branch main, gh pr list --state open + gh pr diff --name-only for each open PR

<details><summary>Full verdict</summary>

```
VERDICT: confirmed
SURFACE: cloned Dockerfile on fix/mo-181 (700567a), GitHub Actions run 32681905149 job log for "Build + publish chassis image" on PR #184, gh pr checks 184, main branch Dockerfile at origin/main (208ecc2), gh run list for the workflow on branch main, gh pr list --state open + gh pr diff --name-only for each open PR

EVIDENCE:
- PR #184's added `RUN mkdir -p /home/chassis && chown -R chassis:chassis /home/chassis` fixes the "mkdir: cannot create directory '/home/chassis/.bun': Permission denied" build failure from issue #181.
  checked: `gh run view --job=97299924446 --repo scrollinondubs/behalfbot --log` (job for run 32681905149, PR #184, head sha 700567a)
  observed: `#33 0.204 useradd: warning: the home directory /home/chassis already exists.` (confirms npm pre-created it as root, matching the PR's stated root cause) followed by `#36 [linux/amd64 stage-1 15/27] RUN mkdir -p /home/chassis && chown -R chassis:chassis /home/chassis` executing, then `#38 [linux/amd64 stage-1 17/27] RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.1.34"` with `#38 1.726 bun was installed successfully to ~/.bun/bin/bun`. The same sequence repeats cleanly for linux/arm64 (`#61 5.852 bun was installed successfully to ~/.bun/bin/bun`). No "Permission denied" appears anywhere in the log except inside a quoted PR-body string (the issue's own repro text), and the job conclusion is `success`.
  verdict: confirmed

- The "Build + publish chassis image" CI check on PR #184 (run 32681905149) passed on a cache-invalidated build of the changed layers, not a fully-cached no-op build.
  checked: `gh run view 32681905149 --repo scrollinondubs/behalfbot --json ...` for identity, plus `grep -c CACHED` / `grep -c "\[linux/amd64 stage-1"` over the same job log
  observed: run identity confirmed as workflow "Build + publish chassis image", event pull_request, headBranch fix/mo-181, headSha 700567a (PR #184's only commit), conclusion success. Of 38 linux/amd64 stage-1 steps, only 3 lines anywhere in the whole log are tagged `CACHED` (`#16 CACHED`, `#17 CACHED`, `#18 CACHED`), all near the very start of the build (before the useradd/mkdir/chown/bun sequence at steps #33-#41). The new chown step (#36) and everything after it, including bun, uv, claude-code, and the arm64 platform pass, show live execution output (timing, install messages), not CACHED markers.
  verdict: confirmed

- No other open PR or main-branch change already fixed this same failure before #184.
  checked: `git show origin/main:Dockerfile | grep "mkdir -p /home/chassis && chown -R chassis:chassis"`; `gh run list --repo scrollinondubs/behalfbot --branch main --workflow "Build + publish chassis image"`; `gh pr list --repo scrollinondubs/behalfbot --state open`; `gh pr diff <n> --name-only` for each other open PR
  observed: the fix line is absent from origin/main's Dockerfile (grep exit 1, main HEAD is 208ecc2, PR #184's base). The three most recent pushes to main (208ecc2, 2ea4d17, 6707d8f) all show `"conclusion":"failure"` for that workflow. Only 4 PRs are open total: #184 (this one), #156, #81, #75. `gh pr diff --name-only` for 156/81/75 shows none touch `Dockerfile` (156 touches only HEARTBEATS.md.template/gather-container-liveness.sh etc; 81 touches daily-log/health-gather scripts; 75 touches plugin-pull machinery, bootstrap.sh, entrypoint.sh - no Dockerfile in any).
  verdict: confirmed

NOTES:
All three claims check out against primary sources: the actual CI job log (not just its pass/fail status) shows the exact failure mechanism reproducing and then resolving step-by-step, the layer-cache evidence in that same log rules out a no-op cached pass, and both the main branch tip and every other open PR's file list rule out a prior fix. Nothing here required trusting the PR author's summary - the useradd warning, the chown step execution, and the successful bun install were all read directly out of the run log.
```

</details>
