### PR TITLE
executor: bake app commit SHA + build timestamp into /healthz

### DIFF
--- a/cloudflare/executor/Dockerfile
+++ b/cloudflare/executor/Dockerfile
@@ -75,6 +75,11 @@ COPY --chown=executor:executor build-context/vibecodelisboa /app/vibecodelisboa
 # along is harmless and keeps the rule simple.
 COPY --chown=executor:executor container/ /app/
 
+# Build identity (issue #173): appCommit + builtAt, written by build.sh
+# before it strips vibecodelisboa's .git. /healthz reads this at runtime
+# so "what is this executor running" is a curl, not a wrangler login.
+COPY --chown=executor:executor build-context/build-info.json /app/build-info.json
+
 USER executor
 WORKDIR /app
 

--- a/cloudflare/executor/build.sh
+++ b/cloudflare/executor/build.sh
@@ -33,6 +33,12 @@ git clone --depth 1 \
   "https://x-access-token:${GITHUB_PAT}@github.com/scrollinondubs/vibecodelisboa.git" \
   "${REPO_DIR}"
 
+echo "[build] recording build identity (issue #173) before .git is scrubbed..."
+APP_COMMIT="$(git -C "${REPO_DIR}" rev-parse --short=7 HEAD)"
+BUILT_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf '{"appCommit":"%s","builtAt":"%s"}\n' "${APP_COMMIT}" "${BUILT_AT}" \
+  > "${CONTEXT_DIR}/build-info.json"
+
 echo "[build] scrubbing git metadata + any env files..."
 rm -rf "${REPO_DIR}/.git"
 find "${REPO_DIR}" -maxdepth 2 -name ".env*" -type f -delete

--- a/cloudflare/executor/container/server.mjs
+++ b/cloudflare/executor/container/server.mjs
@@ -18,10 +18,22 @@
 
 import { createServer } from 'node:http'
 import { spawn } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import { preScanPromotedARow } from './prescan-outcome.mjs'
 
 const PORT = 8080
 const REPO_ROOT = '/app/vibecodelisboa'
+
+// Written by build.sh (issue #173) before it strips vibecodelisboa's .git.
+// Absent on a local/dev run that skipped build.sh - healthz still answers,
+// just with null identity, rather than crashing the shim.
+let buildInfo = { appCommit: null, builtAt: null }
+try {
+  buildInfo = JSON.parse(readFileSync('/app/build-info.json', 'utf8'))
+} catch {
+  console.log(JSON.stringify({ event: 'build_info_missing' }))
+}
+
 const TICK_SCRIPT = 'scripts/behalfbot-heartbeat.ts'
 // Belt-and-braces above the executor's own 25-min CLI timeout and 30-min
 // row wallclock cap. If tsx itself wedges, kill it.
@@ -99,7 +111,12 @@ const server = createServer((req, res) => {
   }
 
   if (req.method === 'GET' && req.url === '/healthz') {
-    return respond(200, { ok: true, inFlight: inFlight !== null })
+    return respond(200, {
+      ok: true,
+      inFlight: inFlight !== null,
+      appCommit: buildInfo.appCommit,
+      builtAt: buildInfo.builtAt,
+    })
   }
 
   if (req.method === 'GET' && req.url === '/status') {


### PR DESCRIPTION
## What

Slice 1 of #173, as scoped by the queueing comment on that issue: bake the
`vibecodelisboa` commit SHA and build timestamp into the executor image and
return both from `/healthz`.

- `build.sh` captures the SHA (`git rev-parse --short=7`) and a UTC build
  timestamp right after the shallow clone of `vibecodelisboa`, before `.git`
  is stripped, and writes them to `build-context/build-info.json`.
- `Dockerfile` copies that file into the image at `/app/build-info.json`.
- `container/server.mjs` reads it at startup (falls back to `null` fields if
  missing, e.g. a local run that skipped `build.sh`) and returns it from
  `/healthz`:

  ```
  {"ok":true,"inFlight":false,"appCommit":"5373e25","builtAt":"2026-08-19T13:27:00Z"}
  ```

## Explicitly out of scope

Per the queueing comment on #173: slices 2 (drift alarm), 3
(deploy-on-merge), and 4 (docs pass on "the image" ambiguity) are not in this
PR and stay open on the issue. Not closing #173.

## Caveat

**This does not fix executor drift by itself.** It's inert until someone runs
a Cloudflare deploy of the executor - same shape as new-jaxity#453
(correct code, waiting on a deploy), not the micro-adventures#172 shape where
merged code was actively wrong in prod. `/healthz` keeps returning the old
`{"ok":true}` shape until that deploy happens.

## Testing

- `node --check container/server.mjs` and `bash -n build.sh` both clean.
- Ran `server.mjs` standalone against a stub `build-info.json` and confirmed
  `/healthz` returns the exact shape shown above.
- Could not do a full `docker build` here - no `GITHUB_PAT` for the private
  `vibecodelisboa` clone in this environment - so the Dockerfile `COPY` path
  is reviewed but not build-tested. Acceptance criteria from the issue
  (build locally, curl `/healthz`, confirm `appCommit` matches the SHA
  actually cloned) still needs a run with real deploy credentials.

🤖 Generated by Jax (midnight oil)

## Independent verification

Fresh-context verifier (new-jaxity#483). This checker did not inherit the
working session context - it saw the issue, the diff and the asserted
claims, and nothing else.

**Verdict: Confirmed**

Authoritative surface checked: cloudflare/executor/container/server.mjs (cloned fix/mo-173, read directly + node --check), cloudflare/executor/build.sh (cloned fix/mo-173, read directly + bash -n), cloudflare/executor/Dockerfile (cloned fix/mo-173, read directly)

<details><summary>Full verdict</summary>

```
VERDICT: confirmed
SURFACE: cloudflare/executor/container/server.mjs (cloned fix/mo-173, read directly + node --check), cloudflare/executor/build.sh (cloned fix/mo-173, read directly + bash -n), cloudflare/executor/Dockerfile (cloned fix/mo-173, read directly)

EVIDENCE:
- /healthz now returns appCommit and builtAt in addition to ok and inFlight
  checked: `sed -n '107,120p' cloudflare/executor/container/server.mjs` on the cloned fix/mo-173 branch
  observed: lines 113-119 show `if (req.method === 'GET' && req.url === '/healthz') { return respond(200, { ok: true, inFlight: inFlight !== null, appCommit: buildInfo.appCommit, builtAt: buildInfo.builtAt, }) }`
  verdict: confirmed

- node --check on server.mjs passes with no syntax errors
  checked: `node --check cloudflare/executor/container/server.mjs`
  observed: command exited 0, printed "NODE_CHECK_OK" with no error output
  verdict: confirmed

- bash -n on build.sh passes with no syntax errors
  checked: `bash -n cloudflare/executor/build.sh`
  observed: command exited 0, printed "BASH_N_OK" with no error output
  verdict: confirmed

- build.sh captures APP_COMMIT and BUILT_AT and writes build-context/build-info.json before rm -rf of .git
  checked: `grep -n "REPO_DIR\|CONTEXT_DIR\|build-info\|rm -rf.*\.git\|APP_COMMIT\|BUILT_AT" cloudflare/executor/build.sh`
  observed: line 37 `APP_COMMIT="$(git -C "${REPO_DIR}" rev-parse --short=7 HEAD)"`, line 38 `BUILT_AT=...`, lines 39-40 write to `"${CONTEXT_DIR}/build-info.json"`, and only at line 43 does `rm -rf "${REPO_DIR}/.git"` occur - the write precedes the .git removal in file order and in a straight-line script with no branches/jumps between them
  verdict: confirmed

- Dockerfile COPY for build-context/build-info.json targets /app/build-info.json, matching server.mjs's readFileSync path
  checked: `grep -n "build-info\|build-context\|WORKDIR /app\|COPY" cloudflare/executor/Dockerfile` and `grep -n "readFileSync" cloudflare/executor/container/server.mjs`
  observed: Dockerfile line 81 `COPY --chown=executor:executor build-context/build-info.json /app/build-info.json`; server.mjs line 32 `buildInfo = JSON.parse(readFileSync('/app/build-info.json', 'utf8'))` - paths match exactly
  verdict: confirmed

- server.mjs handles a missing /app/build-info.json gracefully via try/catch rather than crashing
  checked: `sed -n '27,35p' cloudflare/executor/container/server.mjs`
  observed: `let buildInfo = { appCommit: null, builtAt: null }` followed by `try { buildInfo = JSON.parse(readFileSync(...)) } catch { console.log(JSON.stringify({ event: 'build_info_missing' })) }` - a missing file (ENOENT from readFileSync) is caught, buildInfo stays at its null-valued default, and module load continues rather than throwing
  verdict: confirmed

NOTES:
All six claims are statements about what the code in the diff does, and the diff plus the checked-out source at fix/mo-173 is the authoritative surface for that class of claim (per the packet's own rule: the diff is authoritative for what the code does, not for what it achieves). None of the six claims assert an achieved outcome (e.g. "fixes the drift-visibility problem in production," "the deployed executor now reports its commit") - they are all mechanical, code-level assertions (fields present, syntax valid, write-before-delete ordering, path match, catch present), so checking the source directly is sufficient and no live endpoint or deployment check was needed to settle them. I did not attempt to build the Docker image or run the container, since none of the six claims require that - they are all satisfiable by static inspection of the three changed files, which I did against a fresh clone of the actual PR branch rather than the diff text alone.
```

</details>
