### PR TITLE
fix(executor): report build identity from the Worker /healthz

### DIFF
--- a/cloudflare/executor/README.md
+++ b/cloudflare/executor/README.md
@@ -107,8 +107,15 @@ fails closed instead of deploying to the wrong account.
 1. **Build**: `GITHUB_PAT=... ./build.sh` (stages build-context), then
    `npm install` here.
 2. **Secrets**: `wrangler secret put` the six names above.
-3. **Deploy**: `wrangler deploy` (builds the image via local Docker,
-   pushes to the Cloudflare-managed registry, deploys Worker + container).
+3. **Deploy**: `./deploy.sh` (builds the image via local Docker, pushes to
+   the Cloudflare-managed registry, deploys Worker + container). Use the
+   script, not a bare `wrangler deploy`: it reads `appCommit`/`builtAt` out
+   of `build-context/build-info.json` and passes them to the Worker as
+   vars, so `GET /healthz` reports which app commit is live (issue #173)
+   without waking a container. A bare `wrangler deploy` still works and
+   still ships correct code, but /healthz then answers
+   `appCommit: null` and the executor-drift heartbeat reports a deploy
+   owed.
 4. **Smoke test**: seed a test ask on a throwaway repo, `curl -X POST
    .../trigger -H "Authorization: Bearer ..."`, watch `GET /status` until
    the tick completes, confirm the PR opens and the queue row lands in

--- a/cloudflare/executor/build.sh
+++ b/cloudflare/executor/build.sh
@@ -15,7 +15,11 @@
 # Usage:
 #   GITHUB_PAT=... ./build.sh
 # Then, deploy-gated on Sean's approval:
-#   CLOUDFLARE_API_TOKEN=... npx wrangler deploy   # DO NOT run without approval
+#   CLOUDFLARE_API_TOKEN=... ./deploy.sh   # DO NOT run without approval
+#
+# Use deploy.sh rather than calling wrangler directly. It passes the
+# appCommit/builtAt recorded below to the Worker as vars so /healthz can
+# report them without waking the container (issue #173).
 
 set -euo pipefail
 
@@ -50,4 +54,4 @@ find "${REPO_DIR}" -maxdepth 2 -name ".env*" -type f -delete
 # instead, so platform-specific optional deps resolve for the container.
 
 echo "[build] build-context ready: ${REPO_DIR}"
-echo "[build] next (GATED ON SEAN'S APPROVAL): CLOUDFLARE_API_TOKEN in env, then 'npx wrangler deploy' from ${SCRIPT_DIR}"
+echo "[build] next (GATED ON SEAN'S APPROVAL): CLOUDFLARE_API_TOKEN in env, then './deploy.sh' from ${SCRIPT_DIR}"

--- a/cloudflare/executor/deploy.sh
+++ b/cloudflare/executor/deploy.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Deploy the executor Worker + container with build identity attached
+# (issues #173 / #185).
+#
+# Why this exists rather than a bare `npx wrangler deploy`:
+#
+# build.sh bakes appCommit/builtAt into the image, and the container
+# reports them on its own /healthz. But the Worker answers /healthz itself
+# and never forwards that path, on purpose, so a liveness probe cannot wake
+# a standard-1 instance. That left the fields unreachable: the
+# executor-drift monitor polls the Worker and always saw {"ok":true}, so it
+# reported "deploy owed" even immediately after a deploy.
+#
+# The fix is to hand the same two values to the Worker as plain vars, which
+# it returns from /healthz for free. This script is the thing that keeps
+# the image and the Worker reporting the same commit, so use it instead of
+# calling wrangler directly.
+#
+# Usage:
+#   GITHUB_PAT=... ./build.sh          # stages build-context/, writes build-info.json
+#   CLOUDFLARE_API_TOKEN=... ./deploy.sh
+#
+# The API token is the account-owned "behalfbot-fable-cf-containers" item in
+# Vaultwarden. The ambient CLOUDFLARE_API_TOKEN in the Jax install env
+# belongs to the AllBets account and targets the WRONG account; the
+# account_id pin in wrangler.jsonc forces the right one regardless, but
+# check `npx wrangler whoami` if a deploy looks odd.
+#
+# DO NOT run without Sean's explicit approval.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_INFO="${SCRIPT_DIR}/build-context/build-info.json"
+
+if [[ ! -f "$BUILD_INFO" ]]; then
+  echo "deploy: ${BUILD_INFO} is missing. Run build.sh first." >&2
+  echo "deploy: refusing to ship a build with no provenance - that is the" >&2
+  echo "        exact failure #173 exists to prevent." >&2
+  exit 1
+fi
+
+APP_COMMIT="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["appCommit"])' "$BUILD_INFO")"
+BUILT_AT="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["builtAt"])' "$BUILD_INFO")"
+
+if [[ -z "$APP_COMMIT" || -z "$BUILT_AT" ]]; then
+  echo "deploy: build-info.json has no appCommit/builtAt. Re-run build.sh." >&2
+  exit 1
+fi
+
+echo "[deploy] app commit ${APP_COMMIT}, built ${BUILT_AT}"
+
+cd "$SCRIPT_DIR"
+exec npx wrangler deploy \
+  --var "APP_COMMIT:${APP_COMMIT}" \
+  --var "BUILT_AT:${BUILT_AT}" \
+  "$@"

--- a/cloudflare/executor/package.json
+++ b/cloudflare/executor/package.json
@@ -4,7 +4,8 @@
   "description": "Worker + Container scaffold for the Behalf.bot executor (behalfbot#41, behalfbot#66). Deploy is gated on Sean's approval.",
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "build-context": "bash build.sh"
+    "build-context": "bash build.sh",
+    "deploy": "bash deploy.sh"
   },
   "dependencies": {
     "@cloudflare/containers": "^0.3.7"

--- a/cloudflare/executor/src/index.ts
+++ b/cloudflare/executor/src/index.ts
@@ -29,6 +29,15 @@ interface Env {
   // module load (resend-client constructs at import time) AFTER the PR has
   // shipped, retroactively marking completed jobs failed (#73).
   RESEND_API_KEY: string
+  // Build identity (issue #173). Set as plain vars at deploy time by
+  // deploy.sh, which reads them out of build-context/build-info.json so
+  // the Worker and the container image always report the same commit.
+  // Optional on purpose: a hand-rolled `wrangler deploy` that skips
+  // deploy.sh leaves them undefined and /healthz answers null, which is
+  // what the executor-drift monitor should see. A deploy with no
+  // provenance must look like a deploy with no provenance.
+  APP_COMMIT?: string
+  BUILT_AT?: string
 }
 
 export class ExecutorContainer extends Container<Env> {
@@ -61,8 +70,20 @@ export default {
 
     // Unauthenticated liveness probe for the Worker itself (does not wake
     // the container).
+    //
+    // It also carries build identity (issue #173). The container answers
+    // the same fields on its own /healthz, but nothing routes to that
+    // path: this handler returns before any container.fetch, deliberately,
+    // so a probe never wakes a standard-1 instance. Reading the vars here
+    // keeps the endpoint free and unauthenticated while still making
+    // "which app commit is live" answerable, which is the whole point of
+    // #173. Deploying without deploy.sh yields nulls rather than a lie.
     if (request.method === 'GET' && url.pathname === '/healthz') {
-      return Response.json({ ok: true })
+      return Response.json({
+        ok: true,
+        appCommit: env.APP_COMMIT ?? null,
+        builtAt: env.BUILT_AT ?? null,
+      })
     }
 
     const auth = request.headers.get('authorization') ?? ''


### PR DESCRIPTION
## The bug

#185 baked `appCommit`/`builtAt` into the container image and exposed them from the **container's** `/healthz` (`container/server.mjs:113`). The `executor-drift` monitor added in new-jaxity#540 polls the **Worker's** `/healthz`. Those are two different handlers and nothing connects them.

`src/index.ts:64` returns `{ok:true}` for `/healthz` before any `container.fetch`, deliberately, so a liveness probe never wakes a `standard-1` instance. It never forwards the path. So the baked fields were unreachable from outside, and the monitor reported "deploy owed" regardless of how current the deploy was.

Confirmed today the hard way: I deployed current `vibecodelisboa@main` (`a67bf5a`), the image moved `ce7c5457` to `bf27817b`, and the gather still alerted. The alert would have fired hourly, forever, and always been wrong.

## The fix

Pass the same two values to the Worker as plain vars at deploy time. `/healthz` then reports them for free: still unauthenticated, still no container wake, no extra request.

`deploy.sh` reads them out of the `build-context/build-info.json` that `build.sh` already writes. That is what keeps the image and the Worker reporting the same commit rather than two independently-stamped values that can disagree.

The vars are **optional** in `Env` on purpose. A bare `wrangler deploy` that skips `deploy.sh` still ships correct code, but leaves them undefined and `/healthz` answers `appCommit: null` - which is exactly what the monitor should see. A deploy with no provenance must look like a deploy with no provenance, not like a healthy one.

`deploy.sh` also refuses to run at all if `build-info.json` is missing.

## Alternative considered and rejected

Forwarding `/healthz` to the container. It defeats the reason the Worker answers that path itself, and it wakes a `standard-1` container every hour for a liveness probe.

## Verification

Deployed through the new path, then:

```
GET /healthz
{"ok":true,"appCommit":"a67bf5a","builtAt":"2026-08-27T12:27:21Z"}

gather-executor-drift.sh
{"count": 0, "issues": [], "app_commit": "a67bf5a", "main_sha": "a67bf5a", "built_at": "2026-08-27T12:27:21Z", "ahead_by": 0}
```

`npx tsc --noEmit` clean. Live version ID `39d59c5c-a919-412c-9b76-fb9c83fd7eea`.

## Note

The deploy is already live on Sean's approval. This PR is the code that produced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FvcJzuJAfMrMfE7tNDRhZ