### PR TITLE
docs(executor): the ambient AllBets token trap is gone, say so

### DIFF
--- a/cloudflare/executor/README.md
+++ b/cloudflare/executor/README.md
@@ -88,9 +88,13 @@ only (Workers Scripts:Edit, Workers Containers:Edit, Cloudchamber:Edit,
 Workers R2 Storage:Edit, Account Settings:Read). Wrangler reads it from
 the `CLOUDFLARE_API_TOKEN` env var; it is never hardcoded anywhere.
 
-**Trap:** the ambient `CLOUDFLARE_API_TOKEN` in the Jax install
-environment belongs to the AllBets account. Every deploy shell must
-override it from Vaultwarden first:
+**History:** the Jax install environment used to carry an ambient
+`CLOUDFLARE_API_TOKEN` belonging to the AllBets account, which shadowed
+this one. It was removed from the Vaultwarden hydration manifest on
+2026-08-19 (post-mortem `docs/postmortems/2026-08-19-executor-stale-since-july.md`
+in new-jaxity) and `.env` / `.env.baked` carry no `CLOUDFLARE_*` key as of
+2026-08-30. Every deploy shell still exports it from Vaultwarden - that is
+now the only source, not an override:
 
 ```bash
 export BW_SESSION="$(bash /Users/jax/.behalfbot/scripts/bw-unlock.sh)"

--- a/cloudflare/executor/README.md
+++ b/cloudflare/executor/README.md
@@ -1,8 +1,24 @@
 # Behalf.bot executor on Cloudflare Containers
 
 Scaffold for behalfbot#41 (executor off the Mac mini) and the shared
-foundation for behalfbot#66 (VCL support agent). **Nothing here is
-deployed.** Deploy and cutover are gated on Sean's explicit approval.
+foundation for behalfbot#66 (VCL support agent).
+
+**This is live.** It shipped 2026-07-16 and has been the production
+execution path since. The line that used to
+sit here said "nothing here is deployed", which stayed on the page for six
+weeks after the cutover and is part of why a month-old build ran unnoticed
+(see the post-mortem linked below). Each deploy still needs Sean's explicit
+approval - that gate is real, it is just not the same claim as "unshipped".
+
+Ask what is running rather than reading this file for it:
+
+```bash
+curl -s https://behalfbot-executor.sean-8a1.workers.dev/healthz
+# {"ok":true,"appCommit":"<vibecodelisboa sha>","builtAt":"<utc>"}
+```
+
+Post-mortem on the stale build: `docs/postmortems/2026-08-19-executor-stale-since-july.md`
+in `scrollinondubs/new-jaxity`.
 
 Go/no-go analysis: [docs/cloudflare-containers-eval.md](../../docs/cloudflare-containers-eval.md).
 Verdict: GO-WITH-CAVEAT (no enforced duration cap; host restarts covered by

--- a/cloudflare/executor/deploy.sh
+++ b/cloudflare/executor/deploy.sh
@@ -21,10 +21,12 @@
 #   CLOUDFLARE_API_TOKEN=... ./deploy.sh
 #
 # The API token is the account-owned "behalfbot-fable-cf-containers" item in
-# Vaultwarden. The ambient CLOUDFLARE_API_TOKEN in the Jax install env
-# belongs to the AllBets account and targets the WRONG account; the
-# account_id pin in wrangler.jsonc forces the right one regardless, but
-# check `npx wrangler whoami` if a deploy looks odd.
+# Vaultwarden. There is no ambient CLOUDFLARE_API_TOKEN in the Jax install
+# env any more - the AllBets mapping that used to shadow this one was
+# removed on 2026-08-19 (verified again 2026-08-30), so the export is now
+# the only source rather than an override. The account_id pin in
+# wrangler.jsonc forces the right account regardless, but check
+# `npx wrangler whoami` if a deploy looks odd.
 #
 # DO NOT run without Sean's explicit approval.
 

--- a/cloudflare/executor/wrangler.jsonc
+++ b/cloudflare/executor/wrangler.jsonc
@@ -5,12 +5,14 @@
 // "behalfbot-fable-cf-containers", stored in Vaultwarden). The token is
 // never written to this repo or baked into any file.
 //
-// AUTH TRAP: the ambient CLOUDFLARE_API_TOKEN in the Jax install env
-// (.env.baked) belongs to the AllBets account and targets the WRONG
-// account. Before any wrangler call, export the Vaultwarden token per
-// README.md and confirm `wrangler whoami` shows account
-// 8a119b24123c444dddea567ffde1a405. The account_id pin below forces the
-// correct account regardless.
+// HISTORICAL TRAP (resolved 2026-08-19): the Jax install env used to carry
+// an ambient CLOUDFLARE_API_TOKEN belonging to the AllBets account, which
+// shadowed this deploy token. That mapping was removed from the Vaultwarden
+// hydration manifest on 2026-08-19 and .env / .env.baked carry no
+// CLOUDFLARE_* key today (re-verified 2026-08-30). Still export the
+// Vaultwarden token per README.md and confirm `wrangler whoami` shows
+// account 8a119b24123c444dddea567ffde1a405 before deploying - the check is
+// cheap and the account_id pin below forces the correct account regardless.
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "behalfbot-executor",


### PR DESCRIPTION
## What

`wrangler.jsonc`, `deploy.sh` and `README.md` all warn that the ambient `CLOUDFLARE_API_TOKEN` in the Jax install env belongs to the AllBets account and shadows the real deploy token. That has not been true since 2026-08-19, when the mapping was removed from the Vaultwarden hydration manifest (`docs/postmortems/2026-08-19-executor-stale-since-july.md` in new-jaxity, "What I changed today").

Re-verified on the Mac mini 2026-08-30 before running a deploy: `CLOUDFLARE_API_TOKEN` is unset in the shell, and neither `.env` nor `.env.baked` carries any `CLOUDFLARE_*` key.

## Why it matters

The stale warning is load-bearing in the wrong direction. It reached Sean through the executor-drift alert text and read as "we still have a wrong-account token sitting in the env", which is a security question that then costs someone an investigation to answer with "no we don't".

## What changed

Trap text rewritten as resolved history in all three files. The `wrangler whoami` gate stays - it is cheap and still the right habit - it just no longer claims to be guarding against a live shadowing token.

No behaviour change. Comments and docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mGf4xKkR8LaPacoPaCWMt