### PR TITLE
chore(chassis): remove install-specific content from the shipped harness

### DIFF
--- a/chassis/CLAUDE.md.template
+++ b/chassis/CLAUDE.md.template
@@ -126,8 +126,8 @@ Pattern (the chassis enforces; each trigger fills in the body):
 4. Hand off to the handler script / plugin
 
 The chassis ships ZERO triggers by default. Add your own under this section in your installer-specific CLAUDE.md (this file). Examples from V1:
-- `Pacman <url>` — URL self-improvement filter (Sean's V1 reference; lives in his V1 install only)
-- `Backfill: <description>` — manual meal entry (BFL plugin; activates when bfl module enabled)
+- `Pacman <url>` - URL self-improvement filter (chassis-core; see `chassis/skills/pacman.md`)
+- `Backfill: <description>` - manual meal entry (BFL plugin; activates when bfl module enabled)
 
 ## Scheduled Tasks — Heartbeat Dispatcher
 

--- a/chassis/HEARTBEATS.md.template
+++ b/chassis/HEARTBEATS.md.template
@@ -148,8 +148,8 @@ criticality: background
 
 ## daily-log (chassis-shipped gather + prompt template, opt-in)
 
-Nightly synthesis of the day's work across every operational surface Jax
-touched (GitHub / Gmail / SiYuan / Discord postmortems). See
+Nightly synthesis of the day's work across every operational surface the
+assistant touched (GitHub / Gmail / SiYuan / Discord postmortems). See
 `chassis/docs/heartbeats/daily-log.md` for the full env var contract and
 setup.
 
@@ -253,7 +253,7 @@ to the reserved entity `health:memory-canary`, then reads it back in a
 **separate** server invocation and asserts the two match. Fires only on
 mismatch, error, or an empty read.
 
-The failure it exists for: on Sean's install the graph was unreachable from
+The failure it exists for: on the V1 reference install the graph was unreachable from
 inside the container for at least sixteen days (2026-07-24 to 2026-08-09)
 because `.mcp.json` baked an absolute host path that does not exist in the
 container namespace. Reads returned a well-formed empty graph, which reads as

--- a/chassis/contacts/contacts.py
+++ b/chassis/contacts/contacts.py
@@ -8,7 +8,7 @@ The whole surface:
     update(contact_id, ...)         change fields on a live contact
     delete(contact_id)              soft delete (sets deleted_at)
 
-Relational integrity, per Sean's answers on scrollinondubs/behalfbot#110:
+Relational integrity, per the design decisions in scrollinondubs/behalfbot#110:
 one-way references (everything else points at Postgres, never the reverse),
 soft delete only, and a resolver returns a tombstone rather than an error or a
 silent empty result. That is why `get()` has no include_deleted flag - it
@@ -17,7 +17,7 @@ holding a stale id can tell "deleted" apart from "never existed" apart from
 "unreachable" (the last one still raises ChassisDBUnavailable, same contract
 as every other chassis-core module).
 
-`search()` defaults to excluding tombstoned rows (Sean's stated default) with
+`search()` defaults to excluding tombstoned rows (the documented default) with
 an explicit `include_deleted=True` to opt in. There is no hard-delete path in
 this slice - GDPR erasure is a real requirement but a separate issue.
 """
@@ -126,7 +126,7 @@ def search(
 ) -> list[dict[str, Any]]:
     """Find contacts by name/email/phone. Empty query lists, newest first.
 
-    Excludes tombstoned contacts by default - Sean's stated default in the
+    Excludes tombstoned contacts by default - the documented default in the
     issue thread. Pass include_deleted=True to see them too (e.g. to confirm
     a delete happened, or to audit).
     """

--- a/chassis/db/connection.py
+++ b/chassis/db/connection.py
@@ -6,7 +6,7 @@ carries its own selector until the chassis grows one." Pacman is chassis-core,
 not a plugin, so it cannot carry a third copy of that selector.
 
 Deliberately NOT an ORM and deliberately not a backend selector. The chassis
-already decided Postgres is canonical (Sean's "Postgres from start" call,
+already decided Postgres is canonical (the "Postgres from start" call,
 docker-compose.yml line 9). The dating plugin's selector exists because BFL
 predates that call and still has a SQLite mirror to keep alive; core code has
 no such history and should not inherit the branch.
@@ -23,7 +23,7 @@ DSN resolution order (first non-empty wins):
                            accepted here so an install that set only that one
                            does not need a second variable.
   3. JAX_PG_DSN          - host-side legacy fallback, per the reference
-                           install's docs/jax-db.md. Present so host-run
+                           install's DB docs. Present so host-run
                            scripts (migrations, one-off drains) work outside
                            the container without re-exporting.
 

--- a/chassis/db/migrations/002_contacts.sql
+++ b/chassis/db/migrations/002_contacts.sql
@@ -7,7 +7,7 @@
 -- every other surface references a contact by ID instead of copying its
 -- fields.
 --
--- Slice 1 scope, per Sean's answers in the issue thread on 2026-07-22:
+-- Slice 1 scope, per the issue thread on 2026-07-22:
 --   - Soft delete only, no hard-delete path yet. A deleted contact keeps its
 --     row and gets `deleted_at` set, so a reference from a note degrades to
 --     "this contact was deleted" instead of erroring or silently resolving to
@@ -45,8 +45,8 @@ CREATE INDEX IF NOT EXISTS ix_contacts_email
     ON chassis_contacts (email)
     WHERE email IS NOT NULL;
 
--- Search excludes tombstoned contacts by default (Sean's default from the
--- issue thread), so the common-path query only ever scans live rows.
+-- Search excludes tombstoned contacts by default (the documented default from
+-- the issue thread), so the common-path query only ever scans live rows.
 CREATE INDEX IF NOT EXISTS ix_contacts_live
     ON chassis_contacts (name)
     WHERE deleted_at IS NULL;

--- a/chassis/db/tests/test_connection.py
+++ b/chassis/db/tests/test_connection.py
@@ -39,7 +39,7 @@ class TestDsnResolution(unittest.TestCase):
         self.assertEqual(get_dsn({"BEHALFBOT_PG_DSN": DSN}), DSN)
 
     def test_falls_back_to_jax_pg_dsn(self):
-        """Host-side legacy fallback, per the reference install's docs/jax-db.md."""
+        """Host-side legacy fallback, per the reference install's DB docs."""
         self.assertEqual(get_dsn({"JAX_PG_DSN": DSN}), DSN)
 
     def test_resolution_order_matches_the_documented_constant(self):

--- a/chassis/docs/heartbeats/daily-log.md
+++ b/chassis/docs/heartbeats/daily-log.md
@@ -1,7 +1,7 @@
 # daily-log heartbeat
 
-Nightly synthesis of every operational surface Jax touched over the past 24
-hours. Produces a structured markdown log under SiYuan that the morning
+Nightly synthesis of every operational surface the assistant touched over the
+past 24 hours. Produces a structured markdown log under SiYuan that the morning
 briefing consumes for context.
 
 Ships in chassis as of PR
@@ -23,15 +23,15 @@ Ships in chassis as of PR
 Uses `gh api graphql` to list every repo the `DAILY_LOG_GH_USER` viewer has
 push access to, ordered by recent push. Any repo pushed in the last 14
 days gets its PRs + open issues scanned. This is deliberately dynamic:
-on the VCL platform, customers will have students assigning tasks on
-their own repos, and the daily log needs to capture that activity without
+customers routinely have collaborators assigning work on repos outside
+their own org, and the daily log needs to capture that activity without
 a hardcoded org allowlist.
 
 For each active repo:
 
 - PRs merged / opened / closed-unmerged in the 24h window by
   `DAILY_LOG_GH_USER`
-- Open issues where Jax has commented (candidate "awaiting input")
+- Open issues where the assistant has commented (candidate "awaiting input")
 
 ### Gmail
 
@@ -51,7 +51,7 @@ first 300 chars of first-paragraph content as a hint for the prompt.
 
 Fetches the last 100 messages from `DAILY_LOG_DISCORD_CHANNEL_ID` via the
 Discord HTTP API. Regex-filters bot-authored messages against a fixed
-pattern set that captures Jax's usual postmortem shape:
+pattern set that captures the assistant's usual postmortem shape:
 
 - `Surprises:` / `Sanity-check priorities:` / `Review priorities:`
 - `deviated from spec` / `didn't work` / `broke because`
@@ -65,9 +65,9 @@ to turn into `Learnings & Tribal Knowledge` bullets.
 | Var | Required | Purpose |
 |---|---|---|
 | `CHASSIS_HOME` | yes | Customer install root (already set by dispatcher) |
-| `DAILY_LOG_GH_USER` | recommended | GitHub username Jax pushes as (e.g. `jacketyjax`). If unset, GitHub scan is skipped with a warning. |
-| `DAILY_LOG_DISCORD_CHANNEL_ID` | recommended | The `#jax` channel ID for postmortem mining. If unset, Discord scan is skipped. |
-| `DAILY_LOG_GMAIL_IDENTITY` | optional | Gmail address Jax sends from (e.g. `jax@vibecodelisboa.com`). Enables prompt-side Gmail MCP search. |
+| `DAILY_LOG_GH_USER` | recommended | GitHub username the assistant pushes as (e.g. `<your-agent-gh-user>`). If unset, GitHub scan is skipped with a warning. |
+| `DAILY_LOG_DISCORD_CHANNEL_ID` | recommended | The primary conversation channel ID (`DISCORD_PRIMARY_CHANNEL_ID`) for postmortem mining. If unset, Discord scan is skipped. |
+| `DAILY_LOG_GMAIL_IDENTITY` | optional | Gmail address the assistant sends from (e.g. `<your-agent>@<your-domain>`). Enables prompt-side Gmail MCP search. |
 | `DAILY_LOG_SIYUAN_URL` | optional | SiYuan HTTP API base URL. Falls back to `SIYUAN_URL`. |
 | `DAILY_LOG_SIYUAN_TOKEN` | optional | SiYuan API token. Falls back to `SIYUAN_TOKEN`. |
 | `DAILY_LOG_EXTRA_METRICS_SCRIPT` | optional | Path to a customer-side executable that emits extra metrics as JSON. Chassis calls it and merges output under `metrics.custom`. |
@@ -88,7 +88,7 @@ The gather never crashes.
 
 2. Fill in the four `{{ ... }}` placeholders in the copied prompt:
 
-   - `{{ CUSTOMER_JAX_IDENTITY }}` - `"Sean Tierney's autonomous assistant"`, etc.
+   - `{{ CUSTOMER_AGENT_IDENTITY }}` - `"<principal full name>'s autonomous assistant"`
    - `{{ CUSTOMER_ORG_HANDLES }}` - space-separated org/domain handles
      for the Gmail `in:sent from:` filter
    - `{{ CUSTOMER_DAILY_LOG_PARENT_ID }}` - SiYuan block ID of the parent
@@ -116,7 +116,7 @@ The gather never crashes.
 
    ```bash
    DAILY_LOG_GH_USER=your-gh-username
-   DAILY_LOG_GMAIL_IDENTITY=jax@your-domain.com
+   DAILY_LOG_GMAIL_IDENTITY=your-agent@your-domain.com
    DAILY_LOG_DISCORD_CHANNEL_ID=1234567890123456789
    ```
 
@@ -138,45 +138,42 @@ The gather never crashes.
 without touching chassis. The script should emit a single JSON object on
 stdout; chassis merges it under `metrics.custom`.
 
-Example for Sean's install (adds dating funnel + outreach counts):
+The script lives customer-side, under `${CUSTOMER_HOME}/scripts/`. Shape:
 
 ```bash
 #!/bin/bash
-# scripts/daily-log-extra-metrics.sh
-# Emits Sean-install-specific metrics for the daily-log gather.
+# ${CUSTOMER_HOME}/scripts/daily-log-extra-metrics.sh
+# Emits install-specific metrics for the daily-log gather.
 
 set -euo pipefail
-: "${CHASSIS_HOME:?CHASSIS_HOME must be set}"
+: "${CUSTOMER_HOME:?CUSTOMER_HOME must be set}"
 
 YESTERDAY=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d)
 
-dating_swipes=$(grep -h '"action":"swipe"' \
-    "${CHASSIS_HOME}/logs/dating/${YESTERDAY}-"*.jsonl 2>/dev/null | wc -l | tr -d ' ')
-outreach_sent=$(sqlite3 "${CHASSIS_HOME}/state/outreach.db" \
-    "SELECT COUNT(*) FROM email_outreach_log WHERE date(sent_at) = '${YESTERDAY}'" \
+# Count whatever this install cares about. One line per metric, then emit a
+# single flat JSON object. Anything unreadable must degrade to 0 rather than
+# fail - a crashing extras script must not take the whole gather down.
+widgets_shipped=$(sqlite3 "${CUSTOMER_HOME}/state/your-app.db" \
+    "SELECT COUNT(*) FROM shipments WHERE date(shipped_at) = '${YESTERDAY}'" \
     2>/dev/null || echo 0)
 
-jq -n \
-    --argjson swipes "${dating_swipes:-0}" \
-    --argjson outreach "${outreach_sent:-0}" \
-    '{dating_swipes: $swipes, outreach_sent: $outreach}'
+jq -n --argjson widgets "${widgets_shipped:-0}" '{widgets_shipped: $widgets}'
 ```
 
-Then in `.env`:
+Then in `.env`, pointing at your own copy:
 
 ```bash
-DAILY_LOG_EXTRA_METRICS_SCRIPT=/Users/jax/.behalfbot/scripts/daily-log-extra-metrics.sh
+DAILY_LOG_EXTRA_METRICS_SCRIPT=${CUSTOMER_HOME}/scripts/daily-log-extra-metrics.sh
 ```
 
 ## Design decisions
 
-- **Dynamic repo discovery** over a static allowlist. Rationale: on the VCL
-  platform, students will start assigning tasks to Jax on their own project
-  repos. Hardcoding the customer's own org would silently drop that
-  activity.
+- **Dynamic repo discovery** over a static allowlist. Rationale: collaborators
+  assign work to the assistant on their own project repos. Hardcoding the
+  customer's own org would silently drop that activity.
 - **Postmortem mining from Discord** over an every-subagent-writes log
-  pipeline. Rationale: postmortems already surface in `#jax` when Jax
-  reports back on PRs and heartbeats. Adding a parallel log write in every
+  pipeline. Rationale: postmortems already surface in the primary channel
+  when the assistant reports back on PRs and heartbeats. Adding a parallel log write in every
   subagent is deferred until that first path proves insufficient.
 - **Reflection header stays even when empty.** Rationale: consistency
   across daily logs makes the SiYuan tree scannable at a glance. An empty

--- a/chassis/docs/prompts-setup.md
+++ b/chassis/docs/prompts-setup.md
@@ -80,7 +80,7 @@ If any required value is empty or still has a `<placeholder>` shape, the script 
 Currently rendered:
 
 - `plugins/angel-protocol/scheduled-tasks/welfare-check-prompt.md`
-- `plugins/angel-protocol/scheduled-tasks/dormant-sean-prenudge-prompt.md`
+- `plugins/angel-protocol/scheduled-tasks/dormant-operator-prenudge-prompt.md`
 - `plugins/remarkable/scheduled-tasks/remarkable-health-alert-prompt.md`
 
 The script discovers `*.md.template` by glob — add new templates by dropping them next to existing prompts. They render on the next `bootstrap-prompts.sh` invocation.

--- a/chassis/pacman/tests/test_tokens.py
+++ b/chassis/pacman/tests/test_tokens.py
@@ -54,7 +54,7 @@ class TestTokenShape(unittest.TestCase):
             self.assertNotIn(vowel, TOKEN_ALPHABET)
 
     def test_alphabet_excludes_visually_ambiguous_characters(self):
-        """Sean retypes these on a phone. i/l/1 and o/0 must not appear."""
+        """These get retyped on a phone. i/l/1 and o/0 must not appear."""
         for ambiguous in "ilo":
             self.assertNotIn(ambiguous, TOKEN_ALPHABET)
 

--- a/chassis/pacman/tokens.py
+++ b/chassis/pacman/tokens.py
@@ -38,7 +38,7 @@ Three constraints drove it, in order of how expensive they are to get wrong:
    ever being read as a token, and keeps generated tokens from being obscene
    or confusing.
 
-3. **Sean approves from his phone.** Six characters, one case, no digits to
+3. **The operator approves from a phone.** Six characters, one case, no digits to
    confuse with letters, and no visually ambiguous pairs - the alphabet has no
    `i`/`l`/`1`, no `o`/`0`. A 32-character Notion UUID fails this badly enough
    that the design note called it out by name.

--- a/chassis/scheduled-tasks/bootstrap-audit-prompt.md
+++ b/chassis/scheduled-tasks/bootstrap-audit-prompt.md
@@ -1,6 +1,6 @@
 # Bootstrap audit triage
 
-The chassis `bootstrap-audit.sh` routine has flagged one or more failing checks on this install. Each failure represents a silent install gap that, left unfixed, will surface later as a behavior bug the installer notices and Jax has to chase down.
+The chassis `bootstrap-audit.sh` routine has flagged one or more failing checks on this install. Each failure represents a silent install gap that, left unfixed, will surface later as a behavior bug the installer notices and the assistant has to chase down.
 
 ## What you have
 
@@ -18,17 +18,17 @@ The transcript walks five known install gaps:
 
 1. **Read the transcript file** to see exactly which checks failed and what fix commands the audit suggested.
 2. **Triage by severity.** A missing `origin` or missing backup row is recoverable any time. A non-loaded LaunchDaemon means the bot has been silent on Discord since the failure started - higher priority.
-3. **Propose a fix plan** in a Discord message to `#jax-ops`. Include:
+3. **Propose a fix plan** in a Discord message to the install's ops channel (`discord_channels.ops_label` in `chassis.config.yaml`; runtime ID in `DISCORD_OPS_CHANNEL_ID`). Include:
    - Which gap failed
    - The fix command from the transcript
-   - Whether you need Sean's `sudo` (LaunchDaemon installs do; backup row does not)
+   - Whether you need the operator's `sudo` (LaunchDaemon installs do; backup row does not)
    - An estimate of any ongoing impact (e.g. "Discord has been routing to a dead session for N days")
-4. **Do not auto-execute** a `sudo` command. Surface for Sean's approval first. Non-sudo fixes (HEARTBEATS.md append, `git remote set-url`) can be done via PR following the normal workflow.
+4. **Do not auto-execute** a `sudo` command. Surface for the operator's approval first. Non-sudo fixes (HEARTBEATS.md append, `git remote set-url`) can be done via PR following the normal workflow.
 
 ## Important
 
-- The audit ran on a recurring weekly schedule. Same failure two weeks in a row means the first triage didn't stick. Read the prior week's discord message (search `#jax-ops` for `bootstrap-audit`) before suggesting the same fix again.
-- If you can't make sense of a failure, ask Sean in `#jax-ops` rather than guessing. Better to escalate than auto-fix the wrong thing.
+- The audit ran on a recurring weekly schedule. Same failure two weeks in a row means the first triage didn't stick. Read the prior week's discord message (search the ops channel for `bootstrap-audit`) before suggesting the same fix again.
+- If you can't make sense of a failure, ask the operator in the ops channel rather than guessing. Better to escalate than auto-fix the wrong thing.
 
 ## Out of scope
 

--- a/chassis/scheduled-tasks/chassis-root-health-prompt.md
+++ b/chassis/scheduled-tasks/chassis-root-health-prompt.md
@@ -13,7 +13,7 @@ The runtime resolved the BAKED tree (`mode: baked`) but a usable LIVE tree exist
 1. Confirm the live tree is genuinely usable: `VERSION` readable, `scripts/` present, `scheduled-tasks/heartbeat-dispatcher.sh` present. Compare `live_version` vs `baked_version` from the gather output.
 2. The fix is a container restart so the entrypoint re-runs `resolve-chassis-root.sh` and picks the live tree: `docker compose pull && docker compose up -d` (or the install's `compose.sh` wrapper if an override is in play - never a bare `up -d` when an override exists, per the #100 fix).
 3. After the restart, re-read `$CUSTOMER_HOME/chassis-root.state.json` and confirm `mode` flipped to `live` and `error` is null. Do not mark the work done until it has.
-4. If a restart is disruptive (mid-task), post the finding to the ops channel and ask Sean before bouncing the container.
+4. If a restart is disruptive (mid-task), post the finding to the ops channel and ask the operator before bouncing the container.
 
 ### `chassis_root_assertion_failed`
 
@@ -31,7 +31,7 @@ The resolver hit an exit-5 assertion. The `error` field in the gather output tel
 
 1. Read the `error` field and the version fields; identify which failure mode above applies.
 2. Post a one-line summary to the install's ops channel: which tag fired, `mode`, `live_version` vs `baked_version`, and the fix you propose.
-3. Container restarts on the production stack are operator-visible - surface the fix for Sean's go-ahead rather than bouncing the container autonomously. Non-disruptive diagnosis (reading the state file, `docker inspect`) needs no approval.
+3. Container restarts on the production stack are operator-visible - surface the fix for the operator's go-ahead rather than bouncing the container autonomously. Non-disruptive diagnosis (reading the state file, `docker inspect`) needs no approval.
 
 ## Important
 

--- a/chassis/scheduled-tasks/chassis-update-check-prompt.md
+++ b/chassis/scheduled-tasks/chassis-update-check-prompt.md
@@ -32,7 +32,7 @@ The gather script has already filtered out:
 
 ### Step 1 - Resolve the alerts channel
 
-Read `chassis.config.yaml` at `${CHASSIS_HOME}/chassis.config.yaml`. The customer's alerts channel comes from `discord_channels.alerts_label` (display name, e.g. `#alerts` or `#jax-ops`). The runtime channel ID is in the `.env` as `DISCORD_ALERTS_CHANNEL_ID`. Use `chassis/scripts/post-to-channel.sh` (or the equivalent) with the alerts channel ID.
+Read `chassis.config.yaml` at `${CHASSIS_HOME}/chassis.config.yaml`. The customer's alerts channel comes from `discord_channels.alerts_label` (display name, e.g. `#alerts` or `#<installer>-ops`). The runtime channel ID is in the `.env` as `DISCORD_ALERTS_CHANNEL_ID`. Use `chassis/scripts/post-to-channel.sh` (or the equivalent) with the alerts channel ID.
 
 If neither is configured, fall back to `DISCORD_PRIMARY_CHANNEL_ID`. Do NOT silently drop the notification.
 

--- a/chassis/scheduled-tasks/container-liveness-prompt.md
+++ b/chassis/scheduled-tasks/container-liveness-prompt.md
@@ -16,7 +16,7 @@ You will receive the gather output as JSON: `{"count": N, "issues": [...], "chec
 
 1. `docker logs <c> --tail 100` and `docker inspect <c>` to establish the cause.
 2. Post a one-line summary to the install's ops channel: which container, which tag, the exit cause from the logs.
-3. Restarting production containers is operator-visible - surface the fix for Sean's go-ahead unless it is an obvious transient that has already self-recovered. Diagnosis (logs, inspect) needs no approval.
+3. Restarting production containers is operator-visible - surface the fix for the operator's go-ahead unless it is an obvious transient that has already self-recovered. Diagnosis (logs, inspect) needs no approval.
 4. If `behalfbot` itself was the down container, note how long it was down (from `docker inspect .State.StartedAt` / `FinishedAt`) - a dead dispatcher means every heartbeat was silent for that window.
 
 ## STRUCTURAL coverage note - the fully-dead-behalfbot blind spot

--- a/chassis/scheduled-tasks/daily-log-prompt.md.template
+++ b/chassis/scheduled-tasks/daily-log-prompt.md.template
@@ -4,10 +4,10 @@ Chassis-supplied template. Customer install copies this file to
 `${CUSTOMER_HOME}/scheduled-tasks/daily-log-prompt.md` and fills in the
 `{{ ... }}` placeholders. The template variables are:
 
-- `{{ CUSTOMER_JAX_IDENTITY }}` - the customer's Jax identity (e.g.
-  "Sean Tierney's autonomous assistant", "Ben Lakoff's autonomous assistant")
+- `{{ CUSTOMER_AGENT_IDENTITY }}` - how this install's assistant identifies
+  itself, in the shape "<principal full name>'s autonomous assistant"
 - `{{ CUSTOMER_ORG_HANDLES }}` - space-separated org handles the customer
-  operates under (e.g. "vibecodelisboa fenerum" or just "kogent")
+  operates under (e.g. "acme-labs acme-ventures" or just "acme")
 - `{{ CUSTOMER_DAILY_LOG_PARENT }}` - the parent daily logs are written
   under, in whatever form the install's backend addresses a parent:
     - SiYuan: the parent doc's canonical block ID (`20260507083000-abcd123`).
@@ -24,7 +24,7 @@ Chassis-supplied template. Customer install copies this file to
 
 The heartbeat dispatcher fires this nightly at 02:00 after
 `chassis/scripts/daily-log-gather.py` has already collected a full-day JSON
-payload from every operational surface Jax touched. This prompt consumes
+payload from every operational surface the assistant touched. This prompt consumes
 that payload, synthesizes it into a structured log, and writes it to the
 install's second brain.
 
@@ -35,7 +35,7 @@ mode it is not registered, and naming it is what made this prompt SiYuan-only.
 
 ---
 
-You are Jax, {{ CUSTOMER_JAX_IDENTITY }}. Read CLAUDE.md for your full
+You are {{ CUSTOMER_AGENT_IDENTITY }}. Read CLAUDE.md for your full
 operating manual.
 
 Your task: read the gather payload for the day that just ended and write a
@@ -117,8 +117,8 @@ From the payload, produce the log. **Groupings and priorities:**
 ## Step 3: Write the daily log to the second brain
 
 Write under the canonical Daily Logs parent - by exact ID, NOT by name
-match. Using a name-based path caused a double-parent bug on Sean's install
-2026-04-17/18 where logs landed in the wrong notebook or got a malformed
+match. Using a name-based path caused a double-parent bug on the V1 reference
+install 2026-04-17/18 where logs landed in the wrong notebook or got a malformed
 sibling created with the parent's ID as its name. The rule survives the
 backend change: pass the configured parent through verbatim, never a name
 you assembled yourself.

--- a/chassis/scheduled-tasks/docker-prune-alert-prompt.md
+++ b/chassis/scheduled-tasks/docker-prune-alert-prompt.md
@@ -10,14 +10,14 @@ The weekly docker-prune heartbeat failed. The gather emitted `count > 0` with on
 ## Your job
 
 1. Classify the failure from `status` + `detail`.
-2. Post one concise alert to `#<devops>` (channel `1497870976237699173`) via the discord MCP `reply` tool: date, status tag, best-guess cause, fix suggestion.
-3. If the same status fires for 2+ consecutive weeks, file-or-comment on `scrollinondubs/new-jaxity` using the dedup helper.
+2. Post one concise alert to the install's alerts channel via the discord MCP `reply` tool: date, status tag, best-guess cause, fix suggestion. The display label is `discord_channels.alerts_label` in `${CHASSIS_HOME}/chassis.config.yaml`; the runtime channel ID is `DISCORD_ALERTS_CHANNEL_ID` in the install's `.env`.
+3. If the same status fires for 2+ consecutive weeks, file-or-comment on the install's own repo (the `origin` remote of `${CUSTOMER_HOME}`, not the chassis upstream) using the dedup helper.
 
 ## What NOT to do
 
-- Don't retry the prune from this prompt. The next weekly tick handles retry. If the disk is critical, surface that to Sean to handle manually rather than burning Claude budget on multiple consecutive prune attempts.
-- Don't escalate to `#<primary>`. Infrastructure alerts route to `#<devops>` per the 2026-05-25 routing update.
-- Don't use `gh issue create` directly — use the dedup helper.
+- Don't retry the prune from this prompt. The next weekly tick handles retry. If the disk is critical, surface that to the operator to handle manually rather than burning Claude budget on multiple consecutive prune attempts.
+- Don't escalate to the primary conversation channel. Infrastructure alerts route to the alerts channel.
+- Don't use `gh issue create` directly - use the dedup helper.
 
 ## Cost
 

--- a/chassis/scheduled-tasks/heartbeat-dispatcher.sh
+++ b/chassis/scheduled-tasks/heartbeat-dispatcher.sh
@@ -15,7 +15,7 @@
 #
 # Required environment (set by the install runbook, NOT this script):
 #   CHASSIS_HOME    — absolute path to the installer's chassis directory
-#                     (e.g. /home/installer/behalfbot or /Users/sean/<v1-reference-install>)
+#                     (e.g. /home/installer/behalfbot or /Users/<user>/behalfbot)
 #   HOME            — installer's home directory (for tool paths, .ssh, etc.)
 #   PATH            — set up by the launchd plist / systemd unit; this script
 #                     does not assume any particular Homebrew prefix.
@@ -101,7 +101,7 @@ fi
 # unset, it falls back to OAuth stored in ~/.claude/.credentials.json or the
 # OS keychain → subscription billing.
 #
-# In the V1 reference install (Sean's `$CHASSIS_HOME/`), the .env file's Vaultwarden
+# In the V1 reference install, the .env file's Vaultwarden
 # hydration block exported ANTHROPIC_API_KEY for legitimate non-Claude-Code
 # uses (OpenAI fallback shims, etc.). That silently routed every heartbeat
 # through PAYG and caused a measurable cost spike — confirmed root cause of
@@ -1023,7 +1023,7 @@ main() {
             # broken in state but were green in logs. Writing `success` on a
             # clean PASS is mildly semantically loose (no FIRE happened) but
             # matches the existing "success" semantics elsewhere in this loop
-            # and is the minimal-change fix Sean approved 2026-05-30.
+            # and is the minimal-change fix approved 2026-05-30.
             set_state "$name" "last_result" "success"
             continue
         fi
@@ -1172,12 +1172,12 @@ ${gathered_data}
             # all, where it guarantees silence exactly when something is badly
             # wrong.
             #
-            # 2026-08-17 to 2026-08-19 (new-jaxity): every FIRE failed for 60
+            # 2026-08-17 to 2026-08-19 (V1 reference install): every FIRE failed for 60
             # hours, first on a missing .mcp.json and then on a zeroed OAuth
             # credential. Eleven heartbeats opened their breakers and went
             # quiet. The gathers kept running and kept reporting "no work", so
-            # from outside the install looked healthy. Nobody was told. Sean
-            # found it by asking about something else entirely.
+            # from outside the install looked healthy. Nobody was told. The
+            # operator found it by asking about something else entirely.
             #
             # So: count failures across DIFFERENT heartbeats, and once that
             # crosses the threshold, alert directly and bypass every breaker.

--- a/chassis/scheduled-tasks/memory-canary-prompt.md
+++ b/chassis/scheduled-tasks/memory-canary-prompt.md
@@ -2,7 +2,7 @@
 
 The daily `memory-canary` check could not complete a write-read-verify round trip against this install's memory MCP knowledge graph. Until this is fixed, the assistant is amnesiac: every session starts with no prior context, every memory write is discarded, and nothing about that is visible in normal operation. A read from a broken graph returns a well-formed empty result, which is indistinguishable from "nothing has been saved yet".
 
-This is not hypothetical. Sean's install ran in exactly this state from at least 2026-07-24 to 2026-08-09 - sixteen days - because `.mcp.json` baked an absolute host path that does not exist inside the container namespace. Fixed in #142 / #143; this canary exists so the next one is caught in a day.
+This is not hypothetical. The V1 reference install ran in exactly this state from at least 2026-07-24 to 2026-08-09 - sixteen days - because `.mcp.json` baked an absolute host path that does not exist inside the container namespace. Fixed in #142 / #143; this canary exists so the next one is caught in a day.
 
 ## What the gather gives you
 
@@ -14,7 +14,7 @@ This is not hypothetical. Sean's install ran in exactly this state from at least
 
 `resolved_path` is where the memory server was configured to keep the graph, resolved in the namespace the check ran in. `shape` says how that path was derived: `cwd-resolved, no env block` (the current template) or `env.MEMORY_FILE_PATH` (legacy, an absolute path baked into `.mcp.json`).
 
-Lead your report with `resolved_path` and `error`. "Memory is broken" is not actionable; "the graph resolves to `/Users/jax/.behalfbot/memory/memory.jsonl`, which does not exist in this container namespace" is.
+Lead your report with `resolved_path` and `error`. "Memory is broken" is not actionable; "the graph resolves to `/Users/<host-user>/.behalfbot/memory/memory.jsonl`, which does not exist in this container namespace" is.
 
 ## Triage by stage
 

--- a/chassis/scripts/bake-env.sh
+++ b/chassis/scripts/bake-env.sh
@@ -134,7 +134,7 @@ NEW_VARS=$(comm -13 "$PRE_ENV_FILE" "$POST_ENV_FILE")
 # rationale on keeping these unset at runtime.
 #
 # Concrete incident 2026-05-22 (scrollinondubs/new-jaxity 3h BFL pipeline
-# outage): a stale ANTHROPIC_API_KEY leaked into Sean's .env.baked from some
+# outage): a stale ANTHROPIC_API_KEY leaked into the reference install's .env.baked from some
 # transient shell env on a past bake-env.sh run. Container restart loaded
 # .env.baked → ANTHROPIC_API_KEY became set in container process env →
 # claude -p preferred it over OAuth → 'Invalid API key' on every claude
@@ -146,7 +146,7 @@ SHELL_NOISE_REGEX='^(SHLVL|PWD|OLDPWD|SHELL|TERM|TERM_PROGRAM|TERM_PROGRAM_VERSI
 # Dispatcher-toxic var blocklist (loud WARN — operator should know if these
 # were silently dropped). Concrete incident 2026-05-22 (scrollinondubs/
 # new-jaxity 3h BFL pipeline outage): a stale ANTHROPIC_API_KEY leaked into
-# Sean's .env.baked from some transient shell env on a past bake-env.sh run.
+# the reference install's .env.baked from some transient shell env on a past bake-env.sh run.
 # Container restart loaded .env.baked → ANTHROPIC_API_KEY became set in
 # container process env → claude -p preferred it over OAuth → 'Invalid API
 # key' on every claude invocation → dispatcher cycle blocked 2.5h on

--- a/chassis/scripts/bootstrap-audit.sh
+++ b/chassis/scripts/bootstrap-audit.sh
@@ -9,7 +9,7 @@
 # project_behalfbot_install_checklist_gaps_2026_06_11.md):
 #
 #   Gap 1 - HEARTBEATS.md is missing an `s3-backup` row.
-#           Discovered on Ben Lakoff's install 2026-06-11. S3 backup runs
+#           Discovered on a beta install 2026-06-11. S3 backup runs
 #           once at bootstrap then never again, no alert.
 #   Gap 2 - `git remote -v` returns no customer-owned URL.
 #           Same install. Means customizations only exist on the install
@@ -149,8 +149,8 @@ audit_gap_1_backup_heartbeat() {
         return
     fi
     # Accept any heartbeat whose section header or table row contains "backup"
-    # (Sean's install uses siyuan-backup, turso-backup, n8n-backup; Lakoff's
-    # was s3-backup; future installs may use restic-backup, b2-backup, etc.)
+    # (installs in the wild use siyuan-backup, turso-backup, n8n-backup,
+    # s3-backup; future installs may use restic-backup, b2-backup, etc.)
     if grep -qiE '^(## |\| *)[a-z0-9_-]*backup' "$hb"; then
         local found
         found="$(grep -ioE '^(## |\| *)[a-z0-9_-]*backup[a-z0-9_-]*' "$hb" | sed -E 's/^(## |\| *)//' | sort -u | tr '\n' ' ')"

--- a/chassis/scripts/daily-log-gather.py
+++ b/chassis/scripts/daily-log-gather.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """daily-log-gather.py - Multi-surface daily activity gather for the daily-log heartbeat.
 
-Pre-fetches the day's activity across every operational surface the customer's
-Jax touches, then emits a single JSON payload on stdout for the prompt to
+Pre-fetches the day's activity across every operational surface the install's
+assistant touches, then emits a single JSON payload on stdout for the prompt to
 consume. Runs on the host / dispatcher context (not inside Claude), so all
 API access uses env vars + shell tools, never MCP.
 
@@ -13,12 +13,12 @@ Contract (per chassis gather-script template):
   - non-zero exit ONLY on invariant violations (e.g. can't emit JSON)
 
 Design goals:
-  1. Repo scope is DYNAMIC: query jacketyjax's viewer graph for every repo
-     with recent activity, not scrollinondubs-only. Rationale: customer
-     installs on the VCL platform will have students assigning tasks to Jax
-     on their own project repos.
-  2. Postmortem source is Discord #jax message mining (regex patterns
-     against bot-authored messages in the last 24h).
+  1. Repo scope is DYNAMIC: query DAILY_LOG_GH_USER's viewer graph for every
+     repo with recent activity, not one hardcoded org. Rationale: collaborators
+     assign work to the assistant on their own project repos, and a static org
+     allowlist would silently drop it.
+  2. Postmortem source is message mining in the install's primary Discord
+     channel (regex patterns against bot-authored messages in the last 24h).
   3. Reflection section is prompt-side; this script only supplies raw
      material.
   4. Operational surfaces scanned: GitHub, Gmail, second brain, Discord.
@@ -46,9 +46,9 @@ The backend now decides which path runs:
 
 Env var contract (chassis is generic; customer install sets these):
   CHASSIS_HOME                     - customer install root (required)
-  DAILY_LOG_GH_USER                - GitHub username Jax pushes as
-  DAILY_LOG_GMAIL_IDENTITY         - Gmail address Jax sends from
-  DAILY_LOG_DISCORD_CHANNEL_ID     - #jax channel ID for postmortem mining
+  DAILY_LOG_GH_USER                - GitHub username the assistant pushes as
+  DAILY_LOG_GMAIL_IDENTITY         - Gmail address the assistant sends from
+  DAILY_LOG_DISCORD_CHANNEL_ID     - primary channel ID for postmortem mining
   DAILY_LOG_SIYUAN_URL             - SiYuan HTTP API URL (default: $SIYUAN_URL)
   DAILY_LOG_SIYUAN_TOKEN           - SiYuan API token   (default: $SIYUAN_TOKEN)
   DAILY_LOG_EXTRA_METRICS_SCRIPT   - path to a customer-side script that emits
@@ -277,8 +277,8 @@ def gather_github(gh_user: str, since: datetime, until: datetime, *, verbose: bo
                 "closed_unmerged": closed_unmerged,
             }
 
-        # Step 3: open issues where Jax commented but someone else spoke last,
-        # OR Jax spoke last and is waiting. Best-effort search.
+        # Step 3: open issues where the assistant commented but someone else
+        # spoke last, OR it spoke last and is waiting. Best-effort search.
         issue_data = run_json(
             [
                 "gh", "issue", "list",
@@ -532,7 +532,7 @@ def gather_via_adapter(backend: str, since: datetime, until: datetime,
 
 def gather_discord_postmortems(channel_id: str, token: str, since: datetime,
                                *, verbose: bool) -> tuple[list[dict], list[str]]:
-    """Fetch recent messages from `#jax` and regex-extract postmortem candidates."""
+    """Fetch recent channel messages and regex-extract postmortem candidates."""
     warnings: list[str] = []
     postmortems: list[dict] = []
     url = (

--- a/chassis/scripts/discord-post.sh
+++ b/chassis/scripts/discord-post.sh
@@ -20,13 +20,13 @@
 #
 # Examples:
 #   # Plain text message
-#   discord-post.sh 1487067385159487588 "Briefing for $(date +%F) ready: $URL"
+#   discord-post.sh "$DISCORD_BRIEFINGS_CHANNEL_ID" "Briefing for $(date +%F) ready: $URL"
 #
 #   # Read text body from a file (handy for prose with newlines/markdown/$)
-#   discord-post.sh 1487067385159487588 @/tmp/synopsis.txt
+#   discord-post.sh "$DISCORD_BRIEFINGS_CHANNEL_ID" @/tmp/synopsis.txt
 #
 #   # With one or more file attachments
-#   discord-post.sh 1487067385159487588 "Morning briefing $(date +%F)" \
+#   discord-post.sh "$DISCORD_BRIEFINGS_CHANNEL_ID" "Morning briefing $(date +%F)" \
 #       /app/customer/briefings/$(date +%F)-morning-briefing.md
 #
 # Exit codes:

--- a/chassis/scripts/first-boot-announce.sh
+++ b/chassis/scripts/first-boot-announce.sh
@@ -8,10 +8,10 @@
 # starts, so the installer sees the emit in the ops channel immediately on
 # first container start.
 #
-# Why this exists: installer-2 install + installer-1 install both stalled on "what is
-# my bot's user ID?" during Phase 2 of the Discord channel pattern (PR #51).
-# The ID is only visible in Discord Developer Portal and was unknown until Sean
-# fished it out of screenshots. This script makes it self-reported.
+# Why this exists: two early installs both stalled on "what is my bot's user
+# ID?" during Phase 2 of the Discord channel pattern (PR #51). The ID is only
+# visible in the Discord Developer Portal, and on both installs it had to be
+# fished out of screenshots by hand. This script makes it self-reported.
 # See issue #53 item 4.
 #
 # Flow:
@@ -80,9 +80,9 @@ fi
 # Build the three-line message (or a degraded version when ID unavailable).
 if [[ -n "$BOT_USER_ID" ]]; then
     OAUTH_URL="https://discord.com/oauth2/authorize?client_id=${BOT_USER_ID}&scope=bot+applications.commands&permissions=379968"
-    LINE1="Behalfbot connected as ${BOT_USERNAME} (Discord user ID: ${BOT_USER_ID}). Share this with Sean to add me to the install channel."
+    LINE1="Behalfbot connected as ${BOT_USERNAME} (Discord user ID: ${BOT_USER_ID}). You need this ID to add me to the install channel."
     LINE2="OAuth invite URL: ${OAUTH_URL}"
-    LINE3="Once added: run \`/discord:access group add <channel_id> --no-mention --allow <SEAN_ID>,<JAXBOT_ID>\` on this host to allowlist the channel."
+    LINE3="Once added: run \`/discord:access group add <channel_id> --no-mention --allow <INSTALLER_DISCORD_USER_ID>,<BOT_USER_ID>\` on this host to allowlist the channel."
     if [[ -n "$IDENTITY_WARNING" ]]; then
         LINE3="${LINE3}\n\n${IDENTITY_WARNING}"
     fi

--- a/chassis/scripts/gather-chassis-update-check.sh
+++ b/chassis/scripts/gather-chassis-update-check.sh
@@ -56,7 +56,7 @@ CUSTOMER_HOME="${CUSTOMER_HOME:-${HOME}/.behalfbot}"
 # Resolve VERSION + CHANGELOG paths RELATIVE TO THIS SCRIPT, not $CHASSIS_HOME.
 # Survives both install layouts:
 #   - vendored-subtree (chassis lives at ${CHASSIS_HOME}/chassis/)
-#   - overlay-mount (Jax-style #136, chassis lives at ${CHASSIS_HOME}/chassis/chassis/)
+#   - overlay-mount (reference-install layout #136, chassis lives at ${CHASSIS_HOME}/chassis/chassis/)
 # Either way, this script is at <chassis>/scripts/, so VERSION is at ../VERSION.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LOCAL_VERSION_FILE="${SCRIPT_DIR}/../VERSION"

--- a/chassis/scripts/gather-docker-prune.sh
+++ b/chassis/scripts/gather-docker-prune.sh
@@ -9,7 +9,7 @@
 # only removes images currently NOT used by any container.
 #
 # Why in-container rather than host launchd:
-# Per Sean's 2026-05-25 directive: "any interaction with the [docker daemon]
+# Per the 2026-05-25 operator directive: "any interaction with the [docker daemon]
 # that can run in the container should be there. Dating is the only thing
 # that should run external to the container." This script + the matching
 # heartbeat entry move what was previously a host-resident launchd job

--- a/chassis/scripts/hydrate-mcp-json.py
+++ b/chassis/scripts/hydrate-mcp-json.py
@@ -395,7 +395,7 @@ def main():
     #
     # SiYuan and Notion work on defaults; only Obsidian needs an extra key
     # nobody is prompted for. Force it rather than emit a technically-correct
-    # config that cannot work (Sean's call, 2026-07-20).
+    # config that cannot work (decided 2026-07-20).
     sb = config.get('second_brain') if isinstance(config, dict) else None
     if isinstance(sb, dict) and sb.get('backend') == 'obsidian':
         mode = sb.get('mode')

--- a/chassis/scripts/install-host-clis.sh
+++ b/chassis/scripts/install-host-clis.sh
@@ -6,10 +6,11 @@
 # brew (macOS) or apt (Linux). Idempotent: re-running re-checks each CLI
 # and skips ones already installed.
 #
-# Why this exists (Sean's 2026-05-25 directive, <v1-reference-install>#700 follow-up):
-# Different installs need different CLIs. Sean's install needs vercel,
-# turso, stripe (in addition to gh + awscli which the chassis image bakes).
-# Ben's may not. Marc's may use a fourth combo. Baking every possible CLI
+# Why this exists (2026-05-25, <v1-reference-install>#700 follow-up):
+# Different installs need different CLIs. One install may need vercel, turso
+# and stripe (in addition to gh + awscli, which the chassis image bakes); the
+# next needs none of them, and a third needs a combination of its own. Baking
+# every possible CLI
 # into the image bloats the image and forces every installer to update on
 # every CLI version bump. Instead: per-instance install at bootstrap time
 # based on what the install profile says the customer needs.

--- a/chassis/scripts/md-to-briefing-html.py
+++ b/chassis/scripts/md-to-briefing-html.py
@@ -46,8 +46,8 @@ except ImportError:
 
 CALLOUT_TRIGGERS = {
     "attention": (
-        r"\b(ask|asks|waiting on|needs? sean|needs? your|action needed|awaiting|required|decisions?)\b",
-        "Sections that need the installer's attention — decisions, approvals, follow-ups.",
+        r"\b(ask|asks|waiting on|needs? your|action needed|awaiting|required|decisions?)\b",
+        "Sections that need the installer's attention - decisions, approvals, follow-ups.",
     ),
     "warning": (
         r"\b(broke|break|failed|failure|error|incident|gap|stale|missed|warning)\b",

--- a/chassis/scripts/memory-canary.sh
+++ b/chassis/scripts/memory-canary.sh
@@ -4,7 +4,7 @@
 # The failure this exists for
 # ===========================
 # Between at least 2026-07-24 and 2026-08-09 the memory knowledge graph on
-# Sean's install was unreachable from inside the chassis container. `.mcp.json`
+# the V1 reference install was unreachable from inside the chassis container. `.mcp.json`
 # baked an absolute HOST path; the container sees that same bind-mounted file
 # at a different absolute path, so every container-side read returned
 # `{"entities":[],"relations":[]}` and every write went nowhere. Sixteen days,
@@ -54,7 +54,7 @@
 # and `createEntities` each start with `loadGraph()`. Send both down one pipe
 # and `createEntities` can load the pre-delete graph, see the entity still
 # present, filter it out as already-existing and create nothing - while
-# reporting success. Observed against Sean's live install on the second run:
+# reporting success. Observed against the V1 reference install on the second run:
 # the first run passed (nothing to delete), every run after it failed with
 # "create_entities did not report creating". Process exit is the only ordering
 # barrier available without a stateful JSON-RPC client, so each mutation gets

--- a/chassis/scripts/migrate-customer-state.sh
+++ b/chassis/scripts/migrate-customer-state.sh
@@ -190,7 +190,7 @@ move_if_present "briefings"
 move_if_present "logs"
 move_if_present "data"
 move_if_present "temp"
-# Top-level memory/ on legacy installs (Sean's stack): the MCP memory graph
+# Top-level memory/ on legacy installs: the MCP memory graph
 # at memory/memory.jsonl. Newer layouts may not have this.
 move_if_present "memory"
 

--- a/chassis/scripts/pacman-migrate-siyuan-queue.py
+++ b/chassis/scripts/pacman-migrate-siyuan-queue.py
@@ -2,8 +2,8 @@
 """pacman-migrate-siyuan-queue.py - One-time backfill of the live SiYuan queue.
 
 Reads the URL blocks under the SiYuan /To Investigate parent and writes one
-chassis_pacman_queue row per URL. Runs once per install; Sean's is the only
-install with a populated queue.
+chassis_pacman_queue row per URL. Runs once per install, and is a
+no-op on any install whose SiYuan queue is empty.
 
 Idempotent. Every row it writes carries `legacy_block_id`, and the partial
 unique index ux_pacman_queue_legacy_block_url on (legacy_block_id, url) makes

--- a/chassis/scripts/sync-claude-oauth-bridge.sh
+++ b/chassis/scripts/sync-claude-oauth-bridge.sh
@@ -45,7 +45,7 @@ set -euo pipefail
 
 CRED_FILE="${HOME}/.claude/.credentials.json"
 TMP="${CRED_FILE}.tmp"
-LOG_DIR="${LOG_DIR:-${HOME}/work/new-jaxity/logs/scheduled}"
+LOG_DIR="${LOG_DIR:-${CUSTOMER_HOME:-${HOME}/.behalfbot}/logs/scheduled}"
 LOG="${LOG_DIR}/claude-oauth-bridge-sync.log"
 
 mkdir -p "$LOG_DIR" "$(dirname "$CRED_FILE")"

--- a/chassis/scripts/test-chassis-update-check.sh
+++ b/chassis/scripts/test-chassis-update-check.sh
@@ -5,7 +5,7 @@
 # debounce and implemented as a permanent mute. It matched on version alone
 # and never read the `offered_at` the script itself writes, so an installer
 # who was busy the week they were offered an update was silently opted out of
-# that version forever. Sean's install was offered 0.4.0 on 2026-08-03, did
+# that version forever. The V1 reference install was offered 0.4.0 on 2026-08-03, did
 # not apply it, and returned `{"count": 0, "reason": "already_offered"}` on
 # every check after that.
 #

--- a/chassis/scripts/test-merge-plugin-triggers.sh
+++ b/chassis/scripts/test-merge-plugin-triggers.sh
@@ -99,7 +99,7 @@ check "s1 alpha trigger merged" "1" "$(grep -c 'name: alpha-trigger' <<<"$MERGED
 check "s1 beta trigger merged" "1" "$(grep -c 'name: beta-trigger' <<<"$MERGED_OUT")"
 
 # --- scenario 2: one plugin only in customer-local plugins/ -----------------
-# The behaviour that DID work pre-fix (e.g. Sean's midnight-oil) must keep
+# The behaviour that DID work pre-fix (e.g. the midnight-oil plugin) must keep
 # working: a plugin with no manifest in the resolved root but a manifest
 # under $CUSTOMER_HOME/plugins/<name>.
 fresh_env s2

--- a/chassis/scripts/validate-heartbeats.sh
+++ b/chassis/scripts/validate-heartbeats.sh
@@ -7,7 +7,7 @@
 #     (i.e. don't start with `/` and don't start with `~`). The chassis
 #     dispatcher cd's to $CHASSIS_HOME before evaluating gather_cmd, so
 #     relative paths resolve correctly under both host and container.
-#     Absolute paths (Sean's V1 install had `$CHASSIS_HOME/scripts/...`)
+#     Absolute paths (the V1 reference install had `$CHASSIS_HOME/scripts/...`)
 #     are non-portable and break inside the chassis container.
 #
 #   - Referenced gather scripts have portable shebangs:

--- a/chassis/second_brain/siyuan.py
+++ b/chassis/second_brain/siyuan.py
@@ -1,6 +1,6 @@
 """SiYuan adapter — block-based notes via SiYuan's HTTP kernel API.
 
-Ports the call patterns Sean's V1 <v1-reference-install> instance uses (briefing-siyuan-crosslink.py,
+Ports the call patterns the V1 <v1-reference-install> instance uses (briefing-siyuan-crosslink.py,
 generate-dossier.py, pacman-queue-add.py). Every operation hits the local SiYuan
 kernel, typically reverse-proxied through a per-install host for phone-clickable
 deeplinks (see SIYUAN_DEEPLINK_BASE below - the host is never hardcoded here).

--- a/chassis/skills/pacman.md
+++ b/chassis/skills/pacman.md
@@ -208,7 +208,7 @@ Three properties, each load-bearing:
 
 - **No digits, so it can never collide with `approve N`.** The outreach flow uses `approve 1 3 5` to approve drafts by list position. A token containing no digits is structurally incapable of being read as a number, so the two forms can never be confused. This is a guarantee, not a probability.
 - **No vowels and no `y`, so it can never spell a word.** English has no six-letter vowel-free words, which keeps `approve later` and similar from ever parsing as a token.
-- **Six characters, one case, no `i`/`l`/`1` or `o`/`0` ambiguity.** Sean approves from his phone. A 32-character Notion UUID is unusable there.
+- **Six characters, one case, no `i`/`l`/`1` or `o`/`0` ambiguity.** The operator approves from a phone. A 32-character Notion UUID is unusable there.
 
 Full reasoning and the canonical regex: `chassis/pacman/tokens.py`.
 

--- a/chassis/systemd/INSTALL.md
+++ b/chassis/systemd/INSTALL.md
@@ -90,7 +90,7 @@ Findings JSONL lands at `${CHASSIS_HOME}/logs/scheduled/heartbeat-reconciler-fin
 
 ### Permission denied on `~/behalfbot/...`
 
-If you used `User=behalfbot` (system-scoped) but the chassis tree lives at `/home/sean/behalfbot/`, systemd won't have permission. Either:
+If you used `User=behalfbot` (system-scoped) but the chassis tree lives at `/home/<your-user>/behalfbot/`, systemd won't have permission. Either:
 - Re-clone the chassis as the `behalfbot` user, OR
 - Drop `User=` (runs as root — not recommended), OR
 - Switch to user-scoped systemd (`systemctl --user`)


### PR DESCRIPTION
## What

`chassis/` is the generic harness every installer runs. This strips content that only makes sense on one install and parameterises it to the conventions already in the repo (`$CHASSIS_HOME`, `$CUSTOMER_HOME`, `chassis.config.yaml` keys, `.env` vars).

38 files changed. Audited every hit in `chassis/` for `/Users/jax`, `.behalfbot`, `vibecodelisboa`, `grid7`, `BigPoppa`, `Sean`, `Jax`, `Tierney`, `Lakoff`, `jacketyjax`, `kogent`, `fenerum`, `Lisbon`, 17-20 digit snowflakes, and UUIDs. Most hits were legitimate and were left. `cloudflare/` was not touched.

## 1. Hard leaks fixed (14 files)

Values an installer could copy verbatim and get a broken or wrong-account result.

| File | Was | Now |
|---|---|---|
| `chassis/scheduled-tasks/docker-prune-alert-prompt.md:13` | alerts posted to hardcoded Discord channel `1497870976237699173` | resolve from `discord_channels.alerts_label` + `DISCORD_ALERTS_CHANNEL_ID` |
| `chassis/scheduled-tasks/docker-prune-alert-prompt.md:14` | file issues on `scrollinondubs/new-jaxity` | the install's own `origin` remote |
| `chassis/scripts/sync-claude-oauth-bridge.sh:48` | `LOG_DIR` default `${HOME}/work/new-jaxity/logs/scheduled` | `${CUSTOMER_HOME:-${HOME}/.behalfbot}/logs/scheduled` |
| `chassis/scripts/md-to-briefing-html.py:49` | callout regex contained the literal `needs? sean` | dropped; `needs? your` / `action needed` still cover it |
| `chassis/scripts/first-boot-announce.sh:83` | bot tells every installer "Share this with Sean" | "You need this ID to add me to the install channel" |
| `chassis/scripts/first-boot-announce.sh:85` | `--allow <SEAN_ID>,<JAXBOT_ID>` | `--allow <INSTALLER_DISCORD_USER_ID>,<BOT_USER_ID>` |
| `chassis/scripts/discord-post.sh:23,26,29` | usage examples used real channel ID `1487067385159487588` | `"$DISCORD_BRIEFINGS_CHANNEL_ID"` |
| `chassis/docs/heartbeats/daily-log.md:168` | `DAILY_LOG_EXTRA_METRICS_SCRIPT=/Users/jax/.behalfbot/scripts/...` | `${CUSTOMER_HOME}/scripts/...` |
| `chassis/docs/heartbeats/daily-log.md:70` | `jax@vibecodelisboa.com` | `<your-agent>@<your-domain>` |
| `chassis/docs/heartbeats/daily-log.md:68` | `jacketyjax` as the `DAILY_LOG_GH_USER` example | `<your-agent-gh-user>` |
| `chassis/scheduled-tasks/memory-canary-prompt.md:17` | `/Users/jax/.behalfbot/memory/memory.jsonl` in the worked example | `/Users/<host-user>/.behalfbot/...` (kept concrete on purpose) |
| `chassis/scheduled-tasks/daily-log-prompt.md.template:10` | org handles example `"vibecodelisboa fenerum" or just "kogent"` | `"acme-labs acme-ventures" or just "acme"` |
| `chassis/scheduled-tasks/bootstrap-audit-prompt.md` (5 lines) | routed to `#jax-ops`, needed "Sean's sudo", "ask Sean" | ops channel from config; "the operator" |
| `chassis/systemd/INSTALL.md:93` | `/home/sean/behalfbot/` | `/home/<your-user>/behalfbot/` |
| `chassis/docs/prompts-setup.md:83` | `dormant-sean-prenudge-prompt.md` | `dormant-operator-prenudge-prompt.md` (the actual filename on disk) |
| `chassis/CLAUDE.md.template:129` | "Pacman - Sean's V1 reference; lives in his V1 install only" | "chassis-core; see `chassis/skills/pacman.md`" (also factually stale - pacman ships in chassis) |
| `chassis/scheduled-tasks/chassis-update-check-prompt.md:35` | label example `#jax-ops` | `#<installer>-ops` |
| `chassis/scheduled-tasks/heartbeat-dispatcher.sh:18` | `CHASSIS_HOME` example `/Users/sean/<v1-reference-install>` | `/Users/<user>/behalfbot` |

Plus install-flavoured prose swept out of `chassis/docs/heartbeats/daily-log.md`, `chassis/scripts/daily-log-gather.py`, `chassis/HEARTBEATS.md.template` and `chassis/scheduled-tasks/daily-log-prompt.md.template`: "Jax" to "the assistant", `#jax` to "the primary conversation channel", and "on the VCL platform, students will assign tasks" to a backend-neutral statement of the same rationale.

**One placeholder rename:** `{{ CUSTOMER_JAX_IDENTITY }}` to `{{ CUSTOMER_AGENT_IDENTITY }}` in `daily-log-prompt.md.template`, with the mirror in `docs/heartbeats/daily-log.md`. Existing installs are unaffected - bootstrap copies this template once and never rewrites it, and the file already documents a prior placeholder rename with the same reasoning.

## 2. Provenance comments softened (about 20 comments, 16 files)

Reasoning kept in full; only the personal attribution dropped. `heartbeat-dispatcher.sh`, `bake-env.sh`, `memory-canary.sh`, `bootstrap-audit.sh`, `install-host-clis.sh`, `migrate-customer-state.sh`, `validate-heartbeats.sh`, `gather-docker-prune.sh`, `gather-chassis-update-check.sh`, `test-chassis-update-check.sh`, `test-merge-plugin-triggers.sh`, `hydrate-mcp-json.py`, `pacman-migrate-siyuan-queue.py`, `contacts/contacts.py`, `db/connection.py`, `db/migrations/002_contacts.sql`, `db/tests/test_connection.py`, `pacman/tokens.py`, `pacman/tests/test_tokens.py`, `second_brain/siyuan.py`, `skills/pacman.md`.

Two of these also named a beta installer by full name (`bootstrap-audit.sh:12`, `:152`) - now "a beta install".

`db/connection.py:26` and `test_connection.py:42` cited `docs/jax-db.md`, a filename that embeds the personal name and does not exist in this repo - now "the reference install's DB docs".

## 3. Belongs in new-jaxity, not here

Nothing in this diff needs a move. I checked each candidate against the live reference install rather than assuming:

- **`daily-log-extra-metrics.sh` example** (dating-swipe + outreach.db counts, removed from `daily-log.md:141-169`, replaced with a generic worked example). `DAILY_LOG_EXTRA_METRICS_SCRIPT` is not set in `/Users/jax/.behalfbot/.env` and `/Users/jax/.behalfbot/scripts/daily-log-extra-metrics.sh` does not exist. Load-bearing nowhere. Removed rather than relocated. If you ever want those metrics, write the script customer-side to the shape now documented.
- **`sync-claude-oauth-bridge.sh` LOG_DIR.** The live `com.jax.claude-oauth-bridge-sync.plist` does not set `LOG_DIR`, and already sends stdout to `/Users/jax/.behalfbot/logs/scheduled/`. The new default lands in the same directory, so this is a correction, not a behavior change. `~/work/new-jaxity/` was a stale checkout path.
- **`needs? sean` regex.** Load-bearing on your install only: briefing headings worded "Needs Sean" will stop getting the attention callout. Two options, your call - rename those headings to "Needs your ..." (already matched), or add a per-install `BRIEFING_ATTENTION_PATTERN` env var in a follow-up. I did not add the env var here, one concern per PR.
- **Removed runtime values, for your records.** Alerts channel `1497870976237699173` and briefing channel `1487067385159487588`. Neither needs relocating - both already resolve from your `.env` - but worth confirming `DISCORD_ALERTS_CHANNEL_ID` is populated there before the next docker-prune failure fires.

## 4. Left alone, your call

- **`scrollinondubs/new-jaxity` as a bare issue cross-reference** in about 25 code comments (`bake-env.sh`, `gmail-attachment.py`, `compose.sh`, `discord-post.sh`, dispatcher, and others). These are historical incident citations, same class as CHANGELOG history. Note the repo already has a `<v1-reference-install>` sanitisation token used in ~18 other places, so a full sweep is available if you want the repo name gone entirely.
- **`chassis/scripts/setup-wizard/`** - "Ping Sean + `${ASSISTANT_NAME}` in `#behalf-bot-setup`" (README:177,184 and `src/index.ts:170`). This is the white-glove install service, which is genuinely yours. Left as-is. Separate small bug worth its own PR: `index.ts:170` has `${ASSISTANT_NAME}` inside a double-quoted (not template-literal) TS string, so it prints literally.
- **`BOT_NAME` examples `jax, asimov, ozzy`** and `INSTANCE_NAME` examples `Jax, Asimov, Ozzy` across `bootstrap-customer-scripts.sh`, `restart-discord.sh.template` and the launchd plist templates. They read as "pick a name like one of these", which is useful guidance, but they are three real installs' bot names.
- **`frontmatter_tags: jax, briefing`** in `second_brain/obsidian.py:28` and its tests, and `PG_CONTAINER=jax-pg` in `test-validate-heartbeats.sh` fixtures. Harmless example strings; changing the tests to match would be churn.
- **`CHASSIS_HOME=$HOME/.behalfbot`** at `daily-log.md:126`. That is `CUSTOMER_HOME` by the README's own definition, and `daily-log-gather.py:688` has the same conflation. A real naming muddle, but fixing it means touching semantics - out of scope here.
- **Pre-existing, unrelated:** `chassis/scheduled-tasks/heartbeat-dispatcher.sh:895` uses a zsh glob qualifier (`*.sh(N)`) and fails `bash -n` on `main` today. Not introduced by this PR; my changes to that file are comments only.

Follow-up worth considering: `.github/workflows/no-customer-state-in-chassis.yml` guards file *paths* only. A content-level grep guard would stop this class of leak recurring. Deliberately not in this PR.

## Test plan

- [x] `bash -n` on all 13 touched shell scripts - pass (the 14th, `heartbeat-dispatcher.sh`, fails identically on `main`; comments-only change)
- [x] `python3 -m py_compile` on all 8 touched Python modules - pass
- [x] `python3 -m unittest chassis.pacman.tests.test_tokens chassis.db.tests.test_connection chassis.second_brain.tests.test_obsidian` - 91 tests, OK
- [x] `bash chassis/scripts/test-validate-heartbeats.sh` - 6 passed, 0 failed
- [x] `bash chassis/scripts/test-memory-canary.sh` - 18 passed, 0 failed
- [x] `bash chassis/scripts/test-chassis-update-check.sh` - 46 passed, 0 failed
- [x] `bash chassis/scripts/test-merge-plugin-triggers.sh` - 11 passed, 0 failed
- [x] `bash chassis/scripts/test-bootstrap-audit-memory.sh` - 12 passed, 0 failed
- [x] `bash chassis/scripts/test-daily-log-gather.sh` - 7 passed, 0 failed
- [x] Re-ran the full name sweep post-edit; every remaining hit is in section 4 above
- [x] No em dashes in any added line (`git diff -U0 | grep '^+' | grep '—'` returns nothing)
- [x] No files renamed, so the `no-customer-state-in-chassis` path guard is unaffected
- [x] `cloudflare/` untouched - no overlap with #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mGf4xKkR8LaPacoPaCWMt
