### PR TITLE
fix(plugins): unblock the plugin-root-resolution CI job, and stop the exit-5 fallback resolving to an empty root

### DIFF
--- a/chassis/scripts/resolve-plugin-root.sh
+++ b/chassis/scripts/resolve-plugin-root.sh
@@ -263,7 +263,15 @@ if [[ -n "$compose_failed" ]]; then
     # The union/overlay is usable but we cannot activate it. Fall back to the
     # single highest-precedence baked root and fail LOUDLY - this is the
     # exact silent-no-op class v0.2.0 shipped, so it must never pass quietly.
-    fallback_root="${BAKED_ROOTS[-1]:-}"
+    # Last element is the highest-precedence baked root (later roots overlay
+    # earlier ones above). Spelled out rather than ${BAKED_ROOTS[-1]} because
+    # negative subscripts need bash 4.3 and the macOS host runs /bin/bash 3.2,
+    # where that expansion errors and silently yields the empty string - which
+    # is exactly the empty-root outcome the exit-5 path exists to prevent.
+    fallback_root=""
+    if [[ "${#BAKED_ROOTS[@]}" -gt 0 ]]; then
+        fallback_root="${BAKED_ROOTS[$(( ${#BAKED_ROOTS[@]} - 1 ))]}"
+    fi
     log "ERROR: composed plugin tree (baked union and/or fetched overlay from $FETCHED_ROOT) is usable but could NOT be activated (compose failed under $CUSTOMER_HOME/state)"
     write_state baked "$fallback_root" "compose failed - overlay present but not active"
     printf '%s\n' "$fallback_root"

--- a/chassis/scripts/test-plugin-root-resolution.sh
+++ b/chassis/scripts/test-plugin-root-resolution.sh
@@ -259,7 +259,7 @@ manifest "$IMAGE_BAKED/bfl" "bfl" "1.0.0"
 CHASSIS_HOME_PLUGINS="$CUSTOMER/plugins"
 manifest "$CHASSIS_HOME_PLUGINS/bfl" "bfl" "2.0.0"
 RESOLVED_ROOT="$(env -u CHASSIS_PLUGINS_ROOT -u CHASSIS_BAKED_PLUGINS_ROOT     CUSTOMER_HOME="$CUSTOMER" CHASSIS_HOME="$CUSTOMER"     CHASSIS_IMAGE_PLUGINS_ROOT="$IMAGE_BAKED"     bash "$RESOLVER" 2>>"$TMP/resolver.log")"
-check "s12 $CHASSIS_HOME/plugins wins over /app/plugins on collision" "2.0.0"     "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$RESOLVED_ROOT/bfl/openclaw.plugin.json")"
+check "s12 \$CHASSIS_HOME/plugins wins over /app/plugins on collision" "2.0.0"     "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$RESOLVED_ROOT/bfl/openclaw.plugin.json")"
 
 # ---------------------------------------------------------------------------
 echo


### PR DESCRIPTION
## Why

`Shell unit tests / plugin-root-resolution` is red on `origin/main` and therefore red on every PR branched from it. This unblocks **#193** and **#196**, neither of which touches plugins.

Two independent causes. Only the first one is the CI blocker.

## Cause 1 - the CI blocker: an unbound `CHASSIS_HOME` killed the suite

Scenario 12's `check` label was written as a double-quoted string containing `$CHASSIS_HOME/plugins wins over /app/plugins on collision`. `CHASSIS_HOME` is only ever set in the env passed to the resolver, never in the test's own shell, so under `set -u` that expansion aborted the whole suite before it printed a single result.

Evidence, from the CI log of the last `main` push (run 33966913323):

```
chassis/scripts/test-plugin-root-resolution.sh: line 262: CHASSIS_HOME: unbound variable
##[error]Process completed with exit code 1.
```

The label was meant literally, so the dollar sign is escaped. Introduced with scenario 12 in `1fcf6ae` (#178).

## Cause 2 - a real resolver defect, macOS host only

With cause 1 fixed the suite ran to completion and scenario 8 failed:

```
FAIL [s8 falls back to baked] expected '<TMP>/s8/baked', got ''
```

`s8 loud failure exit` passed (rc 5). Only the printed root was wrong, and it was empty.

Root cause, from the resolver's own stderr in an isolated repro:

```
resolve-plugin-root.sh: line 266: BAKED_ROOTS: bad array subscript
```

The exit-5 path selected its fallback with `${BAKED_ROOTS[-1]:-}`. Negative array subscripts need bash 4.3. macOS ships `/bin/bash` 3.2.57, where that expansion writes `bad array subscript` to stderr and evaluates to the empty string. The resolver then logged its loud ERROR, wrote `plugins-root.state.json` with `"resolved_root": ""` (while `baked_roots` in that same file correctly listed the root), printed nothing on stdout, and exited 5.

I first suspected `write_state` was aborting because scenario 8's whole premise is that `$CUSTOMER/state` is not writable. That is dead: `STATE_FILE` is `$CUSTOMER_HOME/plugins-root.state.json`, not under `state/`, and the file was written with an empty `resolved_root`. So `write_state` ran and `printf` ran - the value was already empty by then.

Attribution: `1fcf6ae` (#178) turned the single baked root into a union. Before it the fallback was the scalar `${BAKED_ROOT:-}` with no subscript.

## Verdict: (a), a real defect in the resolver

Not a stale test. Three reasons:

1. Exit 5 documents itself in the header as "The best-available root is still printed and the state file records the error." On the macOS host it was not printed. The comment directly above the failing line calls an unprinted fallback "the exact silent-no-op class v0.2.0 shipped, so it must never pass quietly". An empty root is precisely the outcome that path exists to prevent, so the test's expectation is the correct one and the resolver was wrong.
2. The macOS host is a supported runtime by design, not an accident of where I ran the tests. `relpath()` shells out to python3 specifically because "host is macOS/BSD, container is Linux" and neither GNU `realpath --relative-to` nor GNU-only `readlink` flags can be assumed on both. `BUILT_ON` exists to record which of the two sides ran the resolution. The host path is real and reaches this line.
3. `[-1]` was the right *intent* - later roots overlay earlier ones, so the last element is the highest-precedence baked root. Only the spelling was unportable. The fix keeps the semantics identical and adds an explicit empty-array guard, because index -1 on a zero-length array is also a subscript error under bash 3.2.

Zero baked roots plus a compose failure still prints empty and exits 5. That is pre-existing and correct: there is genuinely nothing to fall back to. Not changed here.

## Honest scoping: cause 2 does not affect CI

CI is `ubuntu-latest` only, bash 5.2, where `${arr[-1]}` works. **Commit 1 alone would have turned CI green.** I verified that directly: on the tree with only the test-label fix, Linux bash 5.2.15 as uid 1000 gave 44 passed, 0 failed. The resolver fix changes nothing on CI. It is here because the same investigation surfaced it and it is a genuine host-side bug, not because it was blocking anything.

Related: scenario 8 self-skips as root. My first Linux container run while diagnosing this was as root, which skipped it. GitHub's ubuntu runners are non-root so it does execute there, it just passes on bash 5.

## Verification

Exact commands and observations, all on the branch head:

| Environment | Command | Result |
|---|---|---|
| macOS, `/bin/bash` 3.2.57 | `bash chassis/scripts/test-plugin-root-resolution.sh` | `44 passed, 0 failed`, rc 0 (was `43 passed, 1 failed`) |
| Linux, bash 5.2.15, uid 1000 (`python:3.12-slim-bookworm`) | same | `44 passed, 0 failed`, rc 0 |
| Linux, bash 5.2.15, root | same | `42 passed, 0 failed` plus `SKIP [s8] running as root` |
| macOS | `shellcheck -S error` on both files | clean, rc 0 |

Isolated scenario-8 repro against the patched resolver: rc 5, stdout is the baked root, stderr carries the loud ERROR, and `plugins-root.state.json` records `"error": "compose failed - overlay present but not active"`. Before the patch the same repro printed nothing on stdout.

- [x] Suite green on macOS bash 3.2
- [x] Suite green on Linux bash 5.2 as non-root (the CI shape)
- [x] shellcheck clean at the severity `shell-lint.yml` enforces
- [x] Original CI failure line reproduced and confirmed fixed
- [x] `Shell unit tests / plugin-root-resolution` green on this PR: job 101310292365 logs `test-plugin-root-resolution: 44 passed, 0 failed` with no `SKIP [s8]` line, so scenario 8 really executed on the runner. Every other shell-tests job, shellcheck and dco are green too.

## Not included, deliberately

- No `chassis/VERSION` bump - a separate conversation is open about release convention in this repo.
- No new test for the bash 3.2 portability class itself. Scenario 8 already covers it behaviourally on any bash 3.2 host, which is where Sean actually runs the resolver. CI cannot exercise bash 3.2, so that gap stays open rather than being papered over with a grep-for-`[-1]` lint test.
- Scenario 8's assertions are untouched. Nothing was weakened or deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
