### PR TITLE
credential-expiry: jq 1.6 rejects $label, so the gather never ran in the container

### DIFF
--- a/chassis/scripts/gather-credential-expiry.sh
+++ b/chassis/scripts/gather-credential-expiry.sh
@@ -182,9 +182,9 @@ add_check() {
     local exp_json="null"
     [[ -n "$3" ]] && exp_json="$3"
     CHECKS+=("$(jq -nc \
-        --arg id "$1" --arg label "$2" --argjson exp "$exp_json" \
+        --arg id "$1" --arg lbl "$2" --argjson exp "$exp_json" \
         --arg st "$4" --arg detail "$5" \
-        '{id: $id, label: $label, expires_at: $exp,
+        '{id: $id, label: $lbl, expires_at: $exp,
           state: (if $st == "" then null else $st end), detail: $detail}')")
 }
 


### PR DESCRIPTION
Follow-up to #194, found while registering that heartbeat on the reference install.

## The bug

`label` is a keyword in jq 1.6 (`label $out | ...`). `--arg label` creates a variable whose name collides with it and the whole program fails to compile:

```
jq: error: syntax error, unexpected label, expecting IDENT or __loc__
{id: $id, label: $label, expires_at: $exp,
jq: 1 compile error
```

jq 1.7 relaxed this, which is why it passed everywhere it was tested.

## Why it slipped through

Same shape as the bash 3.2 class #199 was built for, one layer over:

```
host      jq-1.7.1-apple    <- where it was written and tested
container jq-1.6            <- where it actually runs
```

The gather ran clean by hand on the host and failed on **every dispatcher tick** inside the container. Reproduced minimally:

```
$ docker exec behalfbot jq -n --arg label x '{label: $label}'
jq: 1 compile error
$ docker exec behalfbot jq -n --arg lbl x '{label: $lbl}'
{ "label": "x" }
```

So the object KEY `label:` is fine and stays. Only the variable name moves, to `$lbl`.

## Why this one matters more than its size

`credential-expiry` is `criticality: critical` and its entire job is to warn before a credential expires. A monitor that cannot run, on a critical schedule, failing silently every hour, is precisely the failure class of https://github.com/scrollinondubs/new-jaxity/issues/550 - which is the outage that caused this heartbeat to be written.

## Verification

- `test-credential-expiry.sh`: 58 passed, 0 failed on macOS `/bin/bash` 3.2.57
- Gather now returns valid JSON inside the real Debian container (`count: 0`, 7 checks) where it previously produced only a jq compile error

## Not fixed here

CI cannot currently catch this class. #199 added a macOS lane for host-vs-CI differences, but this is a **container-vs-host** difference, and the runner's jq is likely 1.7. A jq-1.6 job, or a pinned jq in the image, would close it. Flagging rather than scope-creeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)