### PR TITLE
fix(oauth-bridge): rescue an empty keychain from the container's credential

### DIFF
--- a/chassis/scripts/sync-claude-oauth-bridge.sh
+++ b/chassis/scripts/sync-claude-oauth-bridge.sh
@@ -149,10 +149,51 @@ if ! KC_JSON=$(security find-generic-password -s "Claude Code-credentials" -a "$
 fi
 
 # Validate Keychain JSON has claudeAiOauth.accessToken (else useless).
+#
+# Rescue path (new-jaxity#559): an empty keychain is exactly the state the
+# reverse-sync below was written to repair, and until now the script exited
+# before ever reaching it. Two Claude Code installs share one login - the host
+# keychain and the container's bind-mounted `.credentials.json` - and Anthropic
+# rotates the refresh token on every use. When the container refreshes, the
+# host's refresh token dies with it; the next host refresh 401s and Claude Code
+# clears `claudeAiOauth.accessToken` from the keychain. The container's copy is
+# still perfectly good at that moment. Copying it back up is a one-line repair
+# that the script was already capable of and never attempted, so the operator
+# had to run `/login` by hand roughly twice a day.
+#
+# Two things this must NOT do:
+#   - Fall through to the forward-sync. If both sides are token-less then
+#     KC_EXPIRES and FILE_EXPIRES are both 0, `0 -lt 0` is false, and the
+#     forward-sync would write the broken keychain JSON over the container's
+#     credential - taking down the one side that still worked.
+#   - Rescue with an already-expired file token. Writing a dead token into the
+#     keychain would clear the fault state and silence the alert while leaving
+#     the host just as unauthenticated. The reverse-sync block further down has
+#     no freshness check either, because until this change it could only be
+#     reached from a healthy keychain.
 KC_ACCESS=$(jq -r '.claudeAiOauth.accessToken // empty' <<<"$KC_JSON" 2>/dev/null || true)
 if [[ -z "$KC_ACCESS" ]]; then
+    RESCUE_JSON=""
+    if [[ -f "$CRED_FILE" ]]; then
+        RESCUE_JSON=$(jq -c '.' "$CRED_FILE" 2>/dev/null || true)
+    fi
+    RESCUE_ACCESS=""
+    RESCUE_EXPIRES=0
+    if [[ -n "$RESCUE_JSON" ]]; then
+        RESCUE_ACCESS=$(jq -r '.claudeAiOauth.accessToken // empty' <<<"$RESCUE_JSON" 2>/dev/null || true)
+        RESCUE_EXPIRES=$(jq -r '.claudeAiOauth.expiresAt // 0' <<<"$RESCUE_JSON" 2>/dev/null || echo 0)
+    fi
+    NOW_MS=$(( $(date -u +%s) * 1000 ))
+    if [[ -n "$RESCUE_ACCESS" && "$RESCUE_EXPIRES" -gt "$NOW_MS" ]]; then
+        if security add-generic-password -U -s "Claude Code-credentials" -a "$KEYCHAIN_ACCOUNT" -w "$RESCUE_JSON" 2>/dev/null; then
+            log "rescued: keychain had no accessToken, restored from file expiresAt=$RESCUE_EXPIRES"
+            clear_fault
+            exit 0
+        fi
+        log "WARN: keychain has no accessToken and the rescue write failed (security add-generic-password -U exit non-zero)"
+    fi
     log "WARN: keychain JSON missing claudeAiOauth.accessToken - leaving file untouched"
-    alert_fault "keychain_missing_token" "**Claude oauth bridge: the macOS keychain lost its Claude access token.** The entry \`Claude Code-credentials\` is present but carries no \`claudeAiOauth.accessToken\`, so host interactive \`claude\` cannot authenticate until someone runs \`/login\`. The chassis container is unaffected while its own refresh token holds. This is the exact state that went unreported for four days in new-jaxity#550. You will hear from this again only when it recovers."
+    alert_fault "keychain_missing_token" "**Claude oauth bridge: the macOS keychain lost its Claude access token.** The entry \`Claude Code-credentials\` is present but carries no \`claudeAiOauth.accessToken\`, and the container's credential file has no usable token to restore from either, so host interactive \`claude\` cannot authenticate until someone runs \`/login\`. This is the exact state that went unreported for four days in new-jaxity#550. You will hear from this again only when it recovers."
     exit 0
 fi
 

--- a/chassis/scripts/tests/test_sync_claude_oauth_bridge.sh
+++ b/chassis/scripts/tests/test_sync_claude_oauth_bridge.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Tests for sync-claude-oauth-bridge.sh, and specifically for the rescue path
+# added in new-jaxity#559.
+#
+# The script is the only thing keeping both the host keychain and the chassis
+# container authenticated, so the cases that matter are the ones where one side
+# is broken. Case 3 is the load-bearing one: when BOTH sides have lost their
+# token, KC_EXPIRES and FILE_EXPIRES are both 0, `0 -lt 0` is false, and a
+# naive "just delete the guard" fix would fall through to the forward-sync and
+# write the broken keychain JSON over the container's credential file.
+#
+# `security` is stubbed by a shell script earlier on PATH that reads and writes
+# a plain file, so no real keychain is touched. CHASSIS_ALERT_CMD is stubbed to
+# `true` so a test run cannot post to the operator's alert channel - running
+# this suite against the live install otherwise delivers real "the keychain
+# lost its token" alerts, which is exactly the false alarm the alerting work in
+# #550 was trying to eliminate.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="${SCRIPT_DIR}/../sync-claude-oauth-bridge.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/bin" "$WORK/home/.claude" "$WORK/logs" "$WORK/state"
+
+cat > "$WORK/bin/security" <<'STUB'
+#!/bin/bash
+KC="$(dirname "$(dirname "$0")")/kc.json"
+case "$1" in
+  find-generic-password) [[ -s "$KC" ]] && cat "$KC" || exit 44 ;;
+  add-generic-password)
+    for ((i=1;i<=$#;i++)); do
+      [[ "${!i}" == "-w" ]] && { j=$((i+1)); printf '%s' "${!j}" > "$KC"; exit 0; }
+    done
+    exit 1 ;;
+esac
+STUB
+chmod +x "$WORK/bin/security"
+
+NOW_S=$(date -u +%s)
+FUTURE=$(( (NOW_S + 7200) * 1000 ))
+PAST=$(( (NOW_S - 7200) * 1000 ))
+
+FAILURES=0
+
+# $1 name, $2 keychain json, $3 file json, $4 expected log substring,
+# $5 expected keychain accessToken, $6 expected file accessToken
+run_case() {
+    local name="$1" kc="$2" file="$3" want_log="$4" want_kc="$5" want_file="$6"
+    : > "$WORK/logs/claude-oauth-bridge-sync.log"
+    rm -f "$WORK/state/alert.state"
+    printf '%s' "$kc" > "$WORK/kc.json"
+    printf '%s' "$file" > "$WORK/home/.claude/.credentials.json"
+
+    PATH="$WORK/bin:$PATH" HOME="$WORK/home" LOG_DIR="$WORK/logs" \
+        CHASSIS_OAUTH_BRIDGE_ALERT_STATE="$WORK/state/alert.state" \
+        CHASSIS_ALERT_CMD="true" KEYCHAIN_ACCOUNT="tester" \
+        bash "$TARGET"
+
+    local got_log got_kc got_file
+    got_log="$(cat "$WORK/logs/claude-oauth-bridge-sync.log")"
+    got_kc="$(jq -r '.claudeAiOauth.accessToken // "NONE"' "$WORK/kc.json")"
+    got_file="$(jq -r '.claudeAiOauth.accessToken // "NONE"' "$WORK/home/.claude/.credentials.json")"
+
+    local ok=1
+    [[ "$got_log" == *"$want_log"* ]] || { echo "  log: want *${want_log}*, got: ${got_log}"; ok=0; }
+    [[ "$got_kc" == "$want_kc" ]] || { echo "  keychain accessToken: want ${want_kc}, got ${got_kc}"; ok=0; }
+    [[ "$got_file" == "$want_file" ]] || { echo "  file accessToken: want ${want_file}, got ${got_file}"; ok=0; }
+
+    if (( ok )); then
+        echo "PASS  $name"
+    else
+        echo "FAIL  $name"
+        FAILURES=$(( FAILURES + 1 ))
+    fi
+}
+
+run_case "empty keychain, fresh file token: rescued from the container" \
+    '{"claudeAiOauth":{"expiresAt":0},"mcpOAuth":{}}' \
+    "{\"claudeAiOauth\":{\"accessToken\":\"GOOD\",\"refreshToken\":\"R1\",\"expiresAt\":${FUTURE}}}" \
+    "rescued: keychain had no accessToken" "GOOD" "GOOD"
+
+run_case "empty keychain, expired file token: alert, no rescue write" \
+    '{"claudeAiOauth":{"expiresAt":0},"mcpOAuth":{}}' \
+    "{\"claudeAiOauth\":{\"accessToken\":\"STALE\",\"refreshToken\":\"R1\",\"expiresAt\":${PAST}}}" \
+    "keychain JSON missing claudeAiOauth.accessToken" "NONE" "STALE"
+
+run_case "both sides empty: alert, and the file is NOT clobbered" \
+    '{"claudeAiOauth":{"expiresAt":0},"mcpOAuth":{}}' \
+    '{"claudeAiOauth":{"expiresAt":0},"mcpOAuth":{"keep":"me"}}' \
+    "keychain JSON missing claudeAiOauth.accessToken" "NONE" "NONE"
+
+run_case "healthy keychain newer than file: normal forward sync" \
+    "{\"claudeAiOauth\":{\"accessToken\":\"KCNEW\",\"refreshToken\":\"R2\",\"expiresAt\":${FUTURE}}}" \
+    "{\"claudeAiOauth\":{\"accessToken\":\"OLD\",\"refreshToken\":\"R1\",\"expiresAt\":${PAST}}}" \
+    "synced: keychain expiresAt" "KCNEW" "KCNEW"
+
+run_case "file newer than keychain: reverse sync, container wins" \
+    "{\"claudeAiOauth\":{\"accessToken\":\"KCOLD\",\"refreshToken\":\"R1\",\"expiresAt\":${PAST}}}" \
+    "{\"claudeAiOauth\":{\"accessToken\":\"FILENEW\",\"refreshToken\":\"R2\",\"expiresAt\":${FUTURE}}}" \
+    "reverse-synced" "FILENEW" "FILENEW"
+
+echo
+if (( FAILURES )); then
+    echo "${FAILURES} failure(s)"
+    exit 1
+fi
+echo "all cases passed"


### PR DESCRIPTION
## What broke

Sean has been running `/login` by hand roughly twice a day. The alert that tells him to has fired at 03:33, 08:33 and 16:33 UTC on 2026-09-06 alone.

Two Claude Code installs share one login on this box: the macOS keychain, which the host interactive session reads, and `~/.claude/.credentials.json`, which the chassis container reads over the bind mount. Anthropic rotates the refresh token on every use, so whichever side refreshes second is holding a dead one.

The container fires `claude -p` 86-88 times a day. The host session refreshes every 8 hours. The container almost always wins, the host 401s, and Claude Code clears `claudeAiOauth.accessToken` from the keychain.

Verified on the live install rather than reasoned about:

```
[2026-09-06T08:33:52Z] synced: keychain expiresAt=1788712122079 -> file
                       (1788712122079 = 2026-09-06T16:28:42Z)
16:25:57  dispatcher fires telegram-groups, container refreshes
16:28:42  the host's access token expires
[2026-09-06T16:33:55Z] WARN: keychain JSON missing claudeAiOauth.accessToken
```

And the two lineages, side by side, at the time of writing:

| | refreshToken sha256[:8] | expiresAt |
|---|---|---|
| keychain | `6de2e586` | 2026-09-07T01:34Z |
| file | `09be9e63` | 2026-09-07T00:25Z |

Two different refresh tokens for one account. That is the whole bug.

## Why it stayed broken

The reverse-sync block exists precisely to push the container's fresh credential back into the keychain. It was written for `new-jaxity#86`, the same class of failure. It could have healed every one of these.

It never ran, because the `accessToken` guard `exit 0`s sixty lines above it:

```
152  KC_ACCESS=$(jq -r '.claudeAiOauth.accessToken // empty' ...)
153  if [[ -z "$KC_ACCESS" ]]; then
156      exit 0            <-- always taken in the failure state
180  if [[ "$KC_EXPIRES" -lt "$FILE_EXPIRES" ]]; then   <-- the repair, unreachable
```

During the 03:33 to 08:33 outage this morning the credential file held a token valid until 11:29 UTC. The script had a working credential in hand, five hours of ticks to notice, and by construction could not act on it.

## The fix

An empty keychain now looks for a live token in the credential file and restores it, then clears the fault state. Two things it deliberately does not do:

- **Fall through to the forward-sync.** With both sides token-less, `KC_EXPIRES` and `FILE_EXPIRES` are both `0`, `0 -lt 0` is false, and the forward-sync would write the broken keychain JSON over the container's credential. That turns a host-only outage into a total one. Simply deleting the guard has this bug; the rescue path exits on every branch.
- **Rescue with an already-expired file token.** That would call `clear_fault`, post a recovery notice and silence the alert while leaving the host exactly as unauthenticated. The existing reverse-sync has no freshness check either, because until now it could only be reached from a healthy keychain.

## Tests

`chassis/scripts/tests/test_sync_claude_oauth_bridge.sh`, 5 cases, all passing:

```
PASS  empty keychain, fresh file token: rescued from the container
PASS  empty keychain, expired file token: alert, no rescue write
PASS  both sides empty: alert, and the file is NOT clobbered
PASS  healthy keychain newer than file: normal forward sync
PASS  file newer than keychain: reverse sync, container wins
```

`security` is stubbed by a script earlier on `PATH`, so no real keychain is touched. `CHASSIS_ALERT_CMD` is stubbed to `true` - writing these tests without that stub posted two real "the keychain lost its token" alerts to the live ops channel, which is the exact false alarm #550's alerting work exists to prevent.

## What this does not fix

Time to recovery drops from "until someone notices" to one 30-minute tick. **The logout itself still happens.** A 30-minute cadence cannot win a race that is decided in three minutes.

Closing that needs `WatchPaths` on the credential file in the launchd plist, so the reverse-sync fires within a second of the container writing rather than up to 30 minutes later. The plist is customer-side; that change ships separately in `new-jaxity`.

The structural fix, out of scope here, is for the container to hold its own credential lineage instead of a copy of the operator's.

Refs: new-jaxity#550, new-jaxity#86, chassis#138